### PR TITLE
[TOOLS-4503] Schema Mapping Page checkbox not select

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -556,10 +556,8 @@ public class SchemaMappingPage extends MigrationWizardPage {
 	private void setOnlineSchemaMappingPage() {
 		setOnlineData();
 		getSchemaValues();
+		setOnlineEditor();
 		
-		if (tarCatalog.isDbHasUserSchema()) {
-			setOnlineEditor();
-		}
 	}
 	
 	private void setOnlineData() {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4503

**Purpose**
There is a bug where the schema mapping page schema checkbox is not selected during the migration to CUBRID 11.2 to 11.0.

**Implementation**
Modified that checkbox can be selected even if targetDB CUBRID version is 11.0 or lower.

**Remarks**
N/A