### PR TITLE
[TOOLS-4535] Fix notification for renaming duplicate objects in multiple schemas

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/Catalog.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/Catalog.java
@@ -81,6 +81,7 @@ public class Catalog implements
 	private Map<String, Integer> allTablesCountMap = new HashMap<String, Integer>();
 	private Map<String, Integer> allViewsCountMap = new HashMap<String, Integer>();
 	private Map<String, Integer> allSequencesCountMap = new HashMap<String, Integer>();
+	private Map<String, Integer> allSynonymsCountMap = new HashMap<String, Integer>();
 	private Map<String, Integer> allGrantsCountMap = new HashMap<String, Integer>();
 	
 	private boolean isDBAGroup;
@@ -278,6 +279,10 @@ public class Catalog implements
 	
 	public Map<String, Integer> getAllSequencesCountMap() {
 		return allSequencesCountMap;
+	}
+	
+	public Map<String, Integer> getAllSynonymsCountMap() {
+		return allSynonymsCountMap;
 	}
 	
 	public Map<String, Integer> getAllGrantCountMap() {

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ObjectMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ObjectMappingPage.java
@@ -252,7 +252,6 @@ public class ObjectMappingPage extends
 		util.createDetailMessage(sb, sourceCatalog, DBObject.OBJ_TYPE_VIEW, messageType);
 		util.createDetailMessage(sb, sourceCatalog, DBObject.OBJ_TYPE_SEQUENCE, messageType);
 		util.createDetailMessage(sb, sourceCatalog, DBObject.OBJ_TYPE_SYNONYM, messageType);
-		util.createDetailMessage(sb, sourceCatalog, DBObject.OBJ_TYPE_GRANT, messageType);
 		return sb.toString();
 	}
 

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ObjectMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ObjectMappingPage.java
@@ -160,6 +160,7 @@ public class ObjectMappingPage extends
 		try {
 			//Update migration source database schema
 			Catalog sourceCatalog = mw.getSourceCatalog();
+			Catalog targetCatalog = mw.getTargetCatalog();
 			
 			final MigrationConfiguration cfg = mw.getMigrationConfig();
 			if (cfg.sourceIsOnline() && !cfg.getSourceDBType().equals(DatabaseType.CUBRID)) {
@@ -170,7 +171,7 @@ public class ObjectMappingPage extends
 			int tarSchemaSize = getMigrationWizard().getTarCatalogSchemaCount();
 			if (isFirstVisible) {
 					if (util.checkMultipleSchema(sourceCatalog, cfg)
-							&& util.createAllObjectsMap(sourceCatalog)
+							&& util.createAllObjectsMap(sourceCatalog, targetCatalog, cfg)
 							&& util.hasDuplicatedObjects(sourceCatalog)
 							&& (tarSchemaSize <= 1 || cfg.isTarSchemaDuplicate())) {
 						showDetailMessageDialog(sourceCatalog);

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/utils/MigrationCfgUtils.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/utils/MigrationCfgUtils.java
@@ -55,6 +55,7 @@ import com.cubrid.cubridmigration.core.dbobject.FK;
 import com.cubrid.cubridmigration.core.dbobject.Index;
 import com.cubrid.cubridmigration.core.dbobject.Schema;
 import com.cubrid.cubridmigration.core.dbobject.Sequence;
+import com.cubrid.cubridmigration.core.dbobject.Synonym;
 import com.cubrid.cubridmigration.core.dbobject.Table;
 import com.cubrid.cubridmigration.core.dbobject.TableOrView;
 import com.cubrid.cubridmigration.core.dbobject.Version;
@@ -967,10 +968,12 @@ public class MigrationCfgUtils {
 		Map<String, Integer> allTablesCountMap = sourceCatalog.getAllTablesCountMap();
 		Map<String, Integer> allViewsCountMap = sourceCatalog.getAllViewsCountMap();
 		Map<String, Integer> allSequencesCountMap = sourceCatalog.getAllSequencesCountMap();
+		Map<String, Integer> allSynonymsCountMap = sourceCatalog.getAllSynonymsCountMap();
 
 		allTablesCountMap.clear();
 		allViewsCountMap.clear();
 		allSequencesCountMap.clear();
+		allSynonymsCountMap.clear();
 
 		int targetVersion = Integer.MAX_VALUE;
 		if (targetCatalog != null) {
@@ -984,6 +987,7 @@ public class MigrationCfgUtils {
 				createMap(allTablesCountMap, schema.getTables());
 				createMap(allViewsCountMap, schema.getViews());
 				createMap(allSequencesCountMap, schema.getSequenceList());
+				createMap(allSynonymsCountMap, schema.getSynonymList());
 			}
 			return true;
 		}
@@ -1025,6 +1029,8 @@ public class MigrationCfgUtils {
 				createObjectInformation(sb, catalog.getAllViewsCountMap(), schema.getViews(), messageType);
 			} else if (objType.equals(DBObject.OBJ_TYPE_SEQUENCE)) {
 				createObjectInformation(sb, catalog.getAllSequencesCountMap(), schema.getSequenceList(), messageType);
+			} else if (objType.equals(DBObject.OBJ_TYPE_SYNONYM)) {
+				createObjectInformation(sb, catalog.getAllSynonymsCountMap(), schema.getSynonymList(), messageType);
 			}
 		}
 		sb.append("\n");
@@ -1039,6 +1045,8 @@ public class MigrationCfgUtils {
 					owner = ((TableOrView) object).getOwner();
 				} else if (object instanceof Sequence) {
 					owner = ((Sequence) object).getOwner();
+				} else if (object instanceof Synonym) {
+					owner = ((Synonym) object).getOwner();
 				}
 				appendDuplicatedObjectInformation(sb, owner, objectName, messageType);
 			}


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4535

**Purpose**
Fixes a notification that an object with the same name exists in a different schema in the source database and the target database renames the object even if it is a version that supports multi-schema.

**Implementation**
- If the target database is 11.2 or higher, you will not receive duplicate object name change notifications.
- Add synonym to duplicate object notifications.
- Delete grant from duplicate object notification.

**Remarks**
N/A