### PR TITLE
Release 2018.06

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -98,7 +98,7 @@ public final class CUBRIDSchemaFetcher extends
 
 	private static final String ALL_TABLE_COLUMN = "SELECT a.class_name, a.attr_name, a.attr_type, a.from_class_name,"
 			+ " a.data_type, a.prec, a.scale, a.is_nullable,"
-			+ " a.code_set, a.domain_class_name, a.default_value, a.def_order,c.is_reuse_oid_class"
+			+ " a.domain_class_name, a.default_value, a.def_order,c.is_reuse_oid_class"
 			+ " FROM db_attribute a , db_class c"
 			+ " WHERE c.class_name = a.class_name AND c.class_type='CLASS' AND c.is_system_class='NO' and from_class_name is NULL"
 			+ " ORDER BY a.class_name, c.class_type, a.def_order";
@@ -854,7 +854,7 @@ public final class CUBRIDSchemaFetcher extends
 			// get table information
 			String sql = "SELECT a.attr_name, a.attr_type, a.from_class_name,"
 					+ " a.data_type, a.prec, a.scale, a.is_nullable, "
-					+ " a.code_set, a.domain_class_name, a.default_value, a.def_order"
+					+ " a.domain_class_name, a.default_value, a.def_order"
 					+ " FROM db_attribute a WHERE a.class_name=? " + " order by a.def_order";
 
 			preStmt = conn.prepareStatement(sql);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mssql/trans/MSSQL2CUBRID.xml
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mssql/trans/MSSQL2CUBRID.xml
@@ -347,8 +347,8 @@
 			<scale></scale>
 		</SourceDataType>
 		<TargetDataType>
-			<type>bit varying</type>
-			<precision>64</precision>
+			<type>timestamp</type>
+			<precision></precision>
 			<scale></scale>
 		</TargetDataType>
 	</DataTypeMapping>

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -300,6 +300,12 @@ public class Oracle2CUBRIDTranformHelper extends
 			return;
 		}
 
+		if (isDefaultValueExpression(defaultValue)) {
+			cubridColumn.setDefaultIsExpression(true);
+			cubridColumn.setDefaultValue(defaultValue);
+			return;
+		}
+
 		if ("TIMESTAMP".equalsIgnoreCase(dataType)) {
 			try {
 				CUBRIDTimeUtil.parseDatetime2Long(defaultValue, TimeZone.getDefault());
@@ -329,7 +335,22 @@ public class Oracle2CUBRIDTranformHelper extends
 			}
 		}
 	}
+	
+	/**
+	 * isDefaultValueExpression
+	 * @param defaultValue
+	 * @return
+	 */
+	private boolean isDefaultValueExpression(String defaultValue) {
+		String lowerCaseDefaultValue = defaultValue.toLowerCase(Locale.US);
+		
+		if (lowerCaseDefaultValue.startsWith("to_char")) {
+			return true;
+		}
 
+		return false;
+	}
+	
 	/**
 	 * 
 	 * verify the length that numeric convert to varchar

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/EditScriptDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/EditScriptDialog.java
@@ -186,4 +186,12 @@ public class EditScriptDialog extends
 		}
 		super.buttonPressed(buttonId);
 	}
+	
+
+	/**
+	 * Return a value as boolean 
+	 */
+	protected boolean isResizable() {
+	    return true;
+	}
 }

--- a/com.cubrid.cubridmigration.ui/version.properties
+++ b/com.cubrid.cubridmigration.ui/version.properties
@@ -1,5 +1,5 @@
 #CUBRID Migration version information
-releaseStr=2015
-releaseVersion=9.3.0
-buildVersionId=9.3.0.4600
-releaseYear=2015.04
+releaseStr=2017
+releaseVersion=10.1.0
+buildVersionId=10.1.0.001
+releaseYear=2017.06

--- a/com.cubrid.cubridmigration.ui/version.properties
+++ b/com.cubrid.cubridmigration.ui/version.properties
@@ -1,5 +1,5 @@
 #CUBRID Migration version information
-releaseStr=2017
+releaseStr=2018
 releaseVersion=10.1.0
-buildVersionId=10.1.0.001
-releaseYear=2017.06
+buildVersionId=10.1.0.002
+releaseYear=2018.06


### PR DESCRIPTION
# Enhancements
\[[TOOLS-4294](http://jira.cubrid.org/browse/TOOLS-4294)\] "Migration Script Name" Dialog cannot be resized (#6)
# Bug Fixes
\[[TOOLS-4289](http://jira.cubrid.org/browse/TOOLS-4289)\] fixed invalid type conversion (#5)
\[[TOOLS-4296](http://jira.cubrid.org/browse/TOOLS-4296)\] Invalid DEFAULT clause in a DDL statement, when migrating a database from ORACLE to CUBRID (#7)