### PR TITLE
[TOOLS-4559] When exporting to local xls files, an error occurs if the data is large.

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/event/MigrationXLSNoSupportEvent.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/event/MigrationXLSNoSupportEvent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation. All rights reserved by Search Solution.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.core.engine.event;
+
+public class MigrationXLSNoSupportEvent extends MigrationEvent {
+
+    private String tableName = "";
+    private int rowIndex = 0;
+    private int columIndex = 0;
+    private String errMsg = "";
+
+    public MigrationXLSNoSupportEvent(
+            String tableName, int rowIndex, int columindex, String errMsg) {
+        this.tableName = tableName;
+        this.rowIndex = rowIndex;
+        this.columIndex = columindex;
+        this.errMsg = errMsg;
+    }
+
+    /**
+     * Event to string.
+     *
+     * @return event string
+     */
+    public String toString() {
+        return "Row Index : "
+                + rowIndex
+                + " Colum Index : "
+                + columIndex
+                + " in "
+                + tableName
+                + "["
+                + errMsg
+                + "]";
+    }
+
+    /**
+     * The event's importance level
+     *
+     * @return level
+     */
+    public int getLevel() {
+        return 1;
+    }
+}

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/DefaultMigrationReporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/DefaultMigrationReporter.java
@@ -48,6 +48,7 @@ import com.cubrid.cubridmigration.core.engine.event.MigrationEvent;
 import com.cubrid.cubridmigration.core.engine.event.MigrationFinishedEvent;
 import com.cubrid.cubridmigration.core.engine.event.MigrationNoSupportEvent;
 import com.cubrid.cubridmigration.core.engine.event.MigrationStartEvent;
+import com.cubrid.cubridmigration.core.engine.event.MigrationXLSNoSupportEvent;
 import com.cubrid.cubridmigration.core.engine.event.StartExpTableEvent;
 import com.cubrid.cubridmigration.core.engine.template.MigrationTemplateParser;
 import com.cubrid.cubridmigration.cubrid.CUBRIDTimeUtil;
@@ -213,6 +214,11 @@ public abstract class DefaultMigrationReporter implements IMigrationReporter {
                 return;
             }
             pwNonsupport.append(dbObject.getDDL());
+            pwNonsupport.append("\n");
+            pwNonsupport.flush();
+        } else if (event instanceof MigrationXLSNoSupportEvent) {
+            MigrationXLSNoSupportEvent ev = (MigrationXLSNoSupportEvent) event;
+            pwNonsupport.append(ev.toString());
             pwNonsupport.append("\n");
             pwNonsupport.flush();
         } else if (event instanceof MigrationFinishedEvent) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4559

Purpose
if the data is large (greater the 32767, 'xls file' is not created, and can't know why it wasn't created.

Implementation
If the data is large, it is displayed as blank and a list of errors is displayed in the 'no support' tab.

Remark 
Backport https://github.com/CUBRID/cubrid-migration/pull/142