### PR TITLE
[TOOLS-4312] Change URL reference of CUBRID Tools from ftp.cubrid.org to cubrid.github.io

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/common/ui/common/notice/NoticeDashboardPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/common/ui/common/notice/NoticeDashboardPage.java
@@ -73,7 +73,7 @@ import org.eclipse.ui.forms.widgets.TableWrapLayout;
 public class NoticeDashboardPage extends
 		FormPage {
 
-	private static final String rsssource = "http://ftp.cubrid.org/sites/inf/";
+	private static final String rsssource = "https://cubrid.github.io/";
 	private static String language = Platform.getNL();
 	static {
 		if (language.equals("ko_KR")) {


### PR DESCRIPTION
* Please, Refer to [TOOLS-4312](http://jira.cubrid.org/browse/TOOLS-4312)