### PR TITLE
[TOOLS-4342] [CMT] Add an option to show migration report at once for CMT Console

### DIFF
--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/HistoryCommandHandler.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/HistoryCommandHandler.java
@@ -117,6 +117,18 @@ public class HistoryCommandHandler implements
 	 * @return false to stop display the information
 	 */
 	protected boolean waitForEnter() {
+		return waitForEnter(false);
+	}
+
+	/**
+	 * Waiting for Enter
+	 *
+	 * @return false to stop display the information
+	 */
+	protected boolean waitForEnter(boolean atOnceMode) {
+		if (atOnceMode) {
+			return true;
+		}
 		String ps = "<Press [enter] to continue...>";
 		outPrinter.print(ps);
 		Console console = System.console();

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ReportCommandHandler.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ReportCommandHandler.java
@@ -55,6 +55,7 @@ public class ReportCommandHandler extends
 
 	private PrintStream outPrinter = System.out;
 	private int pageSize = 10;
+	private boolean atOnceMode = false;
 
 	/**
 	 * 
@@ -74,6 +75,7 @@ public class ReportCommandHandler extends
 			printHistoryFiles();
 			return;
 		}
+		this.atOnceMode = isAtOnceMode(args);
 		try {
 			outPrinter.println();
 			outPrinter.println("Reading migration history file: <"
@@ -103,7 +105,7 @@ public class ReportCommandHandler extends
 			outPrinter.println("        Exported:[" + mor.getExpCount() + "]");
 			outPrinter.println("        Imported:[" + mor.getImpCount() + "]");
 		}
-		if (!waitForEnter()) {
+		if (!waitForEnter(atOnceMode)) {
 			return;
 		}
 		outPrinter.println();
@@ -120,13 +122,13 @@ public class ReportCommandHandler extends
 			}
 			if (pageCount >= pageSize) {
 				pageCount = 1;
-				if (!waitForEnter()) {
+				if (!waitForEnter(atOnceMode)) {
 					return;
 				}
 			}
 			pageCount++;
 		}
-		if (!waitForEnter()) {
+		if (!waitForEnter(atOnceMode)) {
 			return;
 		}
 		outPrinter.println();
@@ -141,7 +143,7 @@ public class ReportCommandHandler extends
 			outPrinter.println("        Imported:[" + rmr.getImpCount() + "]");
 			if (pageCount >= pageSize) {
 				pageCount = 1;
-				if (!waitForEnter()) {
+				if (!waitForEnter(atOnceMode)) {
 					return;
 				}
 			}
@@ -157,7 +159,7 @@ public class ReportCommandHandler extends
 					+ "]");
 			if (pageCount >= pageSize) {
 				pageCount = 1;
-				if (!waitForEnter()) {
+				if (!waitForEnter(atOnceMode)) {
 					return;
 				}
 			}
@@ -171,6 +173,16 @@ public class ReportCommandHandler extends
 	 */
 	protected void printHelp() {
 		ConsoleUtils.printHelp("/com/cubrid/cubridmigration/command/help_report.txt");
+	}
+
+	/**
+	 * isAtOnceMode
+	 */
+	private boolean isAtOnceMode(List<String> args) {
+		if (args.indexOf("-ao") >= 0) {
+			return true;
+		}
+		return false;
 	}
 
 }

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_report.txt
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_report.txt
@@ -4,5 +4,6 @@ Usage in Linux: migration.sh report [options] [migration history file(*.mh)]
 
 Available [options]:
     -l,    To show the latest migration report automatically.
-    
+    -ao,   To show the migration report at once without pressing the ENTER key.
+
 Please visit http://www.cubrid.org for more information.


### PR DESCRIPTION
Please refer to http://jira.cubrid.org/browse/TOOLS-4342

For user convenience (for users who want to save the report result to file), We provide -ao option(-ao means at once) for showing report information without pressing the Enter key.