### PR TITLE
[TOOLS-4561] Proceed with migration after ignoring Oracle lob column error

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/event/LobMigrationErrorEvent.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/event/LobMigrationErrorEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation. All rights reserved by Search Solution.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.core.engine.event;
+
+/**
+ * Lob error forwarding
+ *
+ * @author Dongmin Kim
+ */
+public class LobMigrationErrorEvent implements IMigrationErrorEvent {
+
+    private final Throwable error;
+
+    public LobMigrationErrorEvent(Throwable ex) {
+        this.error = ex;
+    }
+
+    /**
+     * To String
+     *
+     * @return String
+     */
+    public String toString() {
+        error.printStackTrace();
+        return error.getMessage();
+    }
+
+    /**
+     * Retrieve the error
+     *
+     * @return Throwable
+     */
+    public Throwable getError() {
+        return error;
+    }
+}

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/exporter/impl/JDBCExporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/exporter/impl/JDBCExporter.java
@@ -42,6 +42,7 @@ import com.cubrid.cubridmigration.core.engine.RecordExportedListener;
 import com.cubrid.cubridmigration.core.engine.ThreadUtils;
 import com.cubrid.cubridmigration.core.engine.config.SourceColumnConfig;
 import com.cubrid.cubridmigration.core.engine.config.SourceTableConfig;
+import com.cubrid.cubridmigration.core.engine.event.LobMigrationErrorEvent;
 import com.cubrid.cubridmigration.core.engine.event.MigrationErrorEvent;
 import com.cubrid.cubridmigration.core.engine.exception.NormalMigrationException;
 import com.cubrid.cubridmigration.core.engine.exporter.MigrationExporter;
@@ -150,6 +151,22 @@ public class JDBCExporter extends MigrationExporter {
                 SourceColumnConfig cc = expCols.get(ci - 1);
                 Column sCol = st.getColumnByName(cc.getName());
                 Object value = srcDBExportHelper.getJdbcObject(rs, sCol);
+
+                if (value instanceof LobMigrationErrorEvent) {
+                    LobMigrationErrorEvent LobError = (LobMigrationErrorEvent) value;
+                    String lobWarning =
+                            "[LOB WARNING]  table: "
+                                    + st.getName()
+                                    + "  column: "
+                                    + (sCol != null ? sCol.getName() : "")
+                                    + "  pk:"
+                                    + getPkValues(st, record);
+
+                    LOG.warn(lobWarning, LobError.getError());
+                    eventHandler.handleEvent(
+                            new MigrationErrorEvent(
+                                    new NormalMigrationException(lobWarning, LobError.getError())));
+                }
                 record.addColumnValue(sCol, value);
             }
             return record;


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4561

**Purpose**
Even if an error occurs in a column with a lob during Oracle table migration, it is ignored and the operation continues.
The table, column name, and pk value where the error occurred are recorded in the log.

**Implementation**
N/A

**Remarks**
Backport - #151 