### PR TITLE
[TOOLS-4566] Fix error for column date/time type default

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDTimeUtil.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDTimeUtil.java
@@ -587,6 +587,10 @@ public class CUBRIDTimeUtil { // NOPMD
      * @return boolean true: CUBRID support; false: CUBRID not support
      */
     public static boolean validateDateTimeFunction(String dateTime) {
+        if (dateTime == null) {
+            return false;
+        }
+
         String upperDateTime = dateTime.toUpperCase(Locale.US);
 
         for (String function : dateTimeFunctions) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4566

**Purpose**
'NullpointException" error occurs when the default setting for column date/time is null.

**Implementation**
Add null check to date/time function verification method.

Remarks
Backport - #159 