### PR TITLE
[TOOLS-4472] NullPointerException occures when source db is Informix

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/trans/INFORMIX2CUBRID.xml
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/trans/INFORMIX2CUBRID.xml
@@ -145,8 +145,8 @@
 			<scale></scale>
 		</SourceDataType>
 		<TargetDataType>
-			<type>list</type>
-			<precision></precision>
+			<type>list(varchar)</type>
+			<precision>255</precision>
 			<scale></scale>
 		</TargetDataType>
     </DataTypeMapping>
@@ -157,8 +157,8 @@
 			<scale></scale>
 		</SourceDataType>
 		<TargetDataType>
-			<type>multiset</type>
-			<precision></precision>
+			<type>multiset(varchar)</type>
+			<precision>255</precision>
 			<scale></scale>
 		</TargetDataType>
     </DataTypeMapping>


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4472

- fixed error NullPointerException Message.