### PR TITLE
[TOOLS-4385] Modify migration settings after click "Previous" in CMT Migration Wizard Step 5/5 does not reflect changes

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ObjectMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ObjectMappingPage.java
@@ -146,6 +146,7 @@ public class ObjectMappingPage extends
 		mw.refreshWizardStatus();
 		util.setTargetCatalog(mw.getTargetCatalog(), mw);
 		if (!isFirstVisible) {
+			refreshTreeView();
 			return;
 		}
 		try {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4385

- Purpose
The settings changed after return from step 5 to step 4 of the CMT migration wizard are not applied.

- Implementation
 N/A

- Remarks 
 N/A