### PR TITLE
[TOOLS-4506] Changed target owner name is not applied when creating synonym

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectDestinationPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectDestinationPage.java
@@ -463,9 +463,7 @@ public class SelectDestinationPage extends
 			
 			int targetCubridVersion = (catalog.getVersion().getDbMajorVersion() * 10) + (catalog.getVersion().getDbMinorVersion());
 			config.setTargetDBVersion(String.valueOf(targetCubridVersion));
-			if (targetCubridVersion >= 112) {
-				config.setAddUserSchema(catalog.isDBAGroup());
-			}
+			config.setAddUserSchema(targetCubridVersion >= 112);
 			
 			
 			if (null != catalog) {

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectDestinationPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectDestinationPage.java
@@ -366,6 +366,7 @@ public class SelectDestinationPage extends
 	 */
 	private class OnlineTargetDBView extends
 			AbstractDestinationView {
+		private final int USERSCHEMA_VERSION = 112;
 		private final JDBCConnectionMgrView conMgrView;
 
 		private Button btnWriteErrorRecords;
@@ -463,7 +464,7 @@ public class SelectDestinationPage extends
 			
 			int targetCubridVersion = (catalog.getVersion().getDbMajorVersion() * 10) + (catalog.getVersion().getDbMinorVersion());
 			config.setTargetDBVersion(String.valueOf(targetCubridVersion));
-			config.setAddUserSchema(targetCubridVersion >= 112);
+			config.setAddUserSchema(targetCubridVersion >= USERSCHEMA_VERSION);
 			
 			
 			if (null != catalog) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4506

**Purpose**
If the target connection user does not have DBA privileges, even if you change the synonym target owner name during migration, the changed name is not applied and a synonym is created.
Fix so that a synonym can be created with the changed target owner name.

**Implementation**
Modified so that user schema can be applied to targetDB even if you are not a DBA.

**Remarks**
N/A
