### PR TITLE
[TOOLS-4413] update export data handler for set

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/export/InformixExportHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/export/InformixExportHelper.java
@@ -43,6 +43,7 @@ import com.cubrid.cubridmigration.informix.export.handler.InformixBSONTypeHandle
 import com.cubrid.cubridmigration.informix.export.handler.InformixBooleanTypeHandler;
 import com.cubrid.cubridmigration.informix.export.handler.InformixCustomTypeHandler;
 import com.cubrid.cubridmigration.informix.export.handler.InformixJSONTypeHandler;
+import com.cubrid.cubridmigration.informix.export.handler.InformixListTypeHandler;
 import com.cubrid.cubridmigration.informix.export.handler.InformixSetTypeHandler;
 
 /**
@@ -61,6 +62,8 @@ public class InformixExportHelper extends DBExportHelper{
 		handlerMap2.put("bson", new InformixBSONTypeHandler());
 		handlerMap2.put("boolean", new InformixBooleanTypeHandler());
 		handlerMap2.put("set", new InformixSetTypeHandler());
+		handlerMap2.put("list", new InformixListTypeHandler());
+		handlerMap2.put("multiset", new InformixListTypeHandler());
 //		handlerMap1.put(CUSTOM, new InformixCustomTypeHandler());
 	}
 	

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/export/handler/InformixListTypeHandler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/export/handler/InformixListTypeHandler.java
@@ -48,9 +48,9 @@ import com.cubrid.cubridmigration.core.export.IExportDataHandler;
  *
  * @author rathana
  * @version 1.0 
- * @created Oct 13, 2022
+ * @created Jan 18, 2023
  */
-public class InformixSetTypeHandler implements
+public class InformixListTypeHandler implements
 IExportDataHandler{
 
 	/**
@@ -63,7 +63,7 @@ IExportDataHandler{
 	 */
 	public Object getJdbcObject(ResultSet rs, Column column) throws SQLException {
 		
-Object obj = rs.getObject(column.getName());
+		Object obj = rs.getObject(column.getName());
 		
 		if (obj != null) {
 			String value = obj.toString();
@@ -71,7 +71,6 @@ Object obj = rs.getObject(column.getName());
 			return value;
 		}
 		return null;
-		
 		
 	}
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/meta/InformixSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/meta/InformixSchemaFetcher.java
@@ -214,6 +214,15 @@ public class InformixSchemaFetcher extends AbstractJDBCSchemaFetcher{
 			}
 			if (table != null) {
 				schema.addTable(table);
+				for(Column column : table.getColumns()) {
+					String dataType = column.getDataType();
+					if(column.getDataType().contains("sendreceive")) {
+						dataType = "set";
+					}
+					
+					column.setDataType(dataType);
+					
+				};
 //				allTables.add(table);
 			}
 		}


### PR DESCRIPTION
[[TOOLS-4413](http://jira.cubrid.org/browse/TOOLS-4413)] Migration from Online Informix to Local CUBRID dump files fail

http://jira.cubrid.org/browse/TOOLS-4413
- update export data handler for set
- add export data handler for list and multiset
