### PR TITLE
[TOOLS-4585] Resolving Issues with LOB Migration through LOB Directory Structure Modification

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/ErrorRecords2SQLFileWriter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/ErrorRecords2SQLFileWriter.java
@@ -74,6 +74,7 @@ public class ErrorRecords2SQLFileWriter {
                 new Data2StrTranslator(
                         mrManager.getDirAndFilesMgr().getErrorFilesDir(),
                         mrManager.getConfig(),
+                        mrManager.getDirAndFilesMgr(),
                         MigrationConfiguration.DEST_SQL);
     }
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -128,6 +128,7 @@ public class LoadFileImporter extends OfflineImporter {
                 new Data2StrTranslator(
                         mrManager.getDirAndFilesMgr().getMergeFilesDir(),
                         config,
+                        mrManager.getDirAndFilesMgr(),
                         config.getDestType());
     }
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -188,9 +188,6 @@ public abstract class OfflineImporter extends Importer {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("[VAR]lobFiles.size=" + (lobFiles == null ? null : lobFiles.size()));
                 }
-                for (String lobFile : lobFiles) {
-                    sendLOBFile(lobFile, stc.getTarget());
-                }
                 return total;
             } finally {
                 pw.close();
@@ -565,17 +562,6 @@ public abstract class OfflineImporter extends Importer {
             }
         };
     }
-
-    //	/**
-    //	 * Retrieve the CM server object.
-    //	 *
-    //	 * @return current CM server
-    //	 */
-    //	protected CMSInfo getCMServer() {
-    //		return CMSManager.getInstance().findServer(
-    //				config.getCmServer().getHost(), config.getCmServer().getPort(),
-    //				config.getCmServer().getUser());
-    //	}
 
     /**
      * Retrieves the string for load DB command of record.


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4585

**Purpose**
To address the issue of degraded OS file read and write performance when a large number of LOB files are created in a single directory, we are considering modifying the directory structure.

**Implementation**
- When establishing the LOB directory, we'll introduce two additional tiers of sub directory below the table name directory.
- A maximum of 65,000 child directories can be created, with each child directory capable of holding up to 100,000 LOB files.

**Remarks**
Backport - #194 