### PR TITLE
[TOOLS-4517] [CMT] Error as informix serial type is converted to cubr…

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/trans/INFORMIX2CUBRID.xml
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/trans/INFORMIX2CUBRID.xml
@@ -451,7 +451,7 @@
 			<scale></scale>
 		</SourceDataType>
 		<TargetDataType>
-			<type>bigint</type>
+			<type>int</type>
 			<precision></precision>
 			<scale></scale>
 		</TargetDataType>


### PR DESCRIPTION
…id bigint type

http://jira.cubrid.org/browse/TOOLS-4517

- fixed serial type convert to bigint problem.
- convert serial type to int instead.