### PR TITLE
[TOOLS-4427] Comment Migration error from CUBRID 9.3 or earlier

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -87,22 +87,10 @@ import com.cubrid.cubridmigration.cubrid.dbobj.CUBRIDTrigger;
 public final class CUBRIDSchemaFetcher extends
 		AbstractJDBCSchemaFetcher {
 
-	private static final String GET_ALLSERIALINFO_SQL = "select name, owner.name, current_val, "
-			+ "increment_val, max_val,min_val, cyclic, started, class_name, att_name, cached_num, comment "
-			+ "from db_serial where class_name is NULL";
-
 	private static final Map<String, String> STD_TYPE_MAPPING = new HashMap<String, String>();
 	static {
 		STD_TYPE_MAPPING.put("STRING", "varchar");
 	};
-
-	private static final String ALL_TABLE_COLUMN = "SELECT a.class_name, a.attr_name, a.attr_type, a.from_class_name,"
-			+ " a.data_type, a.prec, a.scale, a.is_nullable,"
-			+ " a.domain_class_name, a.default_value, a.def_order, a.comment as column_comment,"
-			+ " c.is_reuse_oid_class, c.comment as table_comment"
-			+ " FROM db_attribute a , db_class c"
-			+ " WHERE c.class_name = a.class_name AND c.class_type='CLASS' AND c.is_system_class='NO' and from_class_name is NULL"
-			+ " ORDER BY a.class_name, c.class_type, a.def_order";
 
 	private CUBRIDDataTypeHelper cubDTHelper = CUBRIDDataTypeHelper.getInstance(null);
 
@@ -183,9 +171,11 @@ public final class CUBRIDSchemaFetcher extends
 		Statement stmt = null;
 		try {
 			String sql = "SELECT a.class_name, a.attr_name, a.attr_type,"
-					+ " a.data_type, a.prec, a.scale" + " FROM db_attr_setdomain_elm a, db_class c"
-					+ " WHERE c.class_name = a.class_name AND c.class_type='CLASS' "
-					+ " AND c.is_system_class='NO' " + " ORDER BY a.class_name ";
+					+ " a.data_type, a.prec, a.scale" 
+					+ " FROM db_attr_setdomain_elm a, db_class c"
+					+ " WHERE c.class_name = a.class_name AND c.class_type='CLASS'"
+					+ " AND c.is_system_class='NO'"
+					+ " ORDER BY a.class_name ";
 
 			stmt = conn.createStatement();
 			rs = stmt.executeQuery(sql);
@@ -233,10 +223,12 @@ public final class CUBRIDSchemaFetcher extends
 		ResultSet rs = null; //NOPMD
 		Statement stmt = null;
 		try {
-			String sql = "SELECT i.class_name " + "FROM db_index i, db_class c "
-					+ "WHERE i.class_name=c.class_name AND c.is_system_class='NO' "
-					+ "AND c.class_type='CLASS' AND i.is_foreign_key='YES' "
-					+ "GROUP BY i.class_name";
+			String sql = "SELECT i.class_name" 
+					+ " FROM db_index i, db_class c"
+					+ " WHERE i.class_name=c.class_name AND c.is_system_class='NO'"
+					+ " AND c.class_type='CLASS' AND i.is_foreign_key='YES'"
+					+ " GROUP BY i.class_name";
+			
 			stmt = conn.createStatement();
 			rs = stmt.executeQuery(sql);
 
@@ -281,13 +273,15 @@ public final class CUBRIDSchemaFetcher extends
 				sqlFuncCol = "";
 			}
 
-			String sql = "SELECT a.class_name, a.index_name, a.is_unique, a.comment, b.key_attr_name, b.asc_desc "
+			String sql = "SELECT a.class_name, a.index_name, a.is_unique,"
+					+ " a.comment, b.key_attr_name, b.asc_desc"
 					+ sqlFuncCol
-					+ " FROM db_index a, db_index_key b, db_class c "
-					+ "WHERE a.class_name=b.class_name AND c.class_type='CLASS' "
-					+ "AND a.index_name=b.index_name AND a.class_name=c.class_name "
-					+ "AND c.is_system_class='NO' AND is_primary_key='NO' AND is_foreign_key='NO' "
-					+ "ORDER BY a.class_name, b.index_name, b.key_order";
+					+ " FROM db_index a, db_index_key b, db_class c"
+					+ " WHERE a.class_name=b.class_name AND c.class_type='CLASS'"
+					+ " AND a.index_name=b.index_name AND a.class_name=c.class_name"
+					+ " AND c.is_system_class='NO' AND a.is_primary_key='NO' AND a.is_foreign_key='NO'"
+					+ " ORDER BY a.class_name, b.index_name, b.key_order";
+			
 			stmt = conn.createStatement();
 			rs = stmt.executeQuery(sql);
 
@@ -360,12 +354,14 @@ public final class CUBRIDSchemaFetcher extends
 		ResultSet rs = null; //NOPMD
 		Statement stmt = null;
 		try {
-			String sql = "SELECT a.class_name, a.index_name, a.is_unique, b.key_attr_name, b.asc_desc "
-					+ "FROM db_index a, db_index_key b, db_class c "
-					+ "WHERE a.class_name=b.class_name AND a.index_name=b.index_name "
-					+ "AND a.class_name=c.class_name AND c.is_system_class='NO' "
-					+ "AND a.is_primary_key='YES' AND c.class_type='CLASS' "
-					+ "ORDER BY a.class_name, b.key_order";
+			String sql = "SELECT a.class_name, a.index_name, a.is_unique,"
+					+ " b.key_attr_name, b.asc_desc"
+					+ " FROM db_index a, db_index_key b, db_class c"
+					+ " WHERE a.class_name=b.class_name AND a.index_name=b.index_name"
+					+ " AND a.class_name=c.class_name AND c.is_system_class='NO'"
+					+ " AND a.is_primary_key='YES' AND c.class_type='CLASS'"
+					+ " ORDER BY a.class_name, b.key_order";
+			
 			stmt = conn.createStatement();
 			rs = stmt.executeQuery(sql);
 
@@ -429,9 +425,20 @@ public final class CUBRIDSchemaFetcher extends
 		// get table information
 		ResultSet rs = null;
 		Statement stmt = null;
-		try {
+		try {			
+			String sql = "SELECT a.class_name, a.attr_name, a.attr_type,"
+					+ " a.from_class_name, a.data_type, a.prec,"
+					+ " a.scale, a.is_nullable, a.domain_class_name,"
+					+ " a.default_value, a.def_order, a.comment as column_comment,"
+					+ " c.is_reuse_oid_class, c.comment as table_comment"
+					+ " FROM db_attribute a, db_class c"
+					+ " WHERE c.class_name = a.class_name AND c.class_type='CLASS'"
+					+ " AND c.is_system_class='NO' AND a.from_class_name IS NULL"
+					+ " ORDER BY a.class_name, c.class_type, a.def_order";
+			
+			
 			stmt = conn.createStatement();
-			rs = stmt.executeQuery(ALL_TABLE_COLUMN);
+			rs = stmt.executeQuery(sql);
 
 			while (rs.next()) {
 				String tableName = rs.getString("class_name");
@@ -525,9 +532,12 @@ public final class CUBRIDSchemaFetcher extends
 		Statement stmt = null;
 		// SERIAL
 		try {
-			String sql = "SELECT class_name,name,owner.name,current_val,increment_val,"
-					+ "max_val,min_val,cyclic,started,att_name " + "FROM db_serial "
-					+ "WHERE class_name IS NOT NULL " + "ORDER BY class_name";
+			String sql = "SELECT class_name, name, owner," 
+					+ " current_val, increment_val, max_val,"
+					+ " min_val, cyclic, started, att_name" 
+					+ " FROM db_serial"
+					+ " WHERE class_name IS NOT NULL" 
+					+ " ORDER BY class_name";
 
 			stmt = conn.createStatement();
 			rs = stmt.executeQuery(sql);
@@ -572,10 +582,13 @@ public final class CUBRIDSchemaFetcher extends
 	 * @throws SQLException e
 	 */
 	private void buildPartitions(final Connection conn, final Catalog catalog, final Schema schema) throws SQLException {
-		String sql = "SELECT * FROM db_partition";
 		ResultSet rs = null; //NOPMD
 		Statement stmt = null; //NOPMD
 		try {
+			String sql = "SELECT class_name, partition_name, partition_class_name,"
+					+ " partition_type, partition_expr, partition_values"
+					+ " FROM db_partition";
+			
 			stmt = conn.createStatement();
 			rs = stmt.executeQuery(sql);
 
@@ -698,9 +711,14 @@ public final class CUBRIDSchemaFetcher extends
 		List<Sequence> sequenceList = new ArrayList<Sequence>();
 
 		try {
-
+			String sql = "SELECT name, owner, current_val,"
+					+ " increment_val, max_val, min_val, cyclic,"
+					+ " started, class_name, att_name, cached_num, comment"
+					+ " FROM db_serial"
+					+ " WHERE class_name IS NULL";
+			
 			stmt = conn.createStatement();
-			rs = stmt.executeQuery(GET_ALLSERIALINFO_SQL);
+			rs = stmt.executeQuery(sql);
 			while (rs.next()) {
 				String sequenceName = rs.getString("name");
 				if (filter != null && filter.filter(schema.getName(), sequenceName)) {
@@ -878,12 +896,13 @@ public final class CUBRIDSchemaFetcher extends
 		ResultSet rs = null; //NOPMD
 		PreparedStatement preStmt = null;
 		String tableName = table.getName();
-		try {
-			// get table information
+		try {	
 			String sql = "SELECT a.attr_name, a.attr_type, a.from_class_name,"
-					+ " a.data_type, a.prec, a.scale, a.is_nullable, "
+					+ " a.data_type, a.prec, a.scale, a.is_nullable,"
 					+ " a.domain_class_name, a.default_value, a.def_order, a.comment"
-					+ " FROM db_attribute a WHERE a.class_name=? " + " order by a.def_order";
+					+ " FROM db_attribute a"
+					+ " WHERE a.class_name=?" 
+					+ " ORDER BY a.def_order";
 
 			preStmt = conn.prepareStatement(sql);
 			preStmt.setString(1, tableName);
@@ -951,8 +970,10 @@ public final class CUBRIDSchemaFetcher extends
 
 		try {
 			// get set(object) type information from db_attr_setdomain_elm view
-			String sql = "SELECT a.attr_name, a.attr_type," + " a.data_type, a.prec, a.scale"
-					+ " FROM db_attr_setdomain_elm a" + " WHERE a.class_name=? ";
+			String sql = "SELECT a.attr_name, a.attr_type,"
+					+ " a.data_type, a.prec, a.scale"
+					+ " FROM db_attr_setdomain_elm a"
+					+ " WHERE a.class_name=?";
 
 			preStmt = conn.prepareStatement(sql);
 			preStmt.setString(1, tableName);
@@ -982,8 +1003,12 @@ public final class CUBRIDSchemaFetcher extends
 		}
 
 		try {
-			String sql = "select name,owner.name,current_val,increment_val,max_val,min_val,cyclic,started,class_name,att_name "
-					+ "from db_serial where class_name =?";
+			String sql = "SELECT name, owner, current_val,"
+					+ " increment_val, max_val, min_val,"
+					+ " cyclic, started, class_name, att_name"
+					+ " FROM db_serial"
+					+ " WHERE class_name=?";
+			
 			preStmt = conn.prepareStatement(sql);
 			preStmt.setString(1, tableName);
 			rs = preStmt.executeQuery();
@@ -1123,11 +1148,16 @@ public final class CUBRIDSchemaFetcher extends
 			IBuildSchemaFilter filter) throws SQLException {
 		super.buildViews(conn, catalog, schema, filter);
 		//Set view's DDL
-		String sqlStr = "SELECT vclass_def, comment FROM db_vclass WHERE vclass_name=?";
-		PreparedStatement stmt = conn.prepareStatement(sqlStr);
+		ResultSet rs = null; //NOPMD
+		PreparedStatement stmt = null; //NOPMD
 		try {
+			String sql = "SELECT vclass_def, comment"
+					+ " FROM db_vclass"
+					+ " WHERE vclass_name=?";
+			
+			stmt = conn.prepareStatement(sql);
+			rs = stmt.executeQuery();
 			for (View view : schema.getViews()) {
-				ResultSet rs = null; //NOPMD
 				try {
 					stmt.setString(1, view.getName());
 					rs = stmt.executeQuery();
@@ -1266,13 +1296,16 @@ public final class CUBRIDSchemaFetcher extends
 
 		List<String> tableNames = new ArrayList<String>();
 		try {
-			String sqlStr = "SELECT CLASS_NAME FROM db_class "
-					+ "WHERE is_system_class = 'NO' and class_type = 'CLASS' order by CLASS_NAME";
-			stmt = conn.prepareStatement(sqlStr);
+			String sql = "SELECT class_name"
+					+ " FROM db_class"
+					+ " WHERE is_system_class='NO' AND class_type='CLASS'"
+					+ " ORDER BY class_name";
+			
+			stmt = conn.prepareStatement(sql);
 			rs = stmt.executeQuery();
 
 			while (rs.next()) {
-				tableNames.add(rs.getString("CLASS_NAME"));
+				tableNames.add(rs.getString("class_name"));
 			}
 
 		} finally {
@@ -1281,8 +1314,10 @@ public final class CUBRIDSchemaFetcher extends
 		}
 
 		try {
-			String sqlStr = "SELECT  partition_class_name  FROM db_partition";
-			stmt = conn.prepareStatement(sqlStr);
+			String sql = "SELECT partition_class_name"
+					+ " FROM db_partition";
+			
+			stmt = conn.prepareStatement(sql);
 			rs = stmt.executeQuery();
 
 			while (rs.next()) {
@@ -1307,29 +1342,31 @@ public final class CUBRIDSchemaFetcher extends
 		PreparedStatement stmt = null;
 		ResultSet rs = null; //NOPMD
 		try {
-			String sqlStr = "SELECT T.TARGET_CLASS_NAME,NAME,STATUS,PRIORITY,EVENT,"
-					+ "TARGET_CLASS,TARGET_ATTRIBUTE,CONDITION_TYPE,CONDITION,CONDITION_TIME,"
-					+ "TRIG.ACTION_TYPE,ACTION_DEFINITION,TRIG.ACTION_TIME "
-					+ "FROM DB_CLASS C,DB_TRIGGER TRIG,DB_TRIG T "
-					+ "WHERE TRIG.NAME=T.TRIGGER_NAME AND T.TARGET_CLASS_NAME=C.CLASS_NAME(+) "
-					+ "AND C.IS_SYSTEM_CLASS='NO' ORDER BY NAME";
-			stmt = conn.prepareStatement(sqlStr);
+			String sql = "SELECT t.target_class_name, name, status, priority, event,"
+					+ " target_class, target_attribute, condition_type, condition, condition_time,"
+					+ " trig.action_type, action_definition, trig.action_time"
+					+ " FROM db_class c, db_trigger trig, db_trig t"
+					+ " WHERE trig.name=t.trigger_name AND t.target_class_name=c.class_name(+)"
+					+ " AND c.is_system_class='no'"
+					+ " ORDER BY name";
+			
+			stmt = conn.prepareStatement(sql);
 			rs = stmt.executeQuery();
 			List<Trigger> triggers = new ArrayList<Trigger>();
 
 			while (rs.next()) {
 				CUBRIDTrigger trigger = (CUBRIDTrigger) factory.createTrigger();
-				trigger.setTargetClass(rs.getString("TARGET_CLASS_NAME"));
-				trigger.setName(rs.getString("NAME"));
-				trigger.setStatus(rs.getString("STATUS"));
-				trigger.setPriority(rs.getString("PRIORITY"));
-				trigger.setEventType(rs.getString("EVENT"));
-				trigger.setTargetAttribute(rs.getString("TARGET_ATTRIBUTE"));
-				trigger.setCondition(rs.getString("CONDITION"));
-				trigger.setConditionTime(rs.getString("CONDITION_TIME"));
-				trigger.setActionType(rs.getString("ACTION_TYPE"));
-				trigger.setActionDefintion(rs.getString("ACTION_DEFINITION"));
-				trigger.setActionTime(rs.getString("ACTION_TIME"));
+				trigger.setTargetClass(rs.getString("target_class_name"));
+				trigger.setName(rs.getString("name"));
+				trigger.setStatus(rs.getString("status"));
+				trigger.setPriority(rs.getString("priority"));
+				trigger.setEventType(rs.getString("event"));
+				trigger.setTargetAttribute(rs.getString("target_attribute"));
+				trigger.setCondition(rs.getString("condition"));
+				trigger.setConditionTime(rs.getString("condition_time"));
+				trigger.setActionType(rs.getString("action_type"));
+				trigger.setActionDefintion(rs.getString("action_definition"));
+				trigger.setActionTime(rs.getString("action_time"));
 
 				triggers.add(trigger);
 			}
@@ -1366,14 +1403,17 @@ public final class CUBRIDSchemaFetcher extends
 		PreparedStatement stmt = null;
 		ResultSet rs = null; //NOPMD
 		try {
-			String sqlStr = "SELECT SP.SP_NAME,SP.SP_TYPE,SP.RETURN_TYPE,"
-					+ "SP.ARG_COUNT,SP.LANG,SP.TARGET,SP.OWNER,SPARGS.INDEX_OF,"
-					+ "SPARGS.ARG_NAME,SPARGS.DATA_TYPE,SPARGS.MODE "
-					+ "FROM DB_STORED_PROCEDURE SP "
-					+ "LEFT OUTER JOIN DB_STORED_PROCEDURE_ARGS SPARGS "
-					+ "ON SP.SP_NAME=SPARGS.SP_NAME WHERE SP.SP_TYPE=? "
-					+ "ORDER BY SP.SP_NAME ASC,SPARGS.INDEX_OF ASC";
-			stmt = conn.prepareStatement(sqlStr);
+			String sql = "SELECT sp.sp_name, sp.sp_type, sp.return_type,"
+					+ " sp.arg_count, sp.lang, sp.target,"
+					+ " sp.owner, spargs.index_of, spargs.arg_name,"
+					+ " spargs.data_type, spargs.mode"
+					+ " FROM db_stored_procedure sp"
+					+ " LEFT OUTER JOIN db_stored_procedure_args spargs"
+					+ " ON sp.sp_name=spargs.sp_name"
+					+ " WHERE sp.sp_type=?"
+					+ " ORDER BY sp.sp_name asc, spargs.index_of ASC";
+			
+			stmt = conn.prepareStatement(sql);
 			stmt.setString(1, spType);
 			rs = stmt.executeQuery();
 
@@ -1385,17 +1425,17 @@ public final class CUBRIDSchemaFetcher extends
 			while (rs.next()) {
 				String str = "";
 
-				if (rs.getString("ARG_NAME") != null) {
-					str = "\"" + rs.getString("ARG_NAME") + "\" ";
+				if (rs.getString("arg_name") != null) {
+					str = "\"" + rs.getString("arg_name") + "\" ";
 
-					if (!rs.getString("MODE").equalsIgnoreCase("IN")) { // IN,OUT,IN OUT,INOUT
-						str += rs.getString("MODE") + " ";
+					if (!rs.getString("mode").equalsIgnoreCase("IN")) { // IN,OUT,IN OUT,INOUT
+						str += rs.getString("mode") + " ";
 					}
 
-					str += rs.getString("DATA_TYPE");
+					str += rs.getString("data_type");
 				}
 
-				if (spName.equals(rs.getString("SP_NAME"))) {
+				if (spName.equals(rs.getString("sp_name"))) {
 					String tmp = (String) map.get("PARAMS");
 
 					if (str != null) {
@@ -1409,16 +1449,16 @@ public final class CUBRIDSchemaFetcher extends
 					}
 
 					map = new HashMap<String, Object>();
-					spName = rs.getString("SP_NAME");
-					map.put("SP_NAME", rs.getString("SP_NAME"));
-					map.put("SP_TYPE", rs.getString("SP_TYPE"));
-					map.put("RETURN_TYPE", rs.getString("RETURN_TYPE"));
-					map.put("ARG_COUNT", rs.getInt("ARG_COUNT"));
-					map.put("LANG", rs.getString("LANG"));
-					map.put("TARGET", rs.getString("TARGET"));
-					map.put("OWNER", rs.getString("OWNER"));
-					map.put("INDEX_OF", rs.getInt("INDEX_OF"));
-					map.put("DATA_TYPE", rs.getString("DATA_TYPE"));
+					spName = rs.getString("sp_name");
+					map.put("SP_NAME", rs.getString("sp_name"));
+					map.put("SP_TYPE", rs.getString("sp_type"));
+					map.put("RETURN_TYPE", rs.getString("return_type"));
+					map.put("ARG_COUNT", rs.getInt("arg_count"));
+					map.put("LANG", rs.getString("lang"));
+					map.put("TARGET", rs.getString("target"));
+					map.put("OWNER", rs.getString("owner"));
+					map.put("INDEX_OF", rs.getInt("index_of"));
+					map.put("DATA_TYPE", rs.getString("data_type"));
 					map.put("PARAMS", str);
 
 				}

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -428,8 +428,7 @@ public final class CUBRIDSchemaFetcher extends
 		Statement stmt = null;
 		try {
 			int dbVersion = getDBVersion(conn);
-			String sqlComment = 
-					dbVersion > COMMENT_SUPPORT_VERSION ? ", a.comment as column_comment, c.comment as table_comment" : "";
+			String sqlComment = dbVersion >= COMMENT_SUPPORT_VERSION ? ", a.comment as column_comment, c.comment as table_comment" : "";
 			
 			String sql = "SELECT a.class_name, a.attr_name, a.attr_type,"
 					+ " a.from_class_name, a.data_type, a.prec,"
@@ -913,7 +912,7 @@ public final class CUBRIDSchemaFetcher extends
 		String tableName = table.getName();
 		try {
 			int dbVersion = getDBVersion(conn);
-			String sqlComment = dbVersion > COMMENT_SUPPORT_VERSION ? ", a.comment" : "";
+			String sqlComment = dbVersion >= COMMENT_SUPPORT_VERSION ? ", a.comment" : "";
 			
 			String sql = "SELECT a.attr_name, a.attr_type, a.from_class_name,"
 					+ " a.data_type, a.prec, a.scale, a.is_nullable,"
@@ -1171,7 +1170,7 @@ public final class CUBRIDSchemaFetcher extends
 		PreparedStatement stmt = null; //NOPMD
 		try {
 			int dbVersion = getDBVersion(conn);
-			String sqlComment = dbVersion > COMMENT_SUPPORT_VERSION ? ", comment" : "";
+			String sqlComment = dbVersion >= COMMENT_SUPPORT_VERSION ? ", comment" : "";
 			
 			String sql = "SELECT vclass_def"
 					+ sqlComment


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4427

**Purpos**
CUBRID 9.3 and earlier versions do not have comment columns such as table and view.
Currently, CMT does not check the CUBRID version when importing a schema, so error occurs by searching for comments even in 9.3 or earlier versions.

**Implementation**
When obtaining the source DB schema, if the version supports comment, add a comment to SQL statement

**Remarks**
N/A