### PR TITLE
[TOOLS-4524] If a user does not have a specific object, it will not be displayed on the Schema Mapping Page

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
@@ -58,8 +58,10 @@ import com.cubrid.cubridmigration.core.common.TimeZoneUtils;
 import com.cubrid.cubridmigration.core.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
+import com.cubrid.cubridmigration.core.dbobject.Grant;
 import com.cubrid.cubridmigration.core.dbobject.Schema;
 import com.cubrid.cubridmigration.core.dbobject.Sequence;
+import com.cubrid.cubridmigration.core.dbobject.Synonym;
 import com.cubrid.cubridmigration.core.dbobject.Table;
 import com.cubrid.cubridmigration.core.dbobject.View;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
@@ -597,8 +599,12 @@ public class SelectSourcePage extends
 				List<Table> tableList = schema.getTables();
 				List<View> viewList = schema.getViews();
 				List<Sequence> sequenceList = schema.getSequenceList();
+				List<Synonym> synonymList = schema.getSynonymList();
+				List<Grant> grantList = schema.getGrantList();
 				
-				if (tableList.isEmpty() && viewList.isEmpty() && sequenceList.isEmpty()) {
+				if (tableList.isEmpty() && viewList.isEmpty() 
+						&& sequenceList.isEmpty() && synonymList.isEmpty()
+						&& grantList.isEmpty()) {
 					removeSchema.add(schema);
 				}
 			}


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4524

**Purpose**
If a user does not have any table, view, or serial objects, they will not appear on the Schema Mapping page, even if synonym and grant objects exist.

**Implementation**
Solve the problem by also adding synonym and grant to the condition of not excluding schema display on the Schema Mapping Page.

**Remarks**
N/A