### PR TITLE
[TOOLS-4587] Change the default name of the migration script

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -229,6 +229,7 @@ public class MigrationConfiguration {
     private boolean implicitEstimate = false;
 
     private String name;
+    private String wizardStartDateTime;
     // True by default
     private boolean updateStatistics = true;
 
@@ -2612,6 +2613,10 @@ public class MigrationConfiguration {
         return name;
     }
 
+    public String getWizardStartDateTime() {
+        return wizardStartDateTime;
+    }
+
     public Catalog getOfflineSrcCatalog() {
         return offlineSrcCatalog;
     }
@@ -4259,6 +4264,10 @@ public class MigrationConfiguration {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public void setWizardStartDateTime(String wizardStartDateTime) {
+        this.wizardStartDateTime = wizardStartDateTime;
     }
 
     public void setOfflineSrcCatalog(Catalog offlineSrcCatalog) {

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -4270,6 +4270,10 @@ public class MigrationConfiguration {
         this.name = prefix + "_" + wizardDateTime;
     }
 
+    public void setName(String sourceDBType, String sourceDBName, String wizardDateTime) {
+        this.name = sourceDBType + "_" + sourceDBName + "_" + wizardDateTime;
+    }
+
     public void setWizardStartDateTime(String wizardStartDateTime) {
         this.wizardStartDateTime = wizardStartDateTime;
     }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -4266,6 +4266,10 @@ public class MigrationConfiguration {
         this.name = name;
     }
 
+    public void setName(String prefix, String wizardDateTime) {
+        this.name = prefix + "_" + wizardDateTime;
+    }
+
     public void setWizardStartDateTime(String wizardStartDateTime) {
         this.wizardStartDateTime = wizardStartDateTime;
     }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateHandler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateHandler.java
@@ -514,6 +514,8 @@ public final class MigrationTemplateHandler extends DefaultHandler {
             throws SAXException {
         if (TemplateTags.TAG_MIGRATION.equals(qName)) {
             config.setName(attributes.getValue(TemplateTags.ATTR_NAME));
+            config.setWizardStartDateTime(
+                    attributes.getValue(TemplateTags.ATTR_WIZARD_START_DATE_TIME));
             String version = attributes.getValue(TemplateTags.ATTR_VERSION);
             int versionValue = convertVersionToInt(version);
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateParser.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateParser.java
@@ -224,6 +224,8 @@ public final class MigrationTemplateParser {
             Element root = document.createElement(TemplateTags.TAG_MIGRATION);
             root.setAttribute(TemplateTags.ATTR_VERSION, VERSION);
             root.setAttribute(TemplateTags.ATTR_NAME, config.getName());
+            root.setAttribute(
+                    TemplateTags.ATTR_WIZARD_START_DATE_TIME, config.getWizardStartDateTime());
             document.appendChild(root);
             // Source
             createSourceNode(config, document, root, saveSchema);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
@@ -122,6 +122,7 @@ public final class TemplateTags {
     public static final String ATTR_USER = "user";
     public static final String ATTR_VALUE = "value";
     public static final String ATTR_VERSION = "version";
+    public static final String ATTR_WIZARD_START_DATE_TIME = "wizardStartDateTime";
     // public static final String ATTR_WARNING_RATE = "warning_rate";
     public static final String ATTR_DIR = "dir";
     public static final String ATTR_SCHEMA = "schema";

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDTimeUtil.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDTimeUtil.java
@@ -246,6 +246,17 @@ public class CUBRIDTimeUtil { // NOPMD
     }
 
     /**
+     * Format date into yyyyMMddHHmmss for use as a script name
+     *
+     * @param date Date
+     * @return yyyyMMddHHmmss
+     */
+    public static String wizardStarDateTimeFormat(Date date) {
+        return CUBRIDTimeUtil.getDateFormat("yyyyMMddHHmm", Locale.US, TimeZone.getDefault())
+                .format(date);
+    }
+
+    /**
      * Format date into yyyy-MM-dd HH:mm:ss.SSS with default time zone and default format
      *
      * @param date Date

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/MigrationWizard.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/MigrationWizard.java
@@ -141,8 +141,8 @@ public class MigrationWizard extends Wizard implements IMigrationWizardStatus {
         setNeedsProgressMonitor(true);
         setDialogSettings(new DialogSettings("migration information"));
         migrationConfig = new MigrationConfiguration();
-        migrationConfig.setName(
-                CUBRIDTimeUtil.defaultFormatDateTime(new Date(System.currentTimeMillis())));
+        migrationConfig.setWizardStartDateTime(
+                CUBRIDTimeUtil.wizardStarDateTimeFormat(new Date(System.currentTimeMillis())));
     }
 
     public MigrationWizard(MigrationScript migrationScript) {

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/CSVSelectPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/CSVSelectPage.java
@@ -894,6 +894,11 @@ public class CSVSelectPage extends MigrationWizardPage {
     protected boolean updateMigrationConfig() {
         MigrationWizard wzd = getMigrationWizard();
         MigrationConfiguration config = wzd.getMigrationConfig();
+
+        if (config.getName() == null) {
+            config.setName("CSV_" + config.getWizardStartDateTime());
+        }
+
         config.setSourceType(MigrationConfiguration.CSV);
         if (config.getCSVConfigs().isEmpty()) {
             setErrorMessage(Messages.errMsgNoCSV);

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/CSVSelectPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/CSVSelectPage.java
@@ -896,7 +896,7 @@ public class CSVSelectPage extends MigrationWizardPage {
         MigrationConfiguration config = wzd.getMigrationConfig();
 
         if (config.getName() == null) {
-            config.setName("CSV_" + config.getWizardStartDateTime());
+            config.setName("CSV", config.getWizardStartDateTime());
         }
 
         config.setSourceType(MigrationConfiguration.CSV);

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SQLSelectPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SQLSelectPage.java
@@ -621,6 +621,9 @@ public class SQLSelectPage extends MigrationWizardPage {
             setErrorMessage(null);
         }
         MigrationConfiguration config = getMigrationWizard().getMigrationConfig();
+        if (config.getName() == null) {
+            config.setName("SQL_" + config.getWizardStartDateTime());
+        }
         config.setSqlFiles(sqls);
         config.setSourceFileEncoding(cbFileCharset.getText());
         config.setSourceType(MigrationConfiguration.SQL);

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SQLSelectPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SQLSelectPage.java
@@ -622,7 +622,7 @@ public class SQLSelectPage extends MigrationWizardPage {
         }
         MigrationConfiguration config = getMigrationWizard().getMigrationConfig();
         if (config.getName() == null) {
-            config.setName("SQL_" + config.getWizardStartDateTime());
+            config.setName("SQL", config.getWizardStartDateTime());
         }
         config.setSqlFiles(sqls);
         config.setSourceFileEncoding(cbFileCharset.getText());

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
@@ -408,7 +408,10 @@ public class SelectSourcePage extends MigrationWizardPage {
             MigrationConfiguration cfg = wzd.getMigrationConfig();
 
             if (cfg.getName() == null) {
-                cfg.setName(catalog.getName(), cfg.getWizardStartDateTime());
+                cfg.setName(
+                        catalog.getDatabaseType().getName() + "_XML",
+                        catalog.getName(),
+                        cfg.getWizardStartDateTime());
             }
 
             cfg.setSourceType(MigrationConfiguration.XML);
@@ -564,7 +567,10 @@ public class SelectSourcePage extends MigrationWizardPage {
 
             // create configuration name
             if (cfg.getName() == null) {
-                cfg.setName(catalog.getName(), cfg.getWizardStartDateTime());
+                cfg.setName(
+                        catalog.getDatabaseType().getName(),
+                        catalog.getName(),
+                        cfg.getWizardStartDateTime());
             }
 
             if (isInputChanged() || wzd.getOriginalSourceCatalog() != catalog) {

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
@@ -406,6 +406,11 @@ public class SelectSourcePage extends MigrationWizardPage {
             }
             wzd.setOriginalSourceCatalog(catalog);
             MigrationConfiguration cfg = wzd.getMigrationConfig();
+
+            if (cfg.getName() == null) {
+                cfg.setName(catalog.getName() + "_" + cfg.getWizardStartDateTime());
+            }
+
             cfg.setSourceType(MigrationConfiguration.XML);
             cfg.setSourceFileName(txtXMLFile.getText());
             cfg.setSourceFileEncoding(cboFileCharset.getItem(cboFileCharset.getSelectionIndex()));
@@ -555,6 +560,11 @@ public class SelectSourcePage extends MigrationWizardPage {
                         return false;
                     }
                 }
+            }
+
+            // create configuration name
+            if (cfg.getName() == null) {
+                cfg.setName(catalog.getName() + "_" + cfg.getWizardStartDateTime());
             }
 
             if (isInputChanged() || wzd.getOriginalSourceCatalog() != catalog) {

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
@@ -409,7 +409,7 @@ public class SelectSourcePage extends MigrationWizardPage {
 
             if (cfg.getName() == null) {
                 cfg.setName(
-                        catalog.getDatabaseType().getName() + "_XML",
+                        catalog.getDatabaseType().getName() + "-XML",
                         catalog.getName(),
                         cfg.getWizardStartDateTime());
             }

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SelectSourcePage.java
@@ -408,7 +408,7 @@ public class SelectSourcePage extends MigrationWizardPage {
             MigrationConfiguration cfg = wzd.getMigrationConfig();
 
             if (cfg.getName() == null) {
-                cfg.setName(catalog.getName() + "_" + cfg.getWizardStartDateTime());
+                cfg.setName(catalog.getName(), cfg.getWizardStartDateTime());
             }
 
             cfg.setSourceType(MigrationConfiguration.XML);
@@ -564,7 +564,7 @@ public class SelectSourcePage extends MigrationWizardPage {
 
             // create configuration name
             if (cfg.getName() == null) {
-                cfg.setName(catalog.getName() + "_" + cfg.getWizardStartDateTime());
+                cfg.setName(catalog.getName(), cfg.getWizardStartDateTime());
             }
 
             if (isInputChanged() || wzd.getOriginalSourceCatalog() != catalog) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4587

**Purpose**
We are rename the default migration script. The script name varies depending on the source type.

**Implementation**
- Online Database
  - {source DB type}_{source DB name}_yyyyMMddHH24MI
- MySQL XML Dump file
  - MYSQL-XML_{source DB name}_yyyyMMddHH24MI
- SQL file
  - SQL_yyyyMMddHH24MI
- CSV file
  - CSV_yyyyMMddHH24MI

**Remarks**
N/A