### PR TITLE
[TOOLS-4296] [CMT] Invalid DEFAULT clause in a DDL statement, when migrating a database from ORACLE to CUBRID

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -342,9 +342,9 @@ public class Oracle2CUBRIDTranformHelper extends
 	 * @return
 	 */
 	private boolean isDefaultValueExpression(String defaultValue) {
-		String lowerCaseOfDefaultValue = defaultValue.toLowerCase(Locale.US);
+		String lowerCaseDefaultValue = defaultValue.toLowerCase(Locale.US);
 		
-		if (lowerCaseOfDefaultValue.startsWith("to_char")) {
+		if (lowerCaseDefaultValue.startsWith("to_char")) {
 			return true;
 		}
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -300,6 +300,12 @@ public class Oracle2CUBRIDTranformHelper extends
 			return;
 		}
 
+		if (defaultValue.toLowerCase(Locale.US).startsWith("to_char")) {
+			cubridColumn.setDefaultIsExpression(true);
+			cubridColumn.setDefaultValue(defaultValue);
+			return;
+		}
+
 		if ("TIMESTAMP".equalsIgnoreCase(dataType)) {
 			try {
 				CUBRIDTimeUtil.parseDatetime2Long(defaultValue, TimeZone.getDefault());

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -300,7 +300,7 @@ public class Oracle2CUBRIDTranformHelper extends
 			return;
 		}
 
-		if (defaultValue.toLowerCase(Locale.US).startsWith("to_char")) {
+		if (isDefaultValueExpression(defaultValue)) {
 			cubridColumn.setDefaultIsExpression(true);
 			cubridColumn.setDefaultValue(defaultValue);
 			return;
@@ -335,7 +335,22 @@ public class Oracle2CUBRIDTranformHelper extends
 			}
 		}
 	}
+	
+	/**
+	 * isDefaultValueExpression
+	 * @param defaultValue
+	 * @return
+	 */
+	private boolean isDefaultValueExpression(String defaultValue) {
+		String lowerCaseOfDefaultValue = defaultValue.toLowerCase(Locale.US);
+		
+		if (lowerCaseOfDefaultValue.startsWith("to_char")) {
+			return true;
+		}
 
+		return false;
+	}
+	
 	/**
 	 * 
 	 * verify the length that numeric convert to varchar


### PR DESCRIPTION
- [TOOLS-4296] Add IF condition to check whether the defaultValue is an expression or not
- [TOOLS-4296] Extract isDefaultValueExpression method
- [TOOLS-4296] Change a variable name

Please, Refer to [TOOLS-4296](http://jira.cubrid.org/browse/TOOLS-4296)