### PR TITLE
[TOOLS-4530] Fix null pointer exception after TOOLS-4519 changes has applied

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -2280,14 +2280,9 @@ public final class CUBRIDSchemaFetcher extends
 		Integer ver = Integer.parseInt("" + conn.getMetaData().getDatabaseMajorVersion() 
 				+ conn.getMetaData().getDatabaseMinorVersion());
 		
-		if (ver < 112) {
-			return super.getSchemaNames(conn, cp);
-		}
-		
 		if (!getPrivilege(conn, cp)) {
 			return getUserSchemaNames(conn, cp);
 		}
-		
 		
 		List<String> schemaNames = new ArrayList<String>();
 		PreparedStatement stmt = null;

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -331,36 +331,28 @@ public class SchemaMappingPage extends MigrationWizardPage {
 		Catalog targetCatalog = wizard.getTargetCatalog();
 		Catalog sourceCatalog = wizard.getOriginalSourceCatalog();
 		
-		ArrayList<String> dropDownSchemaList = new ArrayList<String>();
-		tarSchemaNameList = new ArrayList<String>();
-		
-		if (targetCatalog.isDbHasUserSchema()) {
-			List<Schema> targetSchemaList = targetCatalog.getSchemas();
-			
-			for (Schema schema : targetSchemaList) {
-				tarSchemaNameList.add(schema.getName());
-				dropDownSchemaList.add(schema.getName());
-			}
-		} else {
-			tarSchemaNameList.add(targetCatalog.getConnectionParameters().getConUser());
-		}
-		
-		if (sourceCatalog.isDbHasUserSchema()) {
-			List<Schema> sourceSchemaList = sourceCatalog.getSchemas();
-			
-			for (Schema schema : sourceSchemaList) {
-				if (tarSchemaNameList.contains(schema.getName().toUpperCase())) {
-					continue;
-				}
-				
-				dropDownSchemaList.add(schema.getName());
-			}
-		} else {
-			tarSchemaNameList.add(sourceCatalog.getConnectionParameters().getConUser());
-		}
+		List<Schema> targetSchemaList = targetCatalog.getSchemas();
+		List<Schema> sourceSchemaList = sourceCatalog.getSchemas();
 
+		tarSchemaNameList = new ArrayList<String>();
+		ArrayList<String> dropDownSchemaList = new ArrayList<String>();
+		
+		for (Schema schema : targetSchemaList) {
+			tarSchemaNameList.add(schema.getName());
+			dropDownSchemaList.add(schema.getName());
+		}
+		
+		for (Schema schema : sourceSchemaList) {
+			if (tarSchemaNameList.contains(schema.getName().toUpperCase())) {
+				continue;
+			}
+			
+			dropDownSchemaList.add(schema.getName());
+		}
+		
 		if (targetCatalog.isDBAGroup()) {
 			tarSchemaNameArray = dropDownSchemaList.toArray(new String[] {});
+			
 		} else {
 			tarSchemaNameArray = new String[] {targetCatalog.getConnectionParameters().getConUser()};
 		}
@@ -409,10 +401,6 @@ public class SchemaMappingPage extends MigrationWizardPage {
 			
 			@Override
 			public boolean canModify(Object element, String property) {
-				if (!tarCatalog.isDbHasUserSchema()) {
-					return false;
-				}
-				
 				if (property.equals(propertyList[4]) || property.equals(propertyList[0])) {
 					return true;
 				} else {
@@ -582,17 +570,11 @@ public class SchemaMappingPage extends MigrationWizardPage {
 		tarSchemaList = tarCatalog.getSchemas();
 		
 		Map<String, Schema> scriptSchemaMap = config.getScriptSchemaMapping();
-
+		
 		for (Schema schema : srcSchemaList) {
 			SrcTable srcTable = new SrcTable();
 			srcTable.setSrcDBType(srcCatalog.getDatabaseType().getName());
-			
-			if (srcCatalog.isDbHasUserSchema()) {
-				srcTable.setSrcSchema(schema.getName());
-			} else {
-				srcTable.setSrcSchema(srcCatalog.getConnectionParameters().getConUser());
-			}
-			
+			srcTable.setSrcSchema(schema.getName());
 			srcTable.setNote(schema.isGrantorSchema());
 			
 			if (!schema.isGrantorSchema()) {
@@ -625,7 +607,7 @@ public class SchemaMappingPage extends MigrationWizardPage {
 				if (tarCatalog.isDBAGroup() && version >= 112) {
 					srcTable.setTarSchema(srcTable.getSrcSchema());
 				} else {
-					srcTable.setTarSchema(tarCatalog.getConnectionParameters().getConUser());
+					srcTable.setTarSchema(tarCatalog.getSchemas().get(0).getName());
 				}
 			}
 		}


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4530

**Purpose**
After the TOOLS-4519 modification, the connect name is displayed, not the schema name. However, an error occurs because the migration uses the schema name. Therefore, it is modified to use the connect user name, not the schema name.

**Implementation**
Reverts fixes in TOOLS-4519 and apply this change

**Remarks**
N/A