### PR TITLE
[TOOLS-4583] The migration setting node is duplicated in the preference

### DIFF
--- a/com.cubrid.cubridmigration.plugin/plugin.xml
+++ b/com.cubrid.cubridmigration.plugin/plugin.xml
@@ -105,53 +105,5 @@
                tooltip="%ttShowHistory">
          </command>
       </menuContribution>
-   </extension>
-
-   <extension
-         point="org.eclipse.ui.preferencePages">
-      <page
-            class="com.cubrid.cubridmigration.ui.common.composite.MigrationConfigPage"
-            id="com.cubrid.cubridmigration.ui.common.composite.MigrationConfigPage"
-            name="%prefTitleMigration">
-      </page>
-      <page
-            category="com.cubrid.cubridmigration.ui.common.composite.MigrationConfigPage"
-            class="com.cubrid.cubridmigration.ui.common.composite.MySQLToCUBRIDTypeMapPage"
-            id="com.cubrid.cubridmigration.ui.common.composite.MySQLToCUBRIDTypeMapPage"
-            name="MySQL&gt;&gt;CUBRID">
-      </page>
-      <page
-            category="com.cubrid.cubridmigration.ui.common.composite.MySQLToCUBRIDTypeMapPage"
-            class="com.cubrid.cubridmigration.ui.common.composite.MySQLToCUBRIDParameterPage"
-            id="com.cubrid.cubridmigration.ui.common.composite.MySQLToCUBRIDParameterPage"
-            name="%OtherSettings">
-      </page>
-      <page
-            category="com.cubrid.cubridmigration.ui.common.composite.MigrationConfigPage"
-            class="com.cubrid.cubridmigration.ui.common.composite.CUBRID2CUBRIDTypeMapPage"
-            id="com.cubrid.cubridmigration.ui.common.composite.CUBRID2CUBRIDTypeMapPage"
-            name="CUBRID&gt;&gt;CUBRID">
-      </page>
-      <page
-            category="com.cubrid.cubridmigration.ui.common.composite.MigrationConfigPage"
-            class="com.cubrid.cubridmigration.ui.common.composite.Oracle2CUBRIDTypeMapPage"
-            id="com.cubrid.cubridmigration.ui.common.composite.Oracle2CUBRIDTypeMapPage"
-            name="Oracle&gt;&gt;CUBRID">
-      </page>
-      <page
-            category="com.cubrid.cubridmigration.ui.common.composite.MigrationConfigPage"
-            class="com.cubrid.cubridmigration.ui.common.composite.SQLServer2CUBRIDTypeMapPage"
-            id="com.cubrid.cubridmigration.ui.common.composite.SQLServer2CUBRIDTypeMapPage"
-            name="MSSQL&gt;&gt;CUBRID">
-      </page>
-      <!--
-      <page
-            category="com.cubrid.cubridmigration.ui.common.composite.MigrationConfigPage"
-            class="com.cubrid.cubridmigration.ui.preference.JDBCDriverManagePage"
-            id="com.cubrid.cubridmigration.ui.preference.JDBCDriverManagePage"
-            name="%JDBCDrivers">
-      </page>
-      -->
-   </extension>
-   
+   </extension> 
 </plugin>


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4583

**Purpose**
In CMT preferences, migration setting node is displayed in duplicate. Fix that only one can be displayed.

**Implementation**
N/A

**Remarks**
N/A