### PR TITLE
[TOOLS-4563] Automatically change the trigger action definition when creating a foreign key query if the column in NOT NULL

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/FK.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/FK.java
@@ -58,12 +58,11 @@ public class FK extends DBObject {
     private String name;
     private String ddl;
 
-    // private int deferability;
     private int deleteRule;
     private int updateRule;
+    private boolean changedReferentialAction = false;
 
     private String referencedTableName;
-    // private String onCacheObject;
 
     private final Map<String, String> col2RefMapping = new TreeMap<String, String>();
 
@@ -246,6 +245,14 @@ public class FK extends DBObject {
 
     public Map<String, String> getColumns() {
         return new TreeMap<String, String>(col2RefMapping);
+    }
+
+    public void setChangedReferentialAction(boolean changed) {
+        this.changedReferentialAction = changed;
+    }
+
+    public boolean isChangedReferentialAction() {
+        return this.changedReferentialAction;
     }
 
     /**

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/event/MigrationFKWarningEvent.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/event/MigrationFKWarningEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Search Solution Corporation. All rights reserved by Search Solution.
+ * Copyright (C) 2016 CUBRID Corporation. All rights reserved by Search Solution.
  *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
@@ -27,41 +27,49 @@
  * OF SUCH DAMAGE.
  *
  */
-package com.cubrid.cubridmigration.core.engine.task.exp;
 
+package com.cubrid.cubridmigration.core.engine.event;
+
+import com.cubrid.cubridmigration.core.dbobject.DBObject;
 import com.cubrid.cubridmigration.core.dbobject.FK;
-import com.cubrid.cubridmigration.core.dbobject.Table;
-import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
-import com.cubrid.cubridmigration.core.engine.config.SourceTableConfig;
-import com.cubrid.cubridmigration.core.engine.event.MigrationFKWarningEvent;
-import com.cubrid.cubridmigration.core.engine.task.ExportTask;
 
 /**
- * FKExportTask Description
+ * Foreign key option setting alert event
  *
- * @author Kevin Cao
- * @version 1.0 - 2011-8-10 created by Kevin Cao
+ * @author Dongmin Kim
  */
-public class FKExportTask extends ExportTask {
-    protected MigrationConfiguration config;
-    protected SourceTableConfig sourceTableConfig;
+public class MigrationFKWarningEvent extends MigrationEvent {
 
-    public FKExportTask(MigrationConfiguration config, SourceTableConfig tf) {
-        this.config = config;
-        this.sourceTableConfig = tf;
+    private final DBObject dbObject;
+
+    public DBObject getDbObject() {
+        return dbObject;
     }
 
-    /** Execute export operation */
-    protected void executeExportTask() {
-        Table tt = config.getTargetTableSchema(sourceTableConfig.getTarget());
-        for (FK fk : tt.getFks()) {
-            importTaskExecutor.execute((Runnable) taskFactory.createImportFKTask(fk));
+    public MigrationFKWarningEvent(DBObject dbObject) {
+        this.dbObject = dbObject;
+    }
+
+    /**
+     * Event to string.
+     *
+     * @return event string
+     */
+    public String toString() {
+        if (dbObject == null) {
+            return "NULL";
         }
 
-        for (FK fk : tt.getFks()) {
-            if (fk.isChangedReferentialAction()) {
-                eventHandler.handleEvent(new MigrationFKWarningEvent(fk));
-            }
-        }
+        FK fk = (FK) dbObject;
+        return "[FK_WARNING] table: "
+                + fk.getTable().getName()
+                + "  fk: "
+                + fk.getName()
+                + "  Change option(SET NULL -> RESTRICT)";
+    }
+
+    @Override
+    public int getLevel() {
+        return 0;
     }
 }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
@@ -45,7 +45,9 @@ import com.cubrid.cubridmigration.core.dbobject.Table;
 import com.cubrid.cubridmigration.core.dbobject.View;
 import com.cubrid.cubridmigration.core.sql.SQLHelper;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
@@ -61,10 +63,18 @@ public class CUBRIDSQLHelper extends SQLHelper {
 
     private static final Logger LOG = LogUtil.getLogger(CUBRIDSQLHelper.class);
 
+    private static enum ReferentialAction {
+        CASCADE,
+        RESTRICT,
+        SET_NULL,
+        NO_ACTION
+    }
+
     private static final String[] UPDATE_RULE =
             new String[] {"CASCADE", "RESTRICT", "SET NULL", "NO ACTION"};
     private static final String[] DELETE_RULE =
             new String[] {"CASCADE", "RESTRICT", "SET NULL", "NO ACTION"};
+
     private static final String NEWLINE = "\n";
     private static final String HINT = "/*+ NO_STATS */";
     private static final String END_LINE_CHAR = ";";
@@ -177,6 +187,35 @@ public class CUBRIDSQLHelper extends SQLHelper {
     }
 
     /**
+     * If the referential action is 'SET NULL', check the column and change it to 'RESTRICT' if it
+     * is 'NOT NULL'
+     *
+     * @param referentialAction int
+     * @param fk FK
+     * @return int
+     */
+    private int changeReferentialAction(int referentialAction, FK fk) {
+        if (referentialAction != ReferentialAction.SET_NULL.ordinal()) {
+            return referentialAction;
+        }
+
+        List<String> fkColumnNames = fk.getColumnNames();
+        Map<String, Column> tableColumnMap = new HashMap<String, Column>();
+        for (Column column : fk.getTable().getColumns()) {
+            tableColumnMap.put(column.getName(), column);
+        }
+
+        for (String columnName : fkColumnNames) {
+            if (!tableColumnMap.get(columnName).isNullable()) {
+                fk.setChangedReferentialAction(true);
+                return ReferentialAction.RESTRICT.ordinal();
+            }
+        }
+
+        return referentialAction;
+    }
+
+    /**
      * DDL of FK in creating and altering a schema
      *
      * @param fk FK
@@ -222,8 +261,10 @@ public class CUBRIDSQLHelper extends SQLHelper {
         }
 
         bf.append(")");
-        bf.append(" ON DELETE ").append(DELETE_RULE[fk.getDeleteRule()]);
-        bf.append(" ON UPDATE ").append(UPDATE_RULE[fk.getUpdateRule()]);
+        bf.append(" ON DELETE ")
+                .append(DELETE_RULE[changeReferentialAction(fk.getDeleteRule(), fk)]);
+        bf.append(" ON UPDATE ")
+                .append(UPDATE_RULE[changeReferentialAction(fk.getUpdateRule(), fk)]);
         return bf.toString();
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4563

**Purpose**
When generating a foreign key in a column with NOT NULL set, automatically change SET NULL to RESTRICT if SET NULL is present as the foreign key option.

**Implementation**
N/A

**Remarks**
Backport - #158 