### PR TITLE
[TOOLS-4585] Resolving Issues with LOB Migration through LOB Directory Structure Modification

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
@@ -331,25 +331,6 @@ public class MigrationDirAndFilesManager implements ICanDispose {
         }
     }
 
-    //	public String getDataFile() {
-    //		if (config.targetIsFile()
-    //				&& !config.isOneTableOneFile()) {
-    //		}
-    //		if (config.targetIsOffline()) {
-    //
-    //		} else if (config.targetIsDBDump()) {
-    //
-    //		} else if (config.targetIsCSV()) {
-    //
-    //		} else if (config.targetIsSQL()) {
-    //
-    //		} else if (config.targetIsXLS()) {
-    //
-    //		}
-    //
-    //		return "";
-    //	}
-
     /** Dispose, remove useless directories. */
     public void dispose() {
         // Remove privateTempDir

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -80,6 +81,51 @@ public class MigrationDirAndFilesManager implements ICanDispose {
         }
     }
 
+    /**
+     * Saves the parent, child depth, and number of files of the LOB directory
+     *
+     * @author Dongmin Kim
+     */
+    static class LobDirPath {
+        private static final int LOB_DIR_COUNT_MAX = 65000;
+        private static final int LOB_FILE_COUNT_MAX = 100000;
+
+        private long parentPath;
+        private int childPath;
+        private int lobFileCount;
+
+        private LobDirPath() {
+            this.parentPath = 1;
+            this.childPath = 1;
+            this.lobFileCount = 1;
+        }
+
+        /*
+         * Returns the directory depth by combining the parent and child.
+         * Example) 1/1, 34/1569, 129/64968
+         */
+        public String getLobDirDepth(String schemaName, String tableName) {
+    		checkLobFileCount();
+            checkChildDirCount();
+            return parentPath + File.separator + childPath;
+        }
+
+        private void checkChildDirCount() {
+            if (childPath > LOB_DIR_COUNT_MAX) {
+                parentPath++;
+                childPath = 1;
+            }
+        }
+
+        private void checkLobFileCount() {
+            if (lobFileCount > LOB_FILE_COUNT_MAX) {
+                childPath++;
+                lobFileCount = 1;
+            }
+            lobFileCount++;
+        }
+    }
+
     private final MigrationConfiguration config;
 
     private String privateTempDir = null;
@@ -88,6 +134,7 @@ public class MigrationDirAndFilesManager implements ICanDispose {
     private String lobFilesDir = null;
 
     private final Map<String, DataFileInfo> dataFiles = new HashMap<String, DataFileInfo>();
+    private Map<String, LobDirPath> lobDirPaths = new ConcurrentHashMap<String, LobDirPath>();
 
     public MigrationDirAndFilesManager(MigrationConfiguration config) {
         this.config = config;
@@ -145,6 +192,21 @@ public class MigrationDirAndFilesManager implements ICanDispose {
         if (!lobDir.exists() && !lobDir.mkdirs()) {
             throw new BreakMigrationException("Invalid path:" + lobDir);
         }
+    }
+
+    /**
+     * Information needed to create an isolated LOB directory path
+     *
+     * @param schemaName String
+     * @param tableName String
+     * @return LOB directory object
+     */
+    public String getLobDirDepth(String schemaName, String tableName) {
+        String key = schemaName + tableName;
+        if (!lobDirPaths.containsKey(key)) {
+            lobDirPaths.put(key, new LobDirPath());
+        }
+        return lobDirPaths.get(key).getLobDirDepth(schemaName, tableName);
     }
 
     /**

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
@@ -105,7 +105,7 @@ public class MigrationDirAndFilesManager implements ICanDispose {
          * Example) 1/1, 34/1569, 129/64968
          */
         public String getLobDirDepth(String schemaName, String tableName) {
-    		checkLobFileCount();
+            checkLobFileCount();
             checkChildDirCount();
             return parentPath + File.separator + childPath;
         }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
@@ -104,7 +104,7 @@ public class MigrationDirAndFilesManager implements ICanDispose {
          * Returns the directory depth by combining the parent and child.
          * Example) 1/1, 34/1569, 129/64968
          */
-        public String getLobDirDepth(String schemaName, String tableName) {
+        public String getLobDirDepth() {
             checkLobFileCount();
             checkChildDirCount();
             return parentPath + File.separator + childPath;
@@ -206,7 +206,7 @@ public class MigrationDirAndFilesManager implements ICanDispose {
         if (!lobDirPaths.containsKey(key)) {
             lobDirPaths.put(key, new LobDirPath());
         }
-        return lobDirPaths.get(key).getLobDirDepth(schemaName, tableName);
+        return lobDirPaths.get(key).getLobDirDepth();
     }
 
     /**

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/ErrorRecords2SQLFileWriter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/ErrorRecords2SQLFileWriter.java
@@ -74,6 +74,7 @@ public class ErrorRecords2SQLFileWriter {
                 new Data2StrTranslator(
                         mrManager.getDirAndFilesMgr().getErrorFilesDir(),
                         mrManager.getConfig(),
+                        mrManager.getDirAndFilesMgr(),
                         MigrationConfiguration.DEST_SQL);
     }
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -128,6 +128,7 @@ public class LoadFileImporter extends OfflineImporter {
                 new Data2StrTranslator(
                         mrManager.getDirAndFilesMgr().getMergeFilesDir(),
                         config,
+                        mrManager.getDirAndFilesMgr(),
                         config.getDestType());
     }
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -563,17 +563,6 @@ public abstract class OfflineImporter extends Importer {
         };
     }
 
-    //	/**
-    //	 * Retrieve the CM server object.
-    //	 *
-    //	 * @return current CM server
-    //	 */
-    //	protected CMSInfo getCMServer() {
-    //		return CMSManager.getInstance().findServer(
-    //				config.getCmServer().getHost(), config.getCmServer().getPort(),
-    //				config.getCmServer().getUser());
-    //	}
-
     /**
      * Retrieves the string for load DB command of record.
      *

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -188,9 +188,6 @@ public abstract class OfflineImporter extends Importer {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("[VAR]lobFiles.size=" + (lobFiles == null ? null : lobFiles.size()));
                 }
-                for (String lobFile : lobFiles) {
-                    sendLOBFile(lobFile, stc.getTarget());
-                }
                 return total;
             } finally {
                 pw.close();

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/Data2StrTranslator.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/Data2StrTranslator.java
@@ -37,6 +37,7 @@ import com.cubrid.cubridmigration.core.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.datatype.DataTypeConstant;
 import com.cubrid.cubridmigration.core.dbobject.Column;
 import com.cubrid.cubridmigration.core.dbobject.Record.ColumnValue;
+import com.cubrid.cubridmigration.core.engine.MigrationDirAndFilesManager;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import com.cubrid.cubridmigration.core.trans.IData2StrTranslator;
 import com.cubrid.cubridmigration.cubrid.exception.FormatCUBRIDDataTypeException;
@@ -97,11 +98,16 @@ public class Data2StrTranslator implements IData2StrTranslator {
             new HashMap<Integer, IFormatValueToString>();
 
     private final int targetDataFileFormat;
+    private final MigrationDirAndFilesManager dirAndFilesManager;
 
     public Data2StrTranslator(
-            String dataFilePath, MigrationConfiguration config, int targetDataFileFormat) {
+            String dataFilePath,
+            MigrationConfiguration config,
+            MigrationDirAndFilesManager dirAndFilesManager,
+            int targetDataFileFormat) {
         this.lobFilePath = dataFilePath;
         this.targetDataFileFormat = targetDataFileFormat;
+        this.dirAndFilesManager = dirAndFilesManager;
         // Initialize formaters mapping
         formaters.put(DataTypeConstant.CUBRID_DT_MONETARY, new IntegerToCUBRIDString());
         formaters.put(DataTypeConstant.CUBRID_DT_INTEGER, new IntegerToCUBRIDString());
@@ -200,6 +206,7 @@ public class Data2StrTranslator implements IData2StrTranslator {
         }
         // Integer scale = cubridColumn.getScale();
         // Integer dataTypeID = cubridColumn.getJdbcIDOfDataType();
+        final String schemaName = cubridColumn.getTableOrView().getOwner();
         final String tableName = cubridColumn.getTableOrView().getName();
         CUBRIDDataTypeHelper dataTypeHelper = CUBRIDDataTypeHelper.getInstance(null);
         if (dataTypeHelper.isCollection(cubridColumn.getDataType())) {
@@ -215,7 +222,9 @@ public class Data2StrTranslator implements IData2StrTranslator {
                     if (count > 0) {
                         bf.append(",");
                     }
-                    bf.append(exportToCUBRIDUnLoadFile(item, subDataType, tableName, lobFiles));
+                    bf.append(
+                            exportToCUBRIDUnLoadFile(
+                                    item, subDataType, schemaName, tableName, lobFiles));
                     count++;
                 }
                 bf.append("}");
@@ -231,7 +240,9 @@ public class Data2StrTranslator implements IData2StrTranslator {
                         bf.append(",");
                     }
 
-                    bf.append(exportToCUBRIDUnLoadFile(item, subDataType, tableName, lobFiles));
+                    bf.append(
+                            exportToCUBRIDUnLoadFile(
+                                    item, subDataType, schemaName, tableName, lobFiles));
                     count++;
                 }
                 bf.append("}");
@@ -261,7 +272,8 @@ public class Data2StrTranslator implements IData2StrTranslator {
                 throw new FormatCUBRIDDataTypeException(message, result.throwable);
             }
         }
-        return exportToCUBRIDUnLoadFile(dataVal, cubridColumn.getDataType(), tableName, lobFiles);
+        return exportToCUBRIDUnLoadFile(
+                dataVal, cubridColumn.getDataType(), schemaName, tableName, lobFiles);
     }
 
     /**
@@ -274,7 +286,11 @@ public class Data2StrTranslator implements IData2StrTranslator {
      * @return String
      */
     private String exportToCUBRIDUnLoadFile(
-            Object dataVal, String dataType, String tableName, List<String> lobFiles) {
+            Object dataVal,
+            String dataType,
+            String schemaName,
+            String tableName,
+            List<String> lobFiles) {
         CUBRIDDataTypeHelper cubDTHelper = CUBRIDDataTypeHelper.getInstance(null);
         Integer dataTypeID = cubDTHelper.getCUBRIDDataTypeID(dataType);
         IFormatValueToString formater = formaters.get(dataTypeID);
@@ -283,13 +299,13 @@ public class Data2StrTranslator implements IData2StrTranslator {
         }
         if (dataTypeID == DataTypeConstant.CUBRID_DT_BLOB) {
             if (targetDataFileFormat == MigrationConfiguration.DEST_DB_UNLOAD) {
-                return exportBlobToFile(dataVal, tableName, lobFiles);
+                return exportBlobToFile(dataVal, schemaName, tableName, lobFiles);
             }
             formater = formaters.get(DataTypeConstant.CUBRID_DT_BIT);
             return formater.format(dataVal);
         } else if (dataTypeID == DataTypeConstant.CUBRID_DT_CLOB) {
             if (targetDataFileFormat == MigrationConfiguration.DEST_DB_UNLOAD) {
-                return exportClobToFile(dataVal, tableName, lobFiles);
+                return exportClobToFile(dataVal, schemaName, tableName, lobFiles);
             }
             formater = formaters.get(DataTypeConstant.CUBRID_DT_VARCHAR);
             return formater.format(dataVal);
@@ -354,29 +370,41 @@ public class Data2StrTranslator implements IData2StrTranslator {
      * @param lobFiles to be uploaded
      * @return String
      */
-    private String exportBlobToFile(Object data, String targetTableName, List<String> lobFiles) {
+    private String exportBlobToFile(
+            Object data, String schemaName, String tableName, List<String> lobFiles) {
         if (data == null || lobFiles == null) {
             return VALUE_NULL;
         }
-        String blobFileName = targetTableName + "." + DBUtils.getIdentity();
+        String blobFileName = tableName + "." + DBUtils.getIdentity();
+        String lobDirDepth = dirAndFilesManager.getLobDirDepth(schemaName, tableName);
+
         String blobFilePath =
-                PathUtils.mergePath(lobFilePath, "/lob/" + targetTableName + "/" + blobFileName);
+                PathUtils.mergePath(
+                        lobFilePath, "/lob/" + tableName + "/" + lobDirDepth + "/" + blobFileName);
         blobFilePath = PathUtils.getLocalHostFilePath(blobFilePath);
 
         try {
             File parentFile = new File(blobFilePath).getParentFile();
 
-            if (PathUtils.checkPathExist(parentFile)) {
+            boolean isPathExist = false;
+            synchronized (this) {
+            	isPathExist = PathUtils.checkPathExist(parentFile);
+            }
+
+            if (isPathExist) {
                 writeToFile(data, blobFilePath);
             }
+
             lobFiles.add(blobFilePath);
             return new StringBuffer(BLOB_HEADER)
                     .append(new File(blobFilePath).length())
                     .append(LOB_HEADER)
                     .append(LOBFILEPATH)
+                    .append(lobDirDepth)
+                    .append(File.separator)
                     .append(blobFileName)
                     .append("|")
-                    .append(targetTableName)
+                    .append(tableName)
                     .append("'")
                     .toString();
         } catch (Exception e) {
@@ -394,28 +422,41 @@ public class Data2StrTranslator implements IData2StrTranslator {
      * @param lobFiles to be uploaded
      * @return String
      */
-    private String exportClobToFile(Object data, String targetTableName, List<String> lobFiles) {
+    private String exportClobToFile(
+            Object data, String schemaName, String tableName, List<String> lobFiles) {
         if (data == null || lobFiles == null) {
             return VALUE_NULL;
         }
-        String clobFileName = targetTableName + DBUtils.getIdentity();
+        String clobFileName = tableName + DBUtils.getIdentity();
+        String lobDirDepth = dirAndFilesManager.getLobDirDepth(schemaName, tableName);
+
         String clobFilePath =
-                PathUtils.mergePath(lobFilePath, "/lob/" + targetTableName + "/" + clobFileName);
+                PathUtils.mergePath(
+                        lobFilePath, "/lob/" + tableName + "/" + lobDirDepth + "/" + clobFileName);
         clobFilePath = PathUtils.getLocalHostFilePath(clobFilePath);
         try {
             File parentFile = new File(clobFilePath).getParentFile();
-            if (PathUtils.checkPathExist(parentFile)) {
+
+            boolean isPathExist = false;
+            synchronized (this) {
+            	isPathExist = PathUtils.checkPathExist(parentFile);
+            }
+
+            if (isPathExist) {
                 writeToFile(data, clobFilePath);
             }
+
             lobFiles.add(clobFilePath);
 
             return new StringBuffer(CLOB_HEADER)
                     .append(new File(clobFilePath).length())
                     .append(LOB_HEADER)
                     .append(LOBFILEPATH)
+                    .append(lobDirDepth)
+                    .append(File.separator)
                     .append(clobFileName)
                     .append("|")
-                    .append(targetTableName)
+                    .append(tableName)
                     .append("'")
                     .toString();
         } catch (Exception e) {

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/Data2StrTranslator.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/Data2StrTranslator.java
@@ -204,8 +204,7 @@ public class Data2StrTranslator implements IData2StrTranslator {
         if (dataVal == null) {
             return VALUE_NULL;
         }
-        // Integer scale = cubridColumn.getScale();
-        // Integer dataTypeID = cubridColumn.getJdbcIDOfDataType();
+
         final String schemaName = cubridColumn.getTableOrView().getOwner();
         final String tableName = cubridColumn.getTableOrView().getName();
         CUBRIDDataTypeHelper dataTypeHelper = CUBRIDDataTypeHelper.getInstance(null);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/Data2StrTranslator.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/Data2StrTranslator.java
@@ -388,7 +388,7 @@ public class Data2StrTranslator implements IData2StrTranslator {
 
             boolean isPathExist = false;
             synchronized (this) {
-            	isPathExist = PathUtils.checkPathExist(parentFile);
+                isPathExist = PathUtils.checkPathExist(parentFile);
             }
 
             if (isPathExist) {
@@ -439,7 +439,7 @@ public class Data2StrTranslator implements IData2StrTranslator {
 
             boolean isPathExist = false;
             synchronized (this) {
-            	isPathExist = PathUtils.checkPathExist(parentFile);
+                isPathExist = PathUtils.checkPathExist(parentFile);
             }
 
             if (isPathExist) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4585

**Purpose**
To address the issue of degraded OS file read and write performance when a large number of LOB files are created in a single directory, we are considering modifying the directory structure.

**Implementation**
- When establishing the LOB directory, we'll introduce two additional tiers of sub directory below the table name directory.
- A maximum of 65,000 child directories can be created, with each child directory capable of holding up to 100,000 LOB files.

**Remarks**
N/A