### PR TITLE
[TOOLS-4538] Change the Oracle column comment search method

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -106,8 +106,10 @@ public final class OracleSchemaFetcher extends
 	//	private static final String OBJECT_TYPE_INDEX = "INDEX";
 
 	//Undefined columns will not be supported.
-	private static final String SQL_GET_COLUMNS = "SELECT COLUMN_NAME, DATA_TYPE, DATA_LENGTH, DATA_PRECISION, DATA_SCALE, NULLABLE, DATA_DEFAULT, CHAR_LENGTH, CHAR_USED, COLUMN_ID "
-			+ "FROM ALL_TAB_COLUMNS T WHERE T.OWNER=? AND T.TABLE_NAME=? " + "ORDER BY COLUMN_ID";
+	private static final String SQL_GET_COLUMNS = "SELECT T.COLUMN_NAME, T.DATA_TYPE, T.DATA_LENGTH, T.DATA_PRECISION, T.DATA_SCALE, T.NULLABLE, T.DATA_DEFAULT, T.CHAR_LENGTH, T.CHAR_USED, T.COLUMN_ID, C.COMMENTS"
+			+ " FROM ALL_TAB_COLUMNS T, ALL_COL_COMMENTS C"
+			+ " WHERE T.OWNER=? AND T.TABLE_NAME=? AND C.COLUMN_NAME=T.COLUMN_NAME AND T.TABLE_NAME=C.TABLE_NAME"
+			+ " ORDER BY COLUMN_ID";
 
 	private static final String SQL_GET_INDEX_COLUMNS = "SELECT A.COLUMN_NAME, A.DESCEND, B.COLUMN_EXPRESSION "
 			+ "FROM ALL_IND_COLUMNS A LEFT JOIN ALL_IND_EXPRESSIONS B "
@@ -161,9 +163,6 @@ public final class OracleSchemaFetcher extends
 	
 	private static final String SQL_GET_TABLE_COMMENT = "SELECT COMMENTS FROM ALL_TAB_COMMENTS WHERE OWNER=? AND "
 			+ "TABLE_NAME=?";
-	
-	private static final String SQL_GET_COLUMN_COMMENT = "SELECT COMMENTS FROM ALL_COL_COMMENTS WHERE OWNER=? AND "
-			+ "TABLE_NAME=? AND COLUMN_NAME=?";
 	
 	private static final String SQL_SHOW_GRANT_TABLE = "SELECT P.GRANTEE, P.OWNER, P.TABLE_NAME, P.GRANTOR, P.PRIVILEGE, P.GRANTABLE" 
 			+ " FROM USER_TAB_PRIVS P, ALL_TABLES T"
@@ -482,8 +481,8 @@ public final class OracleSchemaFetcher extends
 			stmt.setString(1, schema.getName());
 			stmt.setString(2, table.getName());
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("[SQL]" + SQL_GET_COLUMNS + ", 1=" + table.getName() + ", 2="
-						+ schema.getName() + ", 3=" + table.getName());
+				LOG.debug("[SQL]" + SQL_GET_COLUMNS + ", 1=" + schema.getName() + ", 2="
+						+ table.getName());
 			}
 			OracleDataTypeHelper dtHelper = OracleDataTypeHelper.getInstance(null);
 			rs = stmt.executeQuery();
@@ -533,8 +532,7 @@ public final class OracleSchemaFetcher extends
 
 					String shownDataType = dtHelper.getShownDataType(column);
 					column.setShownDataType(shownDataType);
-					
-					column.setComment(getColumnComment(conn, schema.getName(), table.getName(), column.getName()));
+					column.setComment(rs.getString("COMMENTS"));
 
 					table.addColumn(column);
 				} catch (Exception ex) {
@@ -1216,44 +1214,6 @@ public final class OracleSchemaFetcher extends
 		} finally {
 			Closer.close(rs);
 			Closer.close(pstmt);
-		}
-	}
-	
-	/**
-	 * get column comment
-	 * 
-	 * @param conn
-	 * @param objectName
-	 * @param schemaName
-	 * @return comment
-	 */
-	private String getColumnComment(Connection conn, String schemaName, String tableName, String columnName) {
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-		try {
-			pstmt = conn.prepareStatement(SQL_GET_COLUMN_COMMENT);
-			pstmt.setString(1, schemaName);
-			pstmt.setString(2, tableName);
-			pstmt.setString(3, columnName);
-			
-			rs = pstmt.executeQuery();
-			
-			String comment = "";
-			while (rs.next()) {
-				comment = rs.getString("COMMENTS");
-			}
-			
-			if (comment != null) {
-				comment = commentEditor(comment);
-			}
-			
-			return comment;
-		} catch (Exception e) {
-			e.printStackTrace();
-			return null;
-		} finally {
-			Closer.close(pstmt);
-			Closer.close(rs);
 		}
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4538

**Purpose**
The data is searched by executing a comment search query for the column's comments every time.
Shorten the time to retrieve meta information by modifying the query so that comment information can also be retrieved when querying table column information.

**Implementation**
- Modify table column select query and creation method.
- Delete column comment select query and creation method.

**Remarks**
N/A