### PR TITLE
[TOOLS-4567] Add connection user name on page 2 of the Migration Wizard

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/DBLabelProvider.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/DBLabelProvider.java
@@ -84,12 +84,14 @@ public class DBLabelProvider implements ITableLabelProvider {
             case 2:
                 return info.getDbName();
             case 3:
-                return info.getHostIp();
+                return info.getUser();
             case 4:
-                return info.getPort() + "";
+                return info.getHostIp();
             case 5:
-                return DatabaseType.getDatabaseTypeByID(info.getDatabaseTypeID()).getName();
+                return info.getPort() + "";
             case 6:
+                return DatabaseType.getDatabaseTypeByID(info.getDatabaseTypeID()).getName();
+            case 7:
                 return info.getCharacterEncoding();
             default:
                 return null;

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCConnectionMgrView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCConnectionMgrView.java
@@ -227,12 +227,13 @@ public class JDBCConnectionMgrView {
                     "",
                     Messages.sourceDBPageTableConnNm,
                     Messages.sourceDBPageTableDbNm,
+                    Messages.sourceDBPageTableUserNm,
                     Messages.sourceDBPageTableIP,
                     Messages.sourceDBPageTablePort,
                     Messages.sourceDBPageTableDbType,
                     Messages.sourceDBPageTableCharset
                 });
-        tvBuilder.setColumnWidths(new int[] {28, 150, 120, 110, 85, 121, 110});
+        tvBuilder.setColumnWidths(new int[] {28, 150, 120, 110, 110, 85, 121, 110});
         tvBuilder.setContentProvider(
                 new DBContentProvider(MigrationWizard.getSupportedSrcDBTypes()));
         tvBuilder.setLabelProvider(new DBLabelProvider());

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages.java
@@ -712,6 +712,7 @@ public class Messages extends NLS {
     public static String sourceDBPageTableCharset;
     public static String sourceDBPageTableConnNm;
     public static String sourceDBPageTableDbNm;
+    public static String sourceDBPageTableUserNm;
     public static String sourceDBPageTableDbType;
     public static String sourceDBPageTableIP;
     public static String sourceDBPageTablePort;

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages.properties
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages.properties
@@ -672,6 +672,7 @@ sourceDBPageErrNoSetXMLFileCharset=Please select a charset of MySQL XML dump fil
 sourceDBPageTableCharset=Charset
 sourceDBPageTableConnNm=Connection name
 sourceDBPageTableDbNm=Database name
+sourceDBPageTableUserNm=User name
 sourceDBPageTableDbType=Database type
 sourceDBPageTableIP=Host IP
 sourceDBPageTablePort=Host port

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages_ko_KR.properties
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages_ko_KR.properties
@@ -667,6 +667,7 @@ sourceDBPageErrNoSetXMLFileCharset=xml \uD30C\uC77C\uC758 \uBB38\uC790\uC9D1\uD5
 sourceDBPageTableCharset=\uBB38\uC790 \uC9D1\uD569
 sourceDBPageTableConnNm=\uC5F0\uACB0 \uC774\uB984
 sourceDBPageTableDbNm=\uB370\uC774\uD130\uBCA0\uC774\uC2A4 \uC774\uB984
+sourceDBPageTableUserNm=\uC0AC\uC6A9\uC790 \uC774\uB984
 sourceDBPageTableDbType=\uB370\uC774\uD130\uBCA0\uC774\uC2A4 \uC720\uD615
 sourceDBPageTableIP=\uD638\uC2A4\uD2B8 \uC8FC\uC18C
 sourceDBPageTablePort=\uD638\uC2A4\uD2B8 \uD3EC\uD2B8


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4567

**Purpose**
Add a column to display the connection user name on page 2 of the Migration Wizard.

**Implementation**
N/A

**Remarks**
Backport - #162 