### PR TITLE
[TOOLS-4557] Oracle 'CAST' setting missing error

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -380,7 +380,7 @@ public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
         String lowerCaseDefaultValue = defaultValue.toLowerCase(Locale.US);
 
         // Function names should be lowerCases
-        String[] functions = {"to_char", "to_date"};
+        String[] functions = {"to_char", "to_date", "cast"};
 
         for (String function : functions) {
             if (lowerCaseDefaultValue.startsWith(function)) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4557

**Purpose**
If CAST exists after DEFAULT in Oracle SQL, corrects errors that result in missing strings after DEFAULT.

**Implementation**
N/A

**Remark**
Backport - #141 