### PR TITLE
[TOOLS-4584] Fixed bug where release version was missing when building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,7 +71,7 @@ function update_build_version ()
   echo "releaseVersion=" $VERSION >> $RELEASE_VERSION_FILE_PATH
 
   RELEASE_VERSION=$VERSION.$COMMIT_NUMBER
-  sed -i '/buildVersionId/d' $RELEASE_VERSION_FILE_PATH
+  sed -i "/buildVersionId/d" $RELEASE_VERSION_FILE_PATH
   echo "buildVersionId="$RELEASE_VERSION >> $RELEASE_VERSION_FILE_PATH
   
   echo "VERSION=" $VERSION

--- a/build.sh
+++ b/build.sh
@@ -67,12 +67,15 @@ function update_build_version ()
   fi
 
   VERSION=$(cat ${VERSION_FILE_PATH} | grep version | cut -d '=' -f2)
-  echo "VERSION=" $VERSION
-  echo "COMMIT_NUMBER=" $COMMIT_NUMBER
+  sed -i "/releaseVersion/d" $RELEASE_VERSION_FILE_PATH
+  echo "releaseVersion=" $VERSION >> $RELEASE_VERSION_FILE_PATH
 
   RELEASE_VERSION=$VERSION.$COMMIT_NUMBER
   sed -i '/buildVersionId/d' $RELEASE_VERSION_FILE_PATH
   echo "buildVersionId="$RELEASE_VERSION >> $RELEASE_VERSION_FILE_PATH
+  
+  echo "VERSION=" $VERSION
+  echo "COMMIT_NUMBER=" $COMMIT_NUMBER
   echo "RELEASE_VERSION=" $RELEASE_VERSION
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4584

**Purpose**
Fixes a bug where the release version is not applied when building CMT.

**Implementation**
N/A

**Remarks**
N/A