### PR TITLE
[TOOLS-4301,4302] JDBC driver select

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbtype/DatabaseType.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbtype/DatabaseType.java
@@ -148,7 +148,12 @@ public abstract class DatabaseType {
 		for (String cn : jdbcClassName) {
 			try {
 				cl = JDBCUtil.getJDBCDriverClassLoader(driverPath);
-				cl.loadClass(cn);
+				try {
+					cl.loadClass(cn);
+				} catch (UnsupportedClassVersionError ex2) {
+					jdbcDatas.add(new JDBCData(this, driverPath, cl, cn));
+					continue;
+				}
 			} catch (Exception ex) {
 				continue;
 			}

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -98,7 +98,7 @@ public final class CUBRIDSchemaFetcher extends
 
 	private static final String ALL_TABLE_COLUMN = "SELECT a.class_name, a.attr_name, a.attr_type, a.from_class_name,"
 			+ " a.data_type, a.prec, a.scale, a.is_nullable,"
-			+ " a.code_set, a.domain_class_name, a.default_value, a.def_order,c.is_reuse_oid_class"
+			+ " a.domain_class_name, a.default_value, a.def_order,c.is_reuse_oid_class"
 			+ " FROM db_attribute a , db_class c"
 			+ " WHERE c.class_name = a.class_name AND c.class_type='CLASS' AND c.is_system_class='NO' and from_class_name is NULL"
 			+ " ORDER BY a.class_name, c.class_type, a.def_order";
@@ -854,7 +854,7 @@ public final class CUBRIDSchemaFetcher extends
 			// get table information
 			String sql = "SELECT a.attr_name, a.attr_type, a.from_class_name,"
 					+ " a.data_type, a.prec, a.scale, a.is_nullable, "
-					+ " a.code_set, a.domain_class_name, a.default_value, a.def_order"
+					+ " a.domain_class_name, a.default_value, a.def_order"
 					+ " FROM db_attribute a WHERE a.class_name=? " + " order by a.def_order";
 
 			preStmt = conn.prepareStatement(sql);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mssql/trans/MSSQL2CUBRID.xml
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mssql/trans/MSSQL2CUBRID.xml
@@ -347,8 +347,8 @@
 			<scale></scale>
 		</SourceDataType>
 		<TargetDataType>
-			<type>bit varying</type>
-			<precision>64</precision>
+			<type>timestamp</type>
+			<precision></precision>
 			<scale></scale>
 		</TargetDataType>
 	</DataTypeMapping>

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -300,6 +300,12 @@ public class Oracle2CUBRIDTranformHelper extends
 			return;
 		}
 
+		if (isDefaultValueExpression(defaultValue)) {
+			cubridColumn.setDefaultIsExpression(true);
+			cubridColumn.setDefaultValue(defaultValue);
+			return;
+		}
+
 		if ("TIMESTAMP".equalsIgnoreCase(dataType)) {
 			try {
 				CUBRIDTimeUtil.parseDatetime2Long(defaultValue, TimeZone.getDefault());
@@ -329,7 +335,22 @@ public class Oracle2CUBRIDTranformHelper extends
 			}
 		}
 	}
+	
+	/**
+	 * isDefaultValueExpression
+	 * @param defaultValue
+	 * @return
+	 */
+	private boolean isDefaultValueExpression(String defaultValue) {
+		String lowerCaseDefaultValue = defaultValue.toLowerCase(Locale.US);
+		
+		if (lowerCaseDefaultValue.startsWith("to_char")) {
+			return true;
+		}
 
+		return false;
+	}
+	
 	/**
 	 * 
 	 * verify the length that numeric convert to varchar

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCConnectEditView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCConnectEditView.java
@@ -57,6 +57,7 @@ import com.cubrid.cubridmigration.core.connection.CMTConParamManager;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
 import com.cubrid.cubridmigration.core.connection.JDBCData;
 import com.cubrid.cubridmigration.core.connection.JDBCDriverManager;
+import com.cubrid.cubridmigration.core.connection.JDBCUtil;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
 import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
 import com.cubrid.cubridmigration.ui.common.Status;
@@ -116,6 +117,30 @@ public class JDBCConnectEditView {
 			return;
 		}
 		if (!JDBCDriverManager.getInstance().addDriver(firstFile, false)) {
+			List<JDBCData> driverList = dt.getJDBCDatas();
+			JDBCData jd2 = dt.getJDBCData(firstFile) ;
+			if (jd2 != null) {
+				ClassLoader cl = JDBCUtil.getJDBCDriverClassLoader(firstFile);
+				try {
+					cl.loadClass(jd2.getDriverClassName());
+				} catch (UnsupportedClassVersionError ex) {
+					UICommonTool.openErrorBox(Display.getDefault().getActiveShell(),
+							Messages.errInvalidJdbcJar + "\n[" + ex.getMessage() + "]");
+					return;
+				} catch (ClassNotFoundException ex2) {
+					ex2.printStackTrace();
+				}
+
+				for (JDBCData jd3 : driverList) {
+					if (jd3.getDesc().equals(jd2.getDesc())) {
+						UICommonTool.openInformationBox(Display.getDefault().getActiveShell(),
+								Messages.msgWarning,
+								Messages.msgDuplicatedJdbcDriverFile);
+
+						return;
+					}
+				}
+			}
 			UICommonTool.openErrorBox(Display.getDefault().getActiveShell(),
 					Messages.errInvalidJdbcJar);
 			return;

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/EditScriptDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/EditScriptDialog.java
@@ -186,4 +186,12 @@ public class EditScriptDialog extends
 		}
 		super.buttonPressed(buttonId);
 	}
+	
+
+	/**
+	 * Return a value as boolean 
+	 */
+	protected boolean isResizable() {
+	    return true;
+	}
 }

--- a/com.cubrid.cubridmigration.ui/version.properties
+++ b/com.cubrid.cubridmigration.ui/version.properties
@@ -1,5 +1,5 @@
 #CUBRID Migration version information
-releaseStr=2015
-releaseVersion=9.3.0
-buildVersionId=9.3.0.4600
-releaseYear=2015.04
+releaseStr=2017
+releaseVersion=10.1.0
+buildVersionId=10.1.0.001
+releaseYear=2017.06

--- a/com.cubrid.cubridmigration.ui/version.properties
+++ b/com.cubrid.cubridmigration.ui/version.properties
@@ -1,5 +1,5 @@
 #CUBRID Migration version information
-releaseStr=2017
+releaseStr=2018
 releaseVersion=10.1.0
-buildVersionId=10.1.0.001
-releaseYear=2017.06
+buildVersionId=10.1.0.002
+releaseYear=2018.06


### PR DESCRIPTION
Close the PR to the master and commit it by modifying the source code about "[TOOLS-4301]" and "[TOOLS-4302]" simultaneously.

[TOOLS-4301]
When selecting again a jdbc driver already selected, an error is raising with the reason of invalid jdbc driver was selected.
[TOOLS-4302]
Error message is not displayed if the JRE version of the selected JDBC driver does not match the current installed JRE version
Shows an error message if ojdbc8.jar is selected in a version lower than JDK version 8