### PR TITLE
[TOOLS-4462] Modify trigger CUBRID SQL (#85)

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -1369,7 +1369,7 @@ public final class CUBRIDSchemaFetcher extends
 					+ " trig.action_type, action_definition, trig.action_time"
 					+ " FROM db_class c, db_trigger trig, db_trig t"
 					+ " WHERE trig.name=t.trigger_name AND t.target_class_name=c.class_name(+)"
-					+ " AND c.is_system_class='no'"
+					+ " AND c.is_system_class='NO'"
 					+ " ORDER BY name";
 			
 			stmt = conn.prepareStatement(sql);


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4462

Purpose
CUBRID trigger cannot be searched due to trigger sql typo.

Implementation
N/A

Remarks
For 2023.05 Release