### PR TITLE
[TOOLS-4457] When building, the version (commit-no) should be automatically updated.

### DIFF
--- a/com.cubrid.cubridmigration.build/build.sh
+++ b/com.cubrid.cubridmigration.build/build.sh
@@ -8,13 +8,32 @@ BUILD_HOME=${WORKSPACE}
 BUILD_DIR=${BUILD_HOME}/${PRODUCT_DIR}/com.cubrid.cubridmigration.build
 VERSION_DIR=${BUILD_HOME}/${PRODUCT_DIR}/com.cubrid.cubridmigration.ui
 VERSION_FILE_PATH=${VERSION_DIR}/version.properties
+MAKENSIS_EXEC_PATH=${HOME}/build/nsis/makensis.exe
+MAKENSIS_INPUT_PATH="c:/build/src/${PRODUCT_DIR}/com.cubrid.cubridmigration.build/deploy"
+MAKENSIS_OUTPUT_PATH="c:/build/src/${CUR_VER_DIR}"
+
+echo "Version File Update.... (com.cubrid.cubridmigration.ui/version.properties)"
+
+if [ -d ${BUILD_HOME}/${PRODUCT_DIR}/.git ]; then
+  COMMIT_NUMBER=$(cd ${BUILD_HOME}/${PRODUCT_DIR} && git rev-list --count HEAD | awk '{ printf "%04d", $1 }' 2> /dev/null)
+  [ $? -ne 0 ] && COMMIT_NUMBER=$(cd ${BUILD_HOME}/${PRODUCT_DIR} && git log --oneline | wc -l)
+else
+  COMMIT_NUMBER=0000
+fi
+
+RELEASE_VERSION=$(cat ${VERSION_FILE_PATH} | grep releaseVersion | cut -d '=' -f2)
+
+echo "RELEASE_VERSION = " $RELEASE_VERSION
+echo "COMMIT_NUMBER = " $COMMIT_NUMBER
+FULL_VERSION=buildVersionId=${RELEASE_VERSION}.${COMMIT_NUMBER}
+
+sed -i '/buildVersionId/d' ${VERSION_FILE_PATH}
+echo $FULL_VERSION >> ${VERSION_FILE_PATH}
+
 VERSION=`grep buildVersionId ${VERSION_FILE_PATH} | awk 'BEGIN {FS="="} ; {print $2}'`
 CUR_VER_DIR=`date +%Y%m%d`
 CUR_VER_DIR=cubridmigration-deploy/${CUR_VER_DIR}_${VERSION}
 OUTPUT_DIR=${BUILD_HOME}/${CUR_VER_DIR}
-MAKENSIS_EXEC_PATH=${HOME}/build/nsis/makensis.exe
-MAKENSIS_INPUT_PATH="c:/build/src/${PRODUCT_DIR}/com.cubrid.cubridmigration.build/deploy"
-MAKENSIS_OUTPUT_PATH="c:/build/src/${CUR_VER_DIR}"
 
 echo "${PRODUCT_NAME} ${VERSION} build is started..."
 rm -rf ${OUTPUT_DIR}

--- a/com.cubrid.cubridmigration.build/buildProduct.xml
+++ b/com.cubrid.cubridmigration.build/buildProduct.xml
@@ -2,7 +2,7 @@
 	<property file="${basedir}/../com.cubrid.cubridmigration.ui/version.properties" />
 	<property file="product_build_conf/build.properties" />
 	<property file="product_build_conf/build_common.properties" />
-	<property name="product.version" value="${releaseStr}-build-${buildNumber}" />
+	<property name="product.version" value="build-${buildVersionId}" />
 	<property name="launcher.win.32" value="${basedir}/launcher/win32/cubridmigration.exe" />
 	<property name="launcher.win.64" value="${basedir}/launcher/win64/cubridmigration.exe" />
 	<!-- Clean build directory and workspace -->

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/product/AboutDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/product/AboutDialog.java
@@ -74,7 +74,7 @@ public class AboutDialog extends
 		}
 		String[] strs = Version.buildVersionId.split("\\.");
 		String message = Messages.bind(Messages.aboutMessage, new String[] {productName,
-				Version.releaseYear, strs[strs.length - 1], Messages.msgCubridHomePageUrl,
+				Version.releaseVersion, strs[strs.length - 1], Messages.msgCubridHomePageUrl,
 				Messages.msgCubridProjectSiteUrl, Messages.msgCUBRIDToolsSiteURL});
 		this.setItem(scan(message));
 	}

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/product/Version.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/product/Version.java
@@ -44,8 +44,6 @@ public class Version extends
 		NLS.initializeMessages("version", Version.class);
 	}
 
-	public static String releaseStr;
 	public static String releaseVersion;
 	public static String buildVersionId;
-	public static String releaseYear;
 }

--- a/com.cubrid.cubridmigration.ui/version.properties
+++ b/com.cubrid.cubridmigration.ui/version.properties
@@ -1,5 +1,3 @@
 #CUBRID Migration version information
-releaseStr=2023
 releaseVersion=11.1.0
-buildVersionId=11.1.0.0056
-releaseYear=2023.04
+


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4457

Purpose
Auto-update 'commit-no'

Implementation
- modify 'build.sh'
- create a version using only 'releaseVersion'

Remarks
For 2023-05 Release