### PR TITLE
[TOOLS-4508] Improved speed of importing Oracle schema information

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -98,6 +98,7 @@ public final class OracleSchemaFetcher extends
 
 	private static final String OBJECT_TYPE_FUNCTION = "FUNCTION";
 	private static final String OBJECT_TYPE_PROCEDURE = "PROCEDURE";
+	@SuppressWarnings("unused")
 	private static final String OBJECT_TYPE_SEQUENCE = "SEQUENCE";
 	private static final String OBJECT_TYPE_TABLE = "TABLE";
 	private static final String OBJECT_TYPE_TRIGGER = "TRIGGER";
@@ -212,10 +213,6 @@ public final class OracleSchemaFetcher extends
 				LOG.debug("[VAR]tableList.count=" + tableList.size());
 			}
 			for (Table table : tableList) {
-				String ddl = getObjectDDL(conn, schema.getName(), table.getName(),
-						OBJECT_TYPE_TABLE);
-				table.setDDL(ddl);
-				
 				String comment = getTableComment(conn, schema.getName(), table.getName());
 				
 				if (comment != null) {
@@ -233,8 +230,6 @@ public final class OracleSchemaFetcher extends
 				LOG.debug("[VAR]viewList.count=" + viewList.size());
 			}
 			for (View view : viewList) {
-				String ddl = getObjectDDL(conn, schema.getName(), view.getName(), OBJECT_TYPE_VIEW);
-				view.setDDL(ddl);
 				view.setQuerySpec(getQueryText(conn, schema.getName(), view.getName(), view));
 				
 				String comment = getViewComment(conn, schema.getName(), view.getName());
@@ -394,7 +389,6 @@ public final class OracleSchemaFetcher extends
 				seq.setNoMaxValue(false);
 				seq.setNoMinValue(false);
 				seq.setNoCache(cacheSize <= 1);
-				seq.setDDL(getObjectDDL(conn, schema.getName(), sequenceName, OBJECT_TYPE_SEQUENCE));
 				seq.setOwner(schema.getName());
 				schema.addSequence(seq);
 			}
@@ -1428,12 +1422,6 @@ public final class OracleSchemaFetcher extends
 			Closer.close(rs);
 			Closer.close(stmt);
 		}
-	}
-	
-	private String setViewColumnComment(String queryString, View view) {
-		
-		
-		return null;
 	}
 
 	//	/**

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/ViewMappingView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/ViewMappingView.java
@@ -65,8 +65,6 @@ public class ViewMappingView extends
 	private Composite container;
 	private Text txtTargetName;
 	private Text txtTargetSQL;
-	private Text txtSourceName;
-	private Text txtSourceSQL;
 	private Button btnCreate;
 	private Button btnReplace;
 	private SourceConfig viewConfig;
@@ -123,37 +121,7 @@ public class ViewMappingView extends
 		btnReplace.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
 		btnReplace.setText(Messages.lblReplace);
 
-		createSourcePart(container);
 		createTargetPart(container);
-	}
-
-	/**
-	 * Create source part.
-	 * 
-	 * @param parent of source part
-	 */
-	private void createSourcePart(Composite parent) {
-		Group grpSource = new Group(parent, SWT.NONE);
-		grpSource.setLayout(new GridLayout(2, false));
-		GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1);
-		grpSource.setLayoutData(gd);
-		grpSource.setText(Messages.lblSource);
-
-		Label lblSourceName = new Label(grpSource, SWT.NONE);
-		lblSourceName.setText(Messages.lblViewName);
-
-		txtSourceName = new Text(grpSource, SWT.BORDER);
-		txtSourceName.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-		txtSourceName.setEditable(false);
-		txtSourceName.setText("");
-
-		Label lblSQL = new Label(grpSource, SWT.NONE);
-		lblSQL.setText(Messages.lblViewStatement);
-
-		txtSourceSQL = new Text(grpSource, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL | SWT.WRAP);
-		txtSourceSQL.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-		txtSourceSQL.setEditable(false);
-		txtSourceSQL.setText("");
 	}
 
 	/**
@@ -206,8 +174,6 @@ public class ViewMappingView extends
 		if (viewConfig == null || vw == null) {
 			return;
 		}
-		txtSourceName.setText(vw.getName());
-		txtSourceSQL.setText(vw.getDDL());
 
 		View targetVW = config.getTargetViewSchema(viewConfig.getTarget());
 		if (targetVW == null) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4508

**Purpose**
When reading Oracle schema information, it takes more than 98% of the time to search Object DDL.
Object DDL is searched to show DDL for objects for which CMT does not support migration on the unsupported object page in the migration report.
Therefor, since there is no need to search DDL for objects that support migration in CMT, Table, View and Sequence are modified so that they do not search DDL.

**Implementation**
- Modify not to import Table and Sequence DDL.
- Remove the part that displays ddl from the ObjectMappingPage View Detail page without importing View DDL.

**Remarks**
N/A