### PR TITLE
[TOOLS-4512] When migrating schemas not selected by the user are designated for migration

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -660,6 +660,9 @@ public class SchemaMappingPage extends MigrationWizardPage {
 		for (SrcTable srcTable : srcTableList) {
 			if (!(tarCatalog.isDbHasUserSchema())) {
 				srcTable.setTarSchema(null);
+				if (!srcTable.isSelected) {
+					srcCatalog.removeOneSchema(srcCatalog.getSchemaByName(srcTable.getSrcSchema()));
+				}
 				continue;
 			}
 			


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4512

**Purpose**
When transferring from DB (CUBRID 11.2 or higher) that supports user schema to a version that does not support user schema, only schema selected by the user in Schema Mapping Page is not designated as transfer target, and all schema are designated as transfer target.
Modify so that only schema specified by the user are designated as transfer targets.

**Implementation**
N/A

**Remarks**
N/A