### PR TITLE
[TOOLS-4509] ObjectMappingPage Table node NullPointerError

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/TableOrView.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/TableOrView.java
@@ -153,7 +153,9 @@ public abstract class TableOrView extends
 	 * @return Column
 	 */
 	public Column getColumnByName(String tableOwnerName, String tableName, String name) {
-		if (tableOwnerName == null || tableName == null) {
+		if (tableOwnerName == null
+				|| tableName == null
+				|| tableOwnerName.equals("")) {
 			return getColumnByName(name);
 		}
 		

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -2049,7 +2049,7 @@ public class MigrationConfiguration {
 				if (schema == null) {
 					return setc;
 				}
-				if (schema.equals(setc.getOwner())) {
+				if (schema.equalsIgnoreCase((setc.getOwner()))) {
 					return setc;
 				}
 				if (setc.getOwner() == null) {
@@ -3243,7 +3243,7 @@ public class MigrationConfiguration {
 	 * @return target table
 	 */
 	public Table getTargetTableSchema(String owner, String name) {
-		if (owner == null) {
+		if (owner == null || owner.equals("")) {
 			return getTargetTableSchema(name);
 		}
 		


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4509

**Purpose**
If TargetDB is version 11.0 or lower, a NullPointerError occurs in the Table node in the Object Mapping Page when migration to a script.

**Implementation**
Add tableOwnerName  validation condition.

**Remarks**
N/A