### PR TITLE
[TOOLS-4537] Change grant offline dump file output format

### DIFF
--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
@@ -182,6 +182,9 @@ public class StartCommandHandler implements
 					return null;
 				}
 			}
+			if (targetPath != null) {
+				config.changeTargetFilePath(targetPath);
+			}
 			config.cleanNoUsedConfigForStart();
 			if (config.hasOtherParam()) {
 				String s1 = config.getOtherParam(MySQL2CUBRIDMigParas.UNPARSED_TIME);
@@ -343,9 +346,6 @@ public class StartCommandHandler implements
 				return false;
 			}
 		} else {
-			if (targetPath != null) {
-				config.changeTargetFilePath(targetPath);
-			}
 			boolean confirm;
 			String tempPath = config.getFileRepositroyPath();
 			if (SystemUtils.IS_OS_WINDOWS) {

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/Grant.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/Grant.java
@@ -49,6 +49,7 @@ public class Grant extends
 	private boolean isGrantable;
 	private String createDDL;
 	private String sourceOwner;
+	private String sourceObjectOwner;
 	
 	public Grant() {
 		//do nothing
@@ -164,6 +165,14 @@ public class Grant extends
 	
 	public void setSourceOwner(String sourceOwner) {
 		this.sourceOwner = sourceOwner;
+	}
+	
+	public String getSourceObjectOwner() {
+		return sourceObjectOwner;
+	}
+	
+	public void setSourceObjectOwner(String sourceObjectOwner) {
+		this.sourceObjectOwner = sourceObjectOwner;
 	}
 
 	@Override

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/SourceGrantConfig.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/SourceGrantConfig.java
@@ -40,6 +40,7 @@ public class SourceGrantConfig extends
 	private String className;
 	private String classOwner;
 	private boolean isGrantable;
+	private String sourceObjectOwner;
 	
 	public String getOwner() {
 		return owner;
@@ -111,5 +112,13 @@ public class SourceGrantConfig extends
 	
 	public void setGrantable(boolean isGrantable) {
 		this.isGrantable = isGrantable;
+	}
+	
+	public String getSourceObjectOwner() {
+		return sourceObjectOwner;
+	}
+
+	public void setSourceObjectOwner(String owner) {
+		this.sourceObjectOwner = owner;
 	}
 }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -108,7 +108,7 @@ public class LoadFileImporter extends
 	private final Map<String, String> indexFiles = new HashMap<String, String>();
 	private final Map<String, String> sequenceFiles = new HashMap<String, String>();
 	private final Map<String, String> synonymFiles = new HashMap<String, String>();
-	private final Map<String, String> grantFiles = new HashMap<String, String>();
+	private final Map<String, Map<String, String>> grantFiles = new HashMap<String, Map<String, String>>();
 
 	private final Object lockObj = new Object();
 
@@ -322,11 +322,11 @@ public class LoadFileImporter extends
 	 * @param owner
 	 * @return grant file full path
 	 */
-	protected String handleGrantFile(String owner) {
+	protected String handleGrantFile(String owner, String sourceObjectOwner) {
 		if (!grantFiles.containsKey(owner)) {
 			grantFiles.put(owner, config.getTargetGrantFileName(owner));
 		}
-		return grantFiles.get(owner);
+		return grantFiles.get(owner).get(sourceObjectOwner);
 	}
 	
 	/**
@@ -354,11 +354,13 @@ public class LoadFileImporter extends
 	 * @param listener a call interface.
 	 * @param isIndex true if the DDL is about index
 	 */
-	protected void sendSchemaFile(String fileName, RunnableResultHandler listener, String objectType, String owner) {
-		executeTask(fileName, getFilePath(objectType, owner), listener, config.isDeleteTempFile(), true);
+	protected void sendSchemaFile(String fileName, RunnableResultHandler listener, 
+			String objectType, String owner, String sourceObjectOwner) {
+		executeTask(fileName, getFilePath(objectType, owner, sourceObjectOwner), 
+				listener, config.isDeleteTempFile(), true);
 	}
 	
-	private String getFilePath(String objectType, String owner) {
+	private String getFilePath(String objectType, String owner, String sourceObjectOwner) {
 		if (config.isSplitSchema()) {
 			if (objectType.equals(DBObject.OBJ_TYPE_TABLE)) {
 				return handleTableSchemaFile(owner);
@@ -377,7 +379,7 @@ public class LoadFileImporter extends
 			} else if (objectType.equals(DBObject.OBJ_TYPE_SYNONYM)) {
 				return handleSynonymFile(owner);
 			} else if (objectType.equals(DBObject.OBJ_TYPE_GRANT)) {
-				return handleGrantFile(owner);
+				return handleGrantFile(owner, sourceObjectOwner);
 			}
 		} else {
 			if (objectType.equals(DBObject.OBJ_TYPE_TABLE)

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -420,7 +420,7 @@ public abstract class OfflineImporter extends
 	 * @param isIndex true if the DDL is about index
 	 */
 	protected abstract void sendSchemaFile(String fileName, RunnableResultHandler listener,
-			String objectType, String owner);
+			String objectType, String owner, String sourceObjectOwner);
 
 	/**
 	 * Write content to file.
@@ -459,6 +459,18 @@ public abstract class OfflineImporter extends
 	public void executeDDL(String sql) {
 		executeDDL(sql, null, null, null);
 	}
+	
+	/**
+	 * Execute DDL
+	 * 
+	 * @param sql to be executed.
+	 * @param objectType true if the sql is DDL of index
+	 * @param listener to be called back 
+	 * @param owner Grant owner
+	 */
+	public void executeDDL(String sql, String objectType, RunnableResultHandler listener, String owner) {
+		executeDDL(sql, objectType, listener, owner, null);
+	}
 
 	/**
 	 * Execute DDL SQLs.
@@ -466,8 +478,11 @@ public abstract class OfflineImporter extends
 	 * @param sql to be executed.
 	 * @param isIndex true if the sql is DDL of index
 	 * @param listener to be called back
+	 * @param owner Grant owner
+	 * @param sourceObjectOwner Grant owner in the source database
 	 */
-	protected void executeDDL(String sql, String objectType, RunnableResultHandler listener, String owner) {
+	protected void executeDDL(String sql, String objectType, 
+			RunnableResultHandler listener, String owner, String sourceObjectOwner) {
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("[IN]executeDDL().sql=" + sql);
 		}
@@ -476,7 +491,7 @@ public abstract class OfflineImporter extends
 			LOG.debug("[VAR]fileName=" + fileName);
 		}
 		writeFile(fileName, sql);
-		sendSchemaFile(fileName, listener, objectType, owner);
+		sendSchemaFile(fileName, listener, objectType, owner, sourceObjectOwner);
 	}
 
 	/**
@@ -744,7 +759,7 @@ public abstract class OfflineImporter extends
 		String ddl = CUBRIDSQLHelper.getInstance(null).getGrantDDL(gr, config.isAddUserSchema());
 		gr.setDDL(ddl);
 		executeDDL(ddl + ";\n", DBObject.OBJ_TYPE_GRANT, createResultHandler(gr), 
-				config.isAddUserSchema() ? gr.getSourceOwner() : config.getSourceConParams().getConUser());
+				config.isAddUserSchema() ? gr.getSourceOwner() : config.getSourceConParams().getConUser(), gr.getSourceObjectOwner());
 	}
 	
 	public void createSchema(Schema schema) {

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
@@ -32,8 +32,10 @@ package com.cubrid.cubridmigration.core.engine.scheduler;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -265,7 +267,17 @@ public class MigrationTasksScheduler {
 			PathUtils.deleteFile(new File(config.getTargetSerialFileName(schemaName)));
 			PathUtils.deleteFile(new File(config.getTargetSchemaFileListName(schemaName)));
 			PathUtils.deleteFile(new File(config.getTargetSynonymFileName(schemaName)));
-			PathUtils.deleteFile(new File(config.getTargetGrantFileName(schemaName)));
+			
+			Map<String, String> grantFilePaths = config.getTargetGrantFileName(schemaName);
+			Iterator<String> keys = null;
+			if (grantFilePaths != null) {
+				keys = grantFilePaths.keySet().iterator();
+			}
+			if (keys != null) {
+				while (keys.hasNext()) {
+					PathUtils.deleteFile(new File(grantFilePaths.get(keys.next())));
+				}
+			}
 		} else {
 			PathUtils.deleteFile(new File(config.getTargetSchemaFileName(schemaName)));
 		}

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/SchemaFileListTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/SchemaFileListTask.java
@@ -33,7 +33,9 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 
@@ -139,11 +141,15 @@ public class SchemaFileListTask extends ImportTask {
 			}
 			
 			// grant
-			String grantFileRepository = config.getTargetGrantFileName(schemaName);
-			if (checkFileRepository(grantFileRepository)) {
-				isCreateSchemaListFile = true;
-				sb.append(getFileName(grantFileRepository));
-				sb.append(lineSeparator);
+			Map<String, String> grantFilePaths = config.getTargetGrantFileName(schemaName);
+			Iterator<String> keys = grantFilePaths.keySet().iterator();
+			while (keys.hasNext()) {
+				String grantFileRepository = grantFilePaths.get(keys.next());
+				if (checkFileRepository(grantFileRepository)) {
+					isCreateSchemaListFile = true;
+					sb.append(getFileName(grantFileRepository));
+					sb.append(lineSeparator);
+				}
 			}
 
 			// view query specification

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateHandler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateHandler.java
@@ -471,6 +471,7 @@ public final class MigrationTemplateHandler extends
 		grn.setAuthType(attributes.getValue(TemplateTags.ATTR_AUTH_TYPE));
 		grn.setGrantable(getBoolean(attributes.getValue(TemplateTags.ATTR_GRANTABLE), false));
 		grn.setSourceOwner(attributes.getValue(TemplateTags.ATTR_OWNER));
+		grn.setSourceObjectOwner(attributes.getValue(TemplateTags.ATTR_SOURCE_OBJECT_OWNER));
 		config.addTargetGrantSchema(grn);
 	}
 
@@ -723,7 +724,8 @@ public final class MigrationTemplateHandler extends
 					attributes.getValue(TemplateTags.ATTR_AUTH_TYPE), 
 					getBoolean(attributes.getValue(TemplateTags.ATTR_GRANTABLE), false),
 					attributes.getValue(TemplateTags.ATTR_TARGET_OWNER),
-					attributes.getValue(TemplateTags.ATTR_SOURCE_GRANTOR_NAME));
+					attributes.getValue(TemplateTags.ATTR_SOURCE_GRANTOR_NAME),
+					attributes.getValue(TemplateTags.ATTR_SOURCE_OBJECT_OWNER));
 		} else if (TemplateTags.TAG_TRIGGER.equals(qName)) {
 			config.addExpTriggerCfg(attributes.getValue(TemplateTags.ATTR_NAME));
 		} else if (TemplateTags.TAG_FUNCTION.equals(qName)) {

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateParser.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateParser.java
@@ -933,6 +933,7 @@ public final class MigrationTemplateParser {
 				grNode.setAttribute(TemplateTags.ATTR_GRANTABLE, getBooleanString(sc.isGrantable()));
 				grNode.setAttribute(TemplateTags.ATTR_TARGET_OWNER, sc.getTargetOwner());
 				grNode.setAttribute(TemplateTags.ATTR_SOURCE_GRANTOR_NAME, sc.getSourceGrantorName());
+				grNode.setAttribute(TemplateTags.ATTR_SOURCE_OBJECT_OWNER, sc.getSourceObjectOwner());
 			}
 		}
 		

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
@@ -102,6 +102,7 @@ public final class TemplateTags {
 	public static final String ATTR_REVERSE = "reverse";
 	public static final String ATTR_SCHEMA_NAME = "schema_name";
 	public static final String ATTR_SIZE = "size";
+	public static final String ATTR_SOURCE_OBJECT_OWNER = "source_object_owner";
 	public static final String ATTR_SOURCE_GRANTOR_NAME = "source_grantor_name";
 	public static final String ATTR_SOURCE_OWNER = "source_owner";
 	public static final String ATTR_SPLIT_SCHEMA = "split_schema";

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -2146,6 +2146,7 @@ public final class CUBRIDSchemaFetcher extends
 				grant.setAuthType(rs.getString("auth_type"));
 				grant.setGrantable(rs.getString("is_grantable").equals("NO") ? false : true);
 				grant.setClassOwner(isUserSchema ? rs.getString("owner_name") : null);
+				grant.setSourceObjectOwner(grant.getClassOwner());
 				grant.setDDL(CUBRIDSQLHelper.getInstance(null).getGrantDDL(grant, isUserSchema));
 				grants.add(grant);
 			}

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -846,6 +846,7 @@ public final class OracleSchemaFetcher extends
 				grant.setGrantorName(rs.getString("GRANTOR"));
 				grant.setAuthType(convertPrivilegeOracle2Cubrid(rs.getString("PRIVILEGE")));
 				grant.setGrantable(rs.getString("GRANTABLE").equals("YES") ? true : false);
+				grant.setSourceObjectOwner(grant.getClassOwner());
 				grant.setDDL(CUBRIDSQLHelper.getInstance(null).getGrantDDL(grant, true));
 				schema.addGrant(grant);
 			}
@@ -867,6 +868,7 @@ public final class OracleSchemaFetcher extends
 				grant.setGrantorName(rs.getString("GRANTOR"));
 				grant.setAuthType(rs.getString("PRIVILEGE"));
 				grant.setGrantable(rs.getString("GRANTABLE").equals("YES") ? true : false);
+				grant.setSourceObjectOwner(grant.getClassOwner());
 				grant.setDDL(CUBRIDSQLHelper.getInstance(null).getGrantDDL(grant, true));
 				schema.addGrant(grant);
 			}

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
@@ -31,7 +31,9 @@ package com.cubrid.cubridmigration.ui.wizard.page;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.eclipse.jface.dialogs.PageChangedEvent;
@@ -380,26 +382,33 @@ public class ConfirmationPage extends
 				text.append(Messages.confrimGrant).append(lineSeparator);
 				isCreateFileRepository = false;
 				oldLength = text.length();
+				Set<String> grantFileKeySet = new HashSet<String>();
 				for (Schema targetSchema : migration.getTargetSchemaList()) {
+					String grantSourceObjectOwner = null;
 					for (SourceGrantConfig expGrant : migration.getExpGrantCfg()) {
+						String grantFileKey = expGrant.getOwner() + expGrant.getSourceObjectOwner();
 						if (expGrant.getOwner().equals(targetSchema.getName())
-								&& expGrant.isCreate()) {
+								&& expGrant.isCreate()
+								&& !grantFileKeySet.contains(grantFileKey)) {
 							isCreateFileRepository = true;
-							break;
+							grantFileKeySet.add(grantFileKey);
+							grantSourceObjectOwner = expGrant.getSourceObjectOwner();
 						}
-					}
-					
-					if (isCreateFileRepository) {
-						text.append(tabSeparator).append(tabSeparator);
-						text.append(migration.getTargetGrantFileName(isAddUserSchema ? targetSchema.getName() : conUser));
-						text.append(lineSeparator);
-						isCreateFileRepository = false;
 						
-						if (!isAddUserSchema) {
-							break;
+						if (isCreateFileRepository) {
+							text.append(tabSeparator).append(tabSeparator);
+							text.append(migration.getTargetGrantFileName(
+									isAddUserSchema ? targetSchema.getName() : conUser).get(grantSourceObjectOwner));
+							text.append(lineSeparator);
+							isCreateFileRepository = false;
+							
+							if (!isAddUserSchema) {
+								break;
+							}
 						}
 					}
 				}
+				
 				if (styleRanges != null) {
 					styleRanges.add(new StyleRange(oldLength, text.length() - oldLength,
 							SWTResourceConstents.COLOR_BLUE, null));


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4537

**Purpose**
In CMT, grant information shows the authority received from the other party based on the schema to be transferred. However, this does not allow you to check which user gave the permission.
To conveniently check this, change the grant dump file output format as follows.

**Implementation**
- Separate files by object owner.
- Change the file extension to the object owner name.
ex) [database name]_[source schema name]_grant.[object owner]

**Remarks**
N/A