### PR TITLE
[TOOLS-4410] commnet's Single quote(') is not migrate accurately

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
@@ -1177,4 +1177,13 @@ public abstract class AbstractJDBCSchemaFetcher implements
 	public static final boolean isYes(String value) {
 		return "YES".equalsIgnoreCase(value);
 	}
+	
+	protected String commentEditor(String comment) {
+		String editedComment;
+		
+		editedComment = comment.replaceAll("[\\']", "\\'\\'");
+		
+		return editedComment;
+	}
+	
 }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -313,6 +313,10 @@ public final class CUBRIDSchemaFetcher extends
 
 				String comment = rs.getString("comment");
 				
+				if (comment != null) {
+					comment = commentEditor(comment);
+				}
+				
 				String indexFindKey = tableName + "-" + indexName;
 				Index index = indexes.get(indexFindKey);
 				if (index == null) {
@@ -435,6 +439,12 @@ public final class CUBRIDSchemaFetcher extends
 				if (tableName == null) {
 					continue;
 				}
+				
+				if (tableComment != null) {
+					tableComment = commentEditor(tableComment);
+				}
+				
+				
 				if (filter != null && filter.filter(null, tableName)) {
 					//CUBRID is one DB one schema
 					continue;
@@ -456,6 +466,10 @@ public final class CUBRIDSchemaFetcher extends
 				Integer prec = rs.getInt("prec");
 				Integer scale = rs.getInt("scale");
 				String columnComment = rs.getString("column_comment");
+				
+				if (columnComment != null) {
+					columnComment = commentEditor(columnComment);
+				}
 
 				Column column = factory.createColumn();
 				column.setName(attrName);
@@ -700,6 +714,10 @@ public final class CUBRIDSchemaFetcher extends
 				String comment = rs.getString("comment");
 				int cachedNum = rs.getInt("cached_num");
 
+				if (comment != null) {
+					comment = commentEditor(comment);
+				}
+				
 				boolean isCycle = "1".equals(cyclic);
 
 				Sequence sequence = factory.createSequence(sequenceName, new BigInteger(minVal),
@@ -883,6 +901,10 @@ public final class CUBRIDSchemaFetcher extends
 				String defaultValue = rs.getString("default_value");
 				
 				String comment = rs.getString("comment");
+				
+				if (comment != null) {
+					comment = commentEditor(comment);
+				}
 
 				Column column = factory.createColumn();
 				column.setName(attrName);
@@ -1112,6 +1134,10 @@ public final class CUBRIDSchemaFetcher extends
 					while (rs.next()) {
 						String querySpec = rs.getString("vclass_def");
 						String comment = rs.getString("comment");
+						
+						if (comment != null) {
+							comment = commentEditor(comment);
+						}
 						
 						view.setQuerySpec(querySpec);
 						view.setComment(comment);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -200,6 +200,11 @@ public final class OracleSchemaFetcher extends
 				table.setDDL(ddl);
 				
 				String comment = getTableComment(conn, schema.getName(), table.getName());
+				
+				if (comment != null) {
+					comment = commentEditor(comment);
+				}
+				
 				table.setComment(comment);
 			}
 			// get views
@@ -216,6 +221,11 @@ public final class OracleSchemaFetcher extends
 				view.setQuerySpec(getQueryText(conn, schema.getName(), view.getName(), view));
 				
 				String comment = getViewComment(conn, schema.getName(), view.getName());
+				
+				if (comment != null) {
+					comment = commentEditor(comment);
+				}
+				
 				view.setComment(comment);
 			}
 			buildPartitions(conn, catalog, schema);
@@ -1014,6 +1024,11 @@ public final class OracleSchemaFetcher extends
 			while (rs.next()) {
 				comment = rs.getString("COMMENTS");
 			}
+			
+			if (comment != null) {
+				comment = commentEditor(comment);
+			}
+			
 			return comment;
 		} catch (Exception e){
 			e.printStackTrace();
@@ -1038,6 +1053,11 @@ public final class OracleSchemaFetcher extends
 			while (rs.next()) {
 				comment = rs.getString("COMMENTS");
 			}
+			
+			if (comment != null) {
+				comment = commentEditor(comment);
+			}
+			
 			return comment;
 		} catch (Exception e){
 			e.printStackTrace();
@@ -1063,6 +1083,11 @@ public final class OracleSchemaFetcher extends
 			while (rs.next()) {
 				comment = rs.getString("COMMENTS");
 			}
+			
+			if (comment != null) {
+				comment = commentEditor(comment);
+			}
+			
 			return "\'" + comment + "\'";
 		} catch (Exception e){
 			e.printStackTrace();
@@ -1096,6 +1121,11 @@ public final class OracleSchemaFetcher extends
 			while (rs.next()) {
 				comment = rs.getString("COMMENTS");
 			}
+			
+			if (comment != null) {
+				comment = commentEditor(comment);
+			}
+			
 			return comment;
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -1548,6 +1578,8 @@ public final class OracleSchemaFetcher extends
 	public DatabaseType getDBType() {
 		return DatabaseType.ORACLE;
 	}
+
+	
 	//	protected void buildAllSchemas(Connection conn, Catalog catalog, Schema schema, Map<String, Table> tables)
 	//			throws SQLException {
 	//	}


### PR DESCRIPTION
- add method to edit comment
- if comment have one single quote, CMT will add one more single quote to migrate accurately