### PR TITLE
[TOOLS-4348] [CMT] Support to use MySQL8 JDBC Driver on CMT

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbtype/DBConstant.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbtype/DBConstant.java
@@ -49,6 +49,7 @@ public class DBConstant { //NOPMD
 	public static final String JDBC_CLASS_MSSQL = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
 	public static final String JDBC_CLASS_CUBRID = "cubrid.jdbc.driver.CUBRIDDriver";
 	public static final String JDBC_CLASS_MYSQL = "org.gjt.mm.mysql.Driver";
+	public static final String JDBC_CLASS_MYSQL8_OR_LATER = "com.mysql.cj.jdbc.Driver";
 	public static final String JDBC_CLASS_MSSQL_JTDS = "net.sourceforge.jtds.jdbc.Driver";
 
 	public static final String DEF_PORT_MSSQL = "1433";

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mysql/MySQLDatabase.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mysql/MySQLDatabase.java
@@ -57,7 +57,8 @@ public class MySQLDatabase extends
 	public MySQLDatabase() {
 		super(DBConstant.DBTYPE_MYSQL,
 				DBConstant.DB_NAMES[DBConstant.DBTYPE_MYSQL],
-				new String[]{DBConstant.JDBC_CLASS_MYSQL },
+				new String[] { DBConstant.JDBC_CLASS_MYSQL,
+				DBConstant.JDBC_CLASS_MYSQL8_OR_LATER },
 				DBConstant.DEF_PORT_MYSQL, new MySQLSchemaFetcher(),
 				new MySQLExportHelper(), new MysqlConnHelper(), false);
 	}


### PR DESCRIPTION
**Purpose**
--
MySQL JDBC Driver's class name has been changed from MySQL8 verison. 
CUBRID Migration Toolkit needs to add changed package and class name to use the JDBC driver. 

https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-api-changes.html
> The name of the class that implements java.sql.Driver in MySQL Connector/J has changed from com.mysql.jdbc.Driver to com.mysql.cj.jdbc.Driver. The old class name has been deprecated.

**Implementations**
--
Add changed package and class name to use MySQL8 JDBC driver. 

**Remarks**
--
It needs to be considered as belows before merging this.
* Unsupported data types, functions etc. for MySQL8