### PR TITLE
[TOOLS-4556] Oracle 'SYSDATE' type conversion error

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
@@ -119,14 +119,7 @@ public class CUBRIDSQLHelper extends SQLHelper {
             bf.append(" SHARED ").append(defaultv);
         } else if ((column.getDataType().equals("datetime")
                         || column.getDataType().equals("timestamp"))
-                && ("CURRENT_TIMESTAMP".equalsIgnoreCase(value)
-                        || "SYS_TIMESTAMP".equalsIgnoreCase(value)
-                        || "SYSTIMESTAMP".equalsIgnoreCase(value)
-                        || "SYS_DATETIME".equalsIgnoreCase(value)
-                        || "SYSDATETIME".equalsIgnoreCase(value)
-                        || "CURRENT_DATETIME".equalsIgnoreCase(value)
-                        || "CURRENT_DATETIME()".equalsIgnoreCase(value)
-                        || "NOW()".equalsIgnoreCase(value))) {
+                && CUBRIDTimeUtil.validateDateTimeFunction(value)) {
             bf.append(" DEFAULT ").append(value);
         } else {
             String defaultv = column.getDefaultValue();

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDTimeUtil.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDTimeUtil.java
@@ -161,6 +161,67 @@ public class CUBRIDTimeUtil { // NOPMD
         "''MM-dd-yyyy HH:mm:ss''"
     };
 
+    private static String[] dateTimeFunctions = {
+        "ADDDATE",
+        "DATE_ADD",
+        "ADDTIME",
+        "ADD_MONTHS",
+        "CURDATE",
+        "CURRENT_DATE",
+        "CURRENT_DATETIME",
+        "NOW",
+        "CURTIME",
+        "CURRENT_TIME",
+        "CURRENT_TIMESTAMP",
+        "LOCALTIME",
+        "LOCALTIMESTAMP",
+        "DATE",
+        "DATEDIFF",
+        "DATE_SUB",
+        "SUBDATE",
+        "DAY",
+        "DAYOFMONTH",
+        "DAYOFWEEK",
+        "DAYOFYEAR",
+        "EXTRACT",
+        "FROM_DAYS",
+        "FROM_TZ",
+        "FROM_UNIXTIME",
+        "HOUR",
+        "LAST_DAY",
+        "MAKEDATE",
+        "MAKETIME",
+        "MINUTE",
+        "MONTH",
+        "MONTHS_BETWEEN",
+        "NEW_TIME",
+        "QUARTER",
+        "ROUND",
+        "SEC_TO_TIME",
+        "SECOND",
+        "SYS_DATE",
+        "SYSDATE",
+        "SYS_DATETIME",
+        "SYSDATETIME",
+        "SYS_TIME",
+        "SYSTIME",
+        "SYS_TIMESTAMP",
+        "SYSTIMESTAMP",
+        "TIME",
+        "TIME_TO_SEC",
+        "TIMEDIFF",
+        "TIMESTAMP",
+        "TO_DAYS",
+        "TRUNC",
+        "TZ_OFFSET",
+        "UNIX_TIMESTAMP",
+        "UTC_DATE",
+        "UTC_TIME",
+        "WEEK",
+        "WEEKDAY",
+        "YEAR"
+    };
+
     /**
      * Format date into yyyy-MM-dd with default time zone and default format
      *
@@ -517,5 +578,23 @@ public class CUBRIDTimeUtil { // NOPMD
         formatter.parse(datestring, pp);
 
         return pp.getIndex() == datestring.length();
+    }
+
+    /**
+     * validate of date/time functions supported by CUBRID
+     *
+     * @param dateTime date/time function that requires verification
+     * @return boolean true: CUBRID support; false: CUBRID not support
+     */
+    public static boolean validateDateTimeFunction(String dateTime) {
+        String upperDateTime = dateTime.toUpperCase(Locale.US);
+
+        for (String function : dateTimeFunctions) {
+            if (upperDateTime.startsWith(function)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -59,6 +59,18 @@ import org.apache.commons.lang.StringUtils;
  */
 public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
 
+    private static final String[] ORACLE_DATETIME_FUNCTION = {
+        "CURDATE",
+        "CURRENT_DATE",
+        "CURTIME",
+        "CURRENT_TIMESTAMP",
+        "DBTIMEZONE",
+        "LOCALTIMESTAMP",
+        "SESSIONTIMEZONE",
+        "SYSDATE",
+        "SYSTIMESTAMP"
+    };
+
     public Oracle2CUBRIDTranformHelper(
             AbstractDataTypeMappingHelper dataTypeMapping, ToCUBRIDDataConverterFacade cf) {
         super(dataTypeMapping, cf);
@@ -306,8 +318,8 @@ public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
         }
 
         if ((dataType.indexOf("TIMESTAMP") > -1 || "DATE".equalsIgnoreCase(dataType))
-                && defaultValue.toLowerCase(Locale.US).startsWith("sysdate")) {
-            cubridColumn.setDefaultValue("CURRENT_TIMESTAMP");
+                && isDefaultDateTimeFunction(defaultValue)) {
+            cubridColumn.setDefaultValue(defaultValue);
             return;
         }
 
@@ -384,6 +396,24 @@ public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
 
         for (String function : functions) {
             if (lowerCaseDefaultValue.startsWith(function)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Oracle date/time function validation
+     *
+     * @param defaultValue
+     * @return true: Oracle support; false: Oracle not support
+     */
+    private boolean isDefaultDateTimeFunction(String defaultValue) {
+        String upperCaseDefaultValue = defaultValue.toUpperCase(Locale.US);
+
+        for (String function : ORACLE_DATETIME_FUNCTION) {
+            if (upperCaseDefaultValue.startsWith(function)) {
                 return true;
             }
         }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4556

**Purpose**
Corrects error converting Oracle SQL to incorrect CUBRID SQL when date/time function is next to DEFAULT

**Implementation**
- CUBRID
Validates date/time functions supported in version 11.3

- ORACLE
Validates the remaining functions, except for functions that require parameters or calculate dates.

**Remark**
N/A