### PR TITLE
Revert "[TOOLS-4289] fixed invalid type conversion"

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mssql/trans/MSSQL2CUBRID.xml
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mssql/trans/MSSQL2CUBRID.xml
@@ -347,8 +347,8 @@
 			<scale></scale>
 		</SourceDataType>
 		<TargetDataType>
-			<type>timestamp</type>
-			<precision></precision>
+			<type>bit varying</type>
+			<precision>64</precision>
 			<scale></scale>
 		</TargetDataType>
 	</DataTypeMapping>


### PR DESCRIPTION
Reverts CUBRID/cubrid-migration#5

Below is a description of the timestamp type in MS-SQL.
If you want to know more details then please refer to [here](https://docs.microsoft.com/en-us/sql/t-sql/data-types/rowversion-transact-sql?view=sql-server-2017).
> Is a data type that exposes automatically generated, unique binary numbers within a database. rowversion is generally used as a mechanism for version-stamping table rows. The storage size is 8 bytes. The rowversion data type is just an incrementing number and does not preserve a date or a time. To record a date or time, use a datetime2 data type.
> Timestamp is the synonym for the rowversion data type and is subject to the behavior of data type synonyms. In DDL statements, use rowversion instead of timestamp wherever possible.