### PR TITLE
[TOOLS-4514] Fix JDBC driver incorrect error message

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/connection/JDBCDriverManager.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/connection/JDBCDriverManager.java
@@ -111,13 +111,23 @@ public final class JDBCDriverManager implements
 	 * 
 	 * @return true if driver is already existed in the list
 	 */
-	public boolean isDriverDuplicated(String driverFile) {
+	public boolean isDriverDuplicated(DatabaseType databaseType, String driverFile) {
 		DatabaseType[] allTypes = DatabaseType.getAllTypes();
-		for (DatabaseType dt : allTypes) {
-			if (dt.getJDBCData(driverFile) != null) {
-				return true;
+		if (databaseType == null) {
+			for (DatabaseType dt : allTypes) {
+				if (dt.getJDBCData(driverFile) != null) {
+					return true;
+				}
+			}
+		} else {
+			for (DatabaseType dt : allTypes) {
+				if (databaseType.getID() == dt.getID() 
+						&& dt.getJDBCData(driverFile) != null) {
+					return true;
+				}
 			}
 		}
+
 		return false;
 	}
 

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCConnectEditView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCConnectEditView.java
@@ -115,7 +115,7 @@ public class JDBCConnectEditView {
 		if (StringUtils.isBlank(firstFile)) {
 			return;
 		}
-		if (JDBCDriverManager.getInstance().isDriverDuplicated(firstFile)) {
+		if (JDBCDriverManager.getInstance().isDriverDuplicated(dt, firstFile)) {
 			UICommonTool.openErrorBox(Display.getDefault().getActiveShell(),
 					Messages.msgDuplicatedJdbcDriverFile);
 			return;

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/preference/JDBCDriverManagePage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/preference/JDBCDriverManagePage.java
@@ -235,7 +235,7 @@ public class JDBCDriverManagePage extends
 		if (firstFile == null) {
 			return;
 		}
-		if (JDBCDriverManager.getInstance().isDriverDuplicated(firstFile)) {
+		if (JDBCDriverManager.getInstance().isDriverDuplicated(null, firstFile)) {
 			UICommonTool.openErrorBox(Display.getDefault().getActiveShell(),
 					Messages.msgDuplicatedJdbcDriverFile);
 			return;


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4514

**Purpos**
If you select a DB driver and then select a different type of DB driver again, an error message related to driver duplication will appear.
This is an incorrect error message.
Corrected error message to "Invalid JDBC driver file".

**Implementation**
N/A

**Remarks**
N/A