### PR TITLE
[TOOLS-4490] Change the separator character method

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/SchemaFileListTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/SchemaFileListTask.java
@@ -64,6 +64,7 @@ public class SchemaFileListTask extends ImportTask {
 	 */
 	@Override
 	protected void executeImport() {
+		String lineSeparator = System.getProperty("line.separator");
 		List<Schema> schemaList = config.getTargetSchemaList();
 		for (Schema schema : schemaList) {
 			String schemaName = schema.getTargetSchemaName();
@@ -79,7 +80,7 @@ public class SchemaFileListTask extends ImportTask {
 				if (checkFileRepository(tableFileRepository)) {
 					isCreateSchemaListFile = true;
 					sb.append(getFileName(tableFileRepository));
-					sb.append(System.lineSeparator());
+					sb.append(lineSeparator);
 				}
 				
 				// synonym
@@ -87,7 +88,7 @@ public class SchemaFileListTask extends ImportTask {
 				if (checkFileRepository(synonymFileRepository)) {
 					isCreateSchemaListFile = true;
 					sb.append(getFileName(synonymFileRepository));
-					sb.append(System.lineSeparator());
+					sb.append(lineSeparator);
 				}
 				
 				// view
@@ -95,7 +96,7 @@ public class SchemaFileListTask extends ImportTask {
 				if (checkFileRepository(viewFileRepository)) {
 					isCreateSchemaListFile = true;
 					sb.append(getFileName(viewFileRepository));
-					sb.append(System.lineSeparator());
+					sb.append(lineSeparator);
 				}
 				
 				// serial
@@ -103,7 +104,7 @@ public class SchemaFileListTask extends ImportTask {
 				if (checkFileRepository(serialFileRepository)) {
 					isCreateSchemaListFile = true;
 					sb.append(getFileName(serialFileRepository));
-					sb.append(System.lineSeparator());
+					sb.append(lineSeparator);
 				}
 				
 				// pk
@@ -111,7 +112,7 @@ public class SchemaFileListTask extends ImportTask {
 				if (checkFileRepository(pkFileRepository)) {
 					isCreateSchemaListFile = true;
 					sb.append(getFileName(pkFileRepository));
-					sb.append(System.lineSeparator());
+					sb.append(lineSeparator);
 				}
 				
 				// fk
@@ -119,7 +120,7 @@ public class SchemaFileListTask extends ImportTask {
 				if (checkFileRepository(fkFileRepository)) {
 					isCreateSchemaListFile = true;
 					sb.append(getFileName(fkFileRepository));
-					sb.append(System.lineSeparator());
+					sb.append(lineSeparator);
 				}
 				
 				if (isCreateSchemaListFile) {

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -954,6 +954,7 @@ public class SchemaMappingPage extends MigrationWizardPage {
 	 * @return boolean
 	 */
 	private boolean checkFileRepositroy() {
+		String lineSeparator = System.getProperty("line.separator");
 		StringBuffer buffer = new StringBuffer();
 		try {
 			for (SrcTable srcTable : srcTableList) {
@@ -971,31 +972,31 @@ public class SchemaMappingPage extends MigrationWizardPage {
 					File synonymFile = new File(synonymFileListFullName.get(srcTable.getTarSchema()));
 					
 					if (tableFile.exists()) {
-						buffer.append(tableFile.getCanonicalPath()).append(System.lineSeparator());
+						buffer.append(tableFile.getCanonicalPath()).append(lineSeparator);
 					}
 					if (viewFile.exists()) {
-						buffer.append(viewFile.getCanonicalPath()).append(System.lineSeparator());
+						buffer.append(viewFile.getCanonicalPath()).append(lineSeparator);
 					}
 					if (pkFile.exists()) {
-						buffer.append(pkFile.getCanonicalPath()).append(System.lineSeparator());
+						buffer.append(pkFile.getCanonicalPath()).append(lineSeparator);
 					}
 					if (fkFile.exists()) {
-						buffer.append(fkFile.getCanonicalPath()).append(System.lineSeparator());
+						buffer.append(fkFile.getCanonicalPath()).append(lineSeparator);
 					}
 					if (serialFile.exists()) {
-						buffer.append(serialFile.getCanonicalPath()).append(System.lineSeparator());
+						buffer.append(serialFile.getCanonicalPath()).append(lineSeparator);
 					}
 					if (infoFile.exists()) {
-						buffer.append(infoFile.getCanonicalPath()).append(System.lineSeparator());
+						buffer.append(infoFile.getCanonicalPath()).append(lineSeparator);
 					}
 					if (synonymFile.exists()) {
-						buffer.append(synonymFile.getCanonicalPath()).append(System.lineSeparator());
+						buffer.append(synonymFile.getCanonicalPath()).append(lineSeparator);
 					}
 					
 				} else {
 					File schemaFile = new File(schemaFullName.get(srcTable.getTarSchema()));
 					if (schemaFile.exists()) {
-						buffer.append(schemaFile.getCanonicalPath()).append(System.lineSeparator());
+						buffer.append(schemaFile.getCanonicalPath()).append(lineSeparator);
 					}
 				}
 				
@@ -1004,13 +1005,13 @@ public class SchemaMappingPage extends MigrationWizardPage {
 				File updateStatisticFile = new File(updateStatisticFullName.get(srcTable.getTarSchema()));
 				
 				if (dataFile.exists()) {
-					buffer.append(dataFile.getCanonicalPath()).append(System.lineSeparator());
+					buffer.append(dataFile.getCanonicalPath()).append(lineSeparator);
 				}
 				if (indexFile.exists()) {
-					buffer.append(indexFile.getCanonicalPath()).append(System.lineSeparator());
+					buffer.append(indexFile.getCanonicalPath()).append(lineSeparator);
 				}
 				if (updateStatisticFile.exists()) {
-					buffer.append(updateStatisticFile.getCanonicalPath()).append(System.lineSeparator());
+					buffer.append(updateStatisticFile.getCanonicalPath()).append(lineSeparator);
 				}
 			}
 		} catch (IOException e) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4490

**Purpose**
Changed separator character method to be built in java 6.

**Implementation**
Change System.lineSeparator() to System.getProperty("line.separator")

**Remarks**
N/A