### PR TITLE
[TOOLS-4347] [CMT] The ORDER BY clause for MS-SQL occurs an error in CMT's SQL Tab

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/editor/controller/MigrationProgressUIController.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/editor/controller/MigrationProgressUIController.java
@@ -479,9 +479,13 @@ public class MigrationProgressUIController {
 		item[2] = String.valueOf(newExp);
 		if (!config.isImplicitEstimate()) {
 			long oldimp = getCellValue(item[3]);
-			item[4] = String.valueOf(Math.round(100 * (newExp + oldimp)
-					/ (2 * getCellValue(item[1]))))
-					+ "%";
+			try {
+				item[4] = String.valueOf(Math.round(100 * (newExp + oldimp)
+						/ (2 * getCellValue(item[1]))))
+						+ "%";
+			} catch (Exception e) {
+				// Do nothing
+			}
 		}
 		return item;
 	}
@@ -522,9 +526,13 @@ public class MigrationProgressUIController {
 		item[3] = String.valueOf(newImp);
 		if (!config.isImplicitEstimate()) {
 			long oldexp = getCellValue(item[2]);
-			item[4] = String.valueOf(Math.round(100 * (oldexp + newImp)
-					/ (2 * getCellValue(item[1]))))
-					+ "%";
+			try {
+				item[4] = String.valueOf(Math.round(100 * (oldexp + newImp)
+						/ (2 * getCellValue(item[1]))))
+						+ "%";
+			} catch (Exception e) {
+				// Do nothing
+			}
 		}
 		return item;
 	}


### PR DESCRIPTION
Please, Refer to http://jira.cubrid.org/browse/TOOLS-4347

**Purpose**
--
Fix to be available to use the ORDER BY clause in SQL tab when migrating from MS-SQL to CUBRID.

**Implementation**
--
Supports the ORDER BY clause for MS-SQL in SQL Tab to work fine

**Remarks**
--
This code is written for prototype. It needs to be tested and considered about side-effects before merging this. (@hwany7seo, @Kang-dot)