### PR TITLE
[TOOLS-4436] View creation query is not created normally

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -1178,7 +1178,7 @@ public final class CUBRIDSchemaFetcher extends
 					+ " WHERE vclass_name=?";
 			
 			stmt = conn.prepareStatement(sql);
-			rs = stmt.executeQuery();
+			
 			for (View view : schema.getViews()) {
 				try {
 					stmt.setString(1, view.getName());


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4436

**Purpose**
Fixed a bug that could not create a view creation query due to not getting the query specifications of the view from sourceDB.

**Implementation**
N/A

**Remarks**
N/A