### PR TITLE
[TOOLS-4590] Add schema name to LOB directory depth in Local migration

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/Data2StrTranslator.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/Data2StrTranslator.java
@@ -379,7 +379,15 @@ public class Data2StrTranslator implements IData2StrTranslator {
 
         String blobFilePath =
                 PathUtils.mergePath(
-                        lobFilePath, "/lob/" + tableName + "/" + lobDirDepth + "/" + blobFileName);
+                        lobFilePath,
+                        "/lob/"
+                                + schemaName
+                                + "/"
+                                + tableName
+                                + "/"
+                                + lobDirDepth
+                                + "/"
+                                + blobFileName);
         blobFilePath = PathUtils.getLocalHostFilePath(blobFilePath);
 
         try {
@@ -431,7 +439,15 @@ public class Data2StrTranslator implements IData2StrTranslator {
 
         String clobFilePath =
                 PathUtils.mergePath(
-                        lobFilePath, "/lob/" + tableName + "/" + lobDirDepth + "/" + clobFileName);
+                        lobFilePath,
+                        "/lob/"
+                                + schemaName
+                                + "/"
+                                + tableName
+                                + "/"
+                                + lobDirDepth
+                                + "/"
+                                + clobFileName);
         clobFilePath = PathUtils.getLocalHostFilePath(clobFilePath);
         try {
             File parentFile = new File(clobFilePath).getParentFile();


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4590

**Purpose**
Add the schema name to the LOB directory path so that LOB files are separated and output by schema.

**Implementation**

- ~/output/lob/**{schema_name}**/{table_name}

**Remarks**
N/A