### PR TITLE
[TOOLS-4551] auto_increment is not created in CUBRID 11.2 or later version

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -1011,6 +1011,7 @@ public final class CUBRIDSchemaFetcher extends
 			rs = stmt.executeQuery(sql);
 
 			while (rs.next()) {
+				String ownerName = rs.getString("owner.name");
 				String tableName = rs.getString("class_name");
 				if (tableName == null) {
 					continue;
@@ -1019,7 +1020,7 @@ public final class CUBRIDSchemaFetcher extends
 				String currentVal = rs.getString("current_val");
 				String attrName = rs.getString("att_name");
 
-				Table table = tables.get(tableName);
+				Table table = tables.get(ownerName + "." + tableName);
 				if (table == null) {
 					continue;
 				}


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4551

**Purpose**
When migrating from CMT to CUBRID 11.2 or later, auto_increment is missing in the table creation SQL.

**Implementation**
Modify to compare user name and table name at the same time when migrating from CUBRID 11.2 or later.

**Remarks**
N/A