### PR TITLE
[TOOLS-4586] Fix build script Maven environment variable setting

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ function check_configuration ()
 
   if [ -n "${MAVEN_HOME}" ]; then
     echo MAVEN_HOME: ${MAVEN_HOME}
-    MVN="${MAVEN}/bin/mvn"
+    MVN="${MAVEN_HOME}/bin/mvn"
   fi
 
   if [ -z "$MVN" ]; then


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4586

**Purpose**
Fix the variable names used in the CMT build script for checking and setting Maven environment variables.

**Implementation**
N/A

**Remarks**
N/A