### PR TITLE
[TOOLS-4599] Add script name to migration local file directory structure

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
@@ -167,7 +167,11 @@ public class MigrationDirAndFilesManager implements ICanDispose {
         privateErrorDir = errorDir.getAbsolutePath() + File.separator;
         // mergeFilesDir
         if (config.targetIsFile()) {
-            mergeFilesDir = config.getFileRepositroyPath() + File.separator + config.getName() + File.separator;
+            mergeFilesDir =
+                    config.getFileRepositroyPath()
+                            + File.separator
+                            + config.getName()
+                            + File.separator;
         } else {
             mergeFilesDir = privateTempDir + "cache" + File.separatorChar;
         }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
@@ -167,7 +167,7 @@ public class MigrationDirAndFilesManager implements ICanDispose {
         privateErrorDir = errorDir.getAbsolutePath() + File.separator;
         // mergeFilesDir
         if (config.targetIsFile()) {
-            mergeFilesDir = config.getFileRepositroyPath();
+            mergeFilesDir = config.getFileRepositroyPath() + File.separator + config.getName() + File.separator;
         } else {
             mergeFilesDir = privateTempDir + "cache" + File.separatorChar;
         }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -30,6 +30,8 @@
  */
 package com.cubrid.cubridmigration.core.engine.config;
 
+import static com.cubrid.cubridmigration.core.common.PathUtils.mergePath;
+
 import au.com.bytecode.opencsv.CSVReader;
 import com.cubrid.cubridmigration.core.common.CUBRIDIOUtils;
 import com.cubrid.cubridmigration.core.common.CharsetUtils;
@@ -80,8 +82,6 @@ import java.util.TreeMap;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-
-import static com.cubrid.cubridmigration.core.common.PathUtils.mergePath;
 
 /**
  * MigrationConfiguration Description
@@ -892,14 +892,20 @@ public class MigrationConfiguration {
     private void addTargetObjectFileName(
             String schemaName, boolean isSplit, boolean isOneTableOneFile) {
         if (isSplit) {
-            this.addTargetTableFileName(schemaName, buildLocalFileFullPath(schemaName, "class", null));
-            this.addTargetViewFileName(schemaName, buildLocalFileFullPath(schemaName, "vclass", null));
-            this.addTargetViewQuerySpecFileName(schemaName, buildLocalFileFullPath(schemaName, "vclass_query_spec", null));
+            this.addTargetTableFileName(
+                    schemaName, buildLocalFileFullPath(schemaName, "class", null));
+            this.addTargetViewFileName(
+                    schemaName, buildLocalFileFullPath(schemaName, "vclass", null));
+            this.addTargetViewQuerySpecFileName(
+                    schemaName, buildLocalFileFullPath(schemaName, "vclass_query_spec", null));
             this.addTargetPkFileName(schemaName, buildLocalFileFullPath(schemaName, "pk", null));
             this.addTargetFkFileName(schemaName, buildLocalFileFullPath(schemaName, "fk", null));
-            this.addTargetSerialFileName(schemaName, buildLocalFileFullPath(schemaName, "serial", null));
-            this.addTargetSynonymFileName(schemaName, buildLocalFileFullPath(schemaName, "synonym", null));
-            this.addTargetSchemaFileListName(schemaName, buildLocalFileFullPath(schemaName, "info", null));
+            this.addTargetSerialFileName(
+                    schemaName, buildLocalFileFullPath(schemaName, "serial", null));
+            this.addTargetSynonymFileName(
+                    schemaName, buildLocalFileFullPath(schemaName, "synonym", null));
+            this.addTargetSchemaFileListName(
+                    schemaName, buildLocalFileFullPath(schemaName, "info", null));
 
             Map<String, Map<String, String>> grantFileListFullName =
                     new HashMap<String, Map<String, String>>();
@@ -912,11 +918,13 @@ public class MigrationConfiguration {
                     this.addTargetGrantFileName(
                             schemaName,
                             grant.getSourceGrantorName(),
-                            buildLocalFileFullPath(schemaName, "grant", grant.getSourceGrantorName()));
+                            buildLocalFileFullPath(
+                                    schemaName, "grant", grant.getSourceGrantorName()));
                 }
             }
         } else {
-            this.addTargetSchemaFileName(schemaName, buildLocalFileFullPath(schemaName, "schema", null));
+            this.addTargetSchemaFileName(
+                    schemaName, buildLocalFileFullPath(schemaName, "schema", null));
         }
         if (isOneTableOneFile) {
             for (SourceEntryTableConfig table : expTables) {
@@ -924,11 +932,14 @@ public class MigrationConfiguration {
                         schemaName, buildLocalFileFullPath(schemaName, table.getName(), null));
             }
         } else {
-            this.addTargetTableDataFileName(schemaName, buildLocalFileFullPath(schemaName, "objects", null));
+            this.addTargetTableDataFileName(
+                    schemaName, buildLocalFileFullPath(schemaName, "objects", null));
         }
         this.addTargetDataFileName(schemaName, buildLocalFileFullPath(schemaName, "object", null));
-        this.addTargetIndexFileName(schemaName, buildLocalFileFullPath(schemaName, "indexes", null));
-        this.addTargetUpdateStatisticFileName(schemaName, buildLocalFileFullPath(schemaName, "updatestatistic", null));
+        this.addTargetIndexFileName(
+                schemaName, buildLocalFileFullPath(schemaName, "indexes", null));
+        this.addTargetUpdateStatisticFileName(
+                schemaName, buildLocalFileFullPath(schemaName, "updatestatistic", null));
     }
 
     private String getTargetOwner(List<Schema> schemas, String owner) {
@@ -4767,54 +4778,58 @@ public class MigrationConfiguration {
     public void setTarSchemaDuplicate(boolean isTarSchemaDuplicate) {
         this.isTarSchemaDuplicate = isTarSchemaDuplicate;
     }
-    
+
     /**
-     * Destination type - Creates a file name and directory address to use when selecting Local CUBRID dump, SQL script, CSV, and XLS
-     * 
+     * Destination type - Creates a file name and directory address to use when selecting Local
+     * CUBRID dump, SQL script, CSV, and XLS
+     *
      * @param souceSchemaName
      * @param fileType
      * @param isDataFile
      * @return file full path
      */
-    public String buildLocalFileFullPath(String sourceSchemaName, String fileType, String grantTargetObjectOwnerName) {
-    	StringBuilder fileName = new StringBuilder();
-    	fileName.append(File.separator)
-    			.append(this.getTargetFilePrefix())
-    			.append("_")
-    			.append(sourceSchemaName)
-    			.append("_")
-    			.append(fileType)
-    			.append(fileExtName(fileType, grantTargetObjectOwnerName));
-    	
-    	return mergePath(mergePath(mergePath(getFileRepositroyPath(), getName()), sourceSchemaName), fileName.toString());
+    public String buildLocalFileFullPath(
+            String sourceSchemaName, String fileType, String grantTargetObjectOwnerName) {
+        StringBuilder fileName = new StringBuilder();
+        fileName.append(File.separator)
+                .append(this.getTargetFilePrefix())
+                .append("_")
+                .append(sourceSchemaName)
+                .append("_")
+                .append(fileType)
+                .append(fileExtName(fileType, grantTargetObjectOwnerName));
+
+        return mergePath(
+                mergePath(mergePath(getFileRepositroyPath(), getName()), sourceSchemaName),
+                fileName.toString());
     }
-    
+
     /**
      * Return different extensions depending on file type
-     * 
+     *
      * @param fileType
      * @param grantTargetObjectOwnerName
      * @return file extension
      */
     private String fileExtName(String fileType, String grantTargetObjectOwnerName) {
-    	switch (fileType) {
-    		case "schema":
-    		case "indexes":
-    		case "class":
-    		case "vclass":
-    		case "vclass_query_spec":
-    		case "pk":
-    		case "fk":
-    		case "serial":
-    		case "synonym":
-    		case "info":
-    		case "updatestatistic":
-    			return getDefaultTargetSchemaFileExtName();
-    		case "grant":
-    			return getTargetGrantFileExtName(grantTargetObjectOwnerName);
-    		default:
-    			return getDataFileExt();
-    	}
+        switch (fileType) {
+            case "schema":
+            case "indexes":
+            case "class":
+            case "vclass":
+            case "vclass_query_spec":
+            case "pk":
+            case "fk":
+            case "serial":
+            case "synonym":
+            case "info":
+            case "updatestatistic":
+                return getDefaultTargetSchemaFileExtName();
+            case "grant":
+                return getTargetGrantFileExtName(grantTargetObjectOwnerName);
+            default:
+                return getDataFileExt();
+        }
     }
 
     public String getSrcConnOwner() {

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -81,6 +81,8 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
+import static com.cubrid.cubridmigration.core.common.PathUtils.mergePath;
+
 /**
  * MigrationConfiguration Description
  *
@@ -890,14 +892,14 @@ public class MigrationConfiguration {
     private void addTargetObjectFileName(
             String schemaName, boolean isSplit, boolean isOneTableOneFile) {
         if (isSplit) {
-            this.addTargetTableFileName(schemaName, getTableFullName(schemaName));
-            this.addTargetViewFileName(schemaName, getViewFullName(schemaName));
-            this.addTargetViewQuerySpecFileName(schemaName, getViewQuerySpecFullName(schemaName));
-            this.addTargetPkFileName(schemaName, getPkFullName(schemaName));
-            this.addTargetFkFileName(schemaName, getFkFullName(schemaName));
-            this.addTargetSerialFileName(schemaName, getSequenceFullName(schemaName));
-            this.addTargetSynonymFileName(schemaName, getSynonymFullName(schemaName));
-            this.addTargetSchemaFileListName(schemaName, getSchemaFileListFullName(schemaName));
+            this.addTargetTableFileName(schemaName, buildLocalFileFullPath(schemaName, "class", null));
+            this.addTargetViewFileName(schemaName, buildLocalFileFullPath(schemaName, "vclass", null));
+            this.addTargetViewQuerySpecFileName(schemaName, buildLocalFileFullPath(schemaName, "vclass_query_spec", null));
+            this.addTargetPkFileName(schemaName, buildLocalFileFullPath(schemaName, "pk", null));
+            this.addTargetFkFileName(schemaName, buildLocalFileFullPath(schemaName, "fk", null));
+            this.addTargetSerialFileName(schemaName, buildLocalFileFullPath(schemaName, "serial", null));
+            this.addTargetSynonymFileName(schemaName, buildLocalFileFullPath(schemaName, "synonym", null));
+            this.addTargetSchemaFileListName(schemaName, buildLocalFileFullPath(schemaName, "info", null));
 
             Map<String, Map<String, String>> grantFileListFullName =
                     new HashMap<String, Map<String, String>>();
@@ -910,23 +912,23 @@ public class MigrationConfiguration {
                     this.addTargetGrantFileName(
                             schemaName,
                             grant.getSourceGrantorName(),
-                            getGrantFullName(schemaName, grant.getSourceGrantorName()));
+                            buildLocalFileFullPath(schemaName, "grant", grant.getSourceGrantorName()));
                 }
             }
         } else {
-            this.addTargetSchemaFileName(schemaName, getSchemaFullName(schemaName));
+            this.addTargetSchemaFileName(schemaName, buildLocalFileFullPath(schemaName, "schema", null));
         }
         if (isOneTableOneFile) {
             for (SourceEntryTableConfig table : expTables) {
                 this.addTargetTableDataFileName(
-                        schemaName, getTableDataFullName(schemaName, table.getName()));
+                        schemaName, buildLocalFileFullPath(schemaName, table.getName(), null));
             }
         } else {
-            this.addTargetTableDataFileName(schemaName, getDataFullName(schemaName));
+            this.addTargetTableDataFileName(schemaName, buildLocalFileFullPath(schemaName, "objects", null));
         }
-        this.addTargetDataFileName(schemaName, getDataFullName(schemaName));
-        this.addTargetIndexFileName(schemaName, getIndexFullName(schemaName));
-        this.addTargetUpdateStatisticFileName(schemaName, getUpdateStatisticFullName(schemaName));
+        this.addTargetDataFileName(schemaName, buildLocalFileFullPath(schemaName, "object", null));
+        this.addTargetIndexFileName(schemaName, buildLocalFileFullPath(schemaName, "indexes", null));
+        this.addTargetUpdateStatisticFileName(schemaName, buildLocalFileFullPath(schemaName, "updatestatistic", null));
     }
 
     private String getTargetOwner(List<Schema> schemas, String owner) {
@@ -4765,287 +4767,54 @@ public class MigrationConfiguration {
     public void setTarSchemaDuplicate(boolean isTarSchemaDuplicate) {
         this.isTarSchemaDuplicate = isTarSchemaDuplicate;
     }
-
+    
     /**
-     * get Schema file full path
-     *
-     * @param targetSchemaName
-     * @return schema file full path
+     * Destination type - Creates a file name and directory address to use when selecting Local CUBRID dump, SQL script, CSV, and XLS
+     * 
+     * @param souceSchemaName
+     * @param fileType
+     * @param isDataFile
+     * @return file full path
      */
-    public String getSchemaFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_schema")
-                .append(this.getDefaultTargetSchemaFileExtName());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
+    public String buildLocalFileFullPath(String sourceSchemaName, String fileType, String grantTargetObjectOwnerName) {
+    	StringBuilder fileName = new StringBuilder();
+    	fileName.append(File.separator)
+    			.append(this.getTargetFilePrefix())
+    			.append("_")
+    			.append(sourceSchemaName)
+    			.append("_")
+    			.append(fileType)
+    			.append(fileExtName(fileType, grantTargetObjectOwnerName));
+    	
+    	return mergePath(mergePath(mergePath(getFileRepositroyPath(), getName()), sourceSchemaName), fileName.toString());
     }
-
+    
     /**
-     * get Table file full path
-     *
-     * @param targetSchemaName
-     * @return table file full path
+     * Return different extensions depending on file type
+     * 
+     * @param fileType
+     * @param grantTargetObjectOwnerName
+     * @return file extension
      */
-    public String getTableFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_class")
-                .append(this.getDefaultTargetSchemaFileExtName());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get View file full path
-     *
-     * @param targetSchemaName
-     * @return view file full path
-     */
-    public String getViewFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_vclass")
-                .append(this.getDefaultTargetSchemaFileExtName());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get View Query Specification file full path
-     *
-     * @param targetSchemaName
-     * @return view query specification file full path
-     */
-    public String getViewQuerySpecFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_vclass_query_spec")
-                .append(this.getDefaultTargetSchemaFileExtName());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get Data file full path
-     *
-     * @param targetSchemaName
-     * @return data file full path
-     */
-    public String getDataFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_objects")
-                .append(this.getDataFileExt());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get Index file full path
-     *
-     * @param targetSchemaName
-     * @return index file full path
-     */
-    public String getIndexFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_indexes")
-                .append(this.getDefaultTargetSchemaFileExtName());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get Pk file full path
-     *
-     * @param targetSchemaName
-     * @return pk file full path
-     */
-    public String getPkFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_pk")
-                .append(this.getDefaultTargetSchemaFileExtName());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get Fk file full path
-     *
-     * @param targetSchemaName
-     * @return fk file full path
-     */
-    public String getFkFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_fk")
-                .append(this.getDefaultTargetSchemaFileExtName());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get Sequence file full path
-     *
-     * @param targetSchemaName
-     * @return sequence file full path
-     */
-    public String getSequenceFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_serial")
-                .append(this.getDefaultTargetSchemaFileExtName());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get UpdateStatistic file full path
-     *
-     * @param targetSchemaName
-     * @return updateStatistic file full path
-     */
-    public String getUpdateStatisticFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_updatestatistic")
-                .append(this.getDefaultTargetSchemaFileExtName());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get Info file full path
-     *
-     * @param targetSchemaName
-     * @return info file full path
-     */
-    public String getSchemaFileListFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_info")
-                .append(this.getDefaultTargetSchemaFileExtName());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get synonym file full path
-     *
-     * @param targetSchemaName
-     * @return synonym file full path
-     */
-    public String getSynonymFullName(String targetSchemaName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_synonym")
-                .append(this.getDefaultTargetSchemaFileExtName());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get grant file full path
-     *
-     * @param targetSchemaName
-     * @return grant file full path
-     */
-    public String getGrantFullName(String targetSchemaName, String grantTargetObjectOwnerName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_grant")
-                .append(this.getTargetGrantFileExtName(grantTargetObjectOwnerName));
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
-    }
-
-    /**
-     * get one table one file full path
-     *
-     * @param targetSchemaName
-     * @param tableName
-     * @return table data file full path
-     */
-    public String getTableDataFullName(String targetSchemaName, String tableName) {
-        StringBuffer fileName = new StringBuffer();
-        fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
-                .append("_")
-                .append(targetSchemaName)
-                .append("_")
-                .append(tableName)
-                .append(getDataFileExt());
-
-        return PathUtils.mergePath(
-                PathUtils.mergePath(this.getFileRepositroyPath(), targetSchemaName),
-                fileName.toString());
+    private String fileExtName(String fileType, String grantTargetObjectOwnerName) {
+    	switch (fileType) {
+    		case "schema":
+    		case "indexes":
+    		case "class":
+    		case "vclass":
+    		case "vclass_query_spec":
+    		case "pk":
+    		case "fk":
+    		case "serial":
+    		case "synonym":
+    		case "info":
+    		case "updatestatistic":
+    			return getDefaultTargetSchemaFileExtName();
+    		case "grant":
+    			return getTargetGrantFileExtName(grantTargetObjectOwnerName);
+    		default:
+    			return getDataFileExt();
+    	}
     }
 
     public String getSrcConnOwner() {

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -929,13 +929,10 @@ public class MigrationConfiguration {
         if (isOneTableOneFile) {
             for (SourceEntryTableConfig table : expTables) {
                 this.addTargetTableDataFileName(
-                        schemaName, buildLocalFileFullPath(schemaName, table.getName(), null));
+                        schemaName, buildDataFileFullPath(schemaName, table.getName()));
             }
-        } else {
-            this.addTargetTableDataFileName(
-                    schemaName, buildLocalFileFullPath(schemaName, "objects", null));
         }
-        this.addTargetDataFileName(schemaName, buildLocalFileFullPath(schemaName, "object", null));
+        this.addTargetDataFileName(schemaName, buildDataFileFullPath(schemaName, "object"));
         this.addTargetIndexFileName(
                 schemaName, buildLocalFileFullPath(schemaName, "indexes", null));
         this.addTargetUpdateStatisticFileName(
@@ -4792,7 +4789,7 @@ public class MigrationConfiguration {
             String sourceSchemaName, String fileType, String grantTargetObjectOwnerName) {
         StringBuilder fileName = new StringBuilder();
         fileName.append(File.separator)
-                .append(this.getTargetFilePrefix())
+                .append(getTargetFilePrefix())
                 .append("_")
                 .append(sourceSchemaName)
                 .append("_")
@@ -4801,6 +4798,31 @@ public class MigrationConfiguration {
 
         return mergePath(
                 mergePath(mergePath(getFileRepositroyPath(), getName()), sourceSchemaName),
+                fileName.toString());
+    }
+
+    /**
+     * Destination type - Creates a Data file name and directory address to use when selecting Local
+     * CUBRID dump, SQL script, CSV, and XLS
+     *
+     * @param sourceSchemaName
+     * @param fileType
+     * @return data file full path
+     */
+    public String buildDataFileFullPath(String sourceSchemaName, String fileType) {
+        StringBuilder fileName = new StringBuilder();
+        fileName.append(File.separator)
+                .append(getTargetFilePrefix())
+                .append("_")
+                .append(sourceSchemaName)
+                .append("_")
+                .append(fileType)
+                .append(getDataFileExt());
+
+        return mergePath(
+                mergePath(
+                        mergePath(mergePath(getFileRepositroyPath(), getName()), sourceSchemaName),
+                        isOneTableOneFile() ? "objects" : ""),
                 fileName.toString());
     }
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/CleanDBTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/CleanDBTask.java
@@ -288,6 +288,8 @@ public class CleanDBTask extends ImportTask {
                     new File(
                             config.getFileRepositroyPath()
                                     + File.separator
+                                    + config.getName()
+                                    + File.separator
                                     + ownerName
                                     + File.separator
                                     + ownerName

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -831,13 +831,11 @@ public class SchemaMappingPage extends MigrationWizardPage {
                     if (tableList == null) {
                         tableList = new ArrayList<String>();
                     }
-                    tableList.add(config.buildLocalFileFullPath(schemaName, table.getName(), null));
+                    tableList.add(config.buildDataFileFullPath(schemaName, table.getName()));
                 }
                 tableDataFileListFullName.put(schemaName, tableList);
-            } else {
-                dataFullName.put(
-                        schemaName, config.buildLocalFileFullPath(schemaName, "objects", null));
             }
+            dataFullName.put(schemaName, config.buildDataFileFullPath(schemaName, "objects"));
             indexFullName.put(
                     schemaName, config.buildLocalFileFullPath(schemaName, "indexes", null));
             updateStatisticFullName.put(

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -792,15 +792,21 @@ public class SchemaMappingPage extends MigrationWizardPage {
                     config.isAddUserSchema() ? srcTable.getSrcSchema() : config.getSrcConnOwner();
 
             if (splitSchema) {
-            	tableFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "class", null));
-            	viewFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "vclass", null));
-            	viewQuerySpecFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "vclass_query_spec", null));
+                tableFullName.put(
+                        schemaName, config.buildLocalFileFullPath(schemaName, "class", null));
+                viewFullName.put(
+                        schemaName, config.buildLocalFileFullPath(schemaName, "vclass", null));
+                viewQuerySpecFullName.put(
+                        schemaName,
+                        config.buildLocalFileFullPath(schemaName, "vclass_query_spec", null));
                 pkFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "pk", null));
                 fkFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "fk", null));
-                serialFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "serial", null));
+                serialFullName.put(
+                        schemaName, config.buildLocalFileFullPath(schemaName, "serial", null));
                 schemaFileListFullName.put(
                         schemaName, config.buildLocalFileFullPath(schemaName, "info", null));
-                synonymFileListFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "synonym", null));
+                synonymFileListFullName.put(
+                        schemaName, config.buildLocalFileFullPath(schemaName, "synonym", null));
 
                 List<Grant> grantList = schema.getGrantList();
                 for (Grant grant : grantList) {
@@ -811,11 +817,13 @@ public class SchemaMappingPage extends MigrationWizardPage {
                     if (!grantMap.containsKey(grant.getSourceObjectOwner())) {
                         grantMap.put(
                                 grant.getSourceObjectOwner(),
-                                config.buildLocalFileFullPath(schemaName, "grant", grant.getSourceObjectOwner()));
+                                config.buildLocalFileFullPath(
+                                        schemaName, "grant", grant.getSourceObjectOwner()));
                     }
                 }
             } else {
-                schemaFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "schema", null));
+                schemaFullName.put(
+                        schemaName, config.buildLocalFileFullPath(schemaName, "schema", null));
             }
             if (config.isOneTableOneFile()) {
                 List<String> tableList = tableDataFileListFullName.get(schemaName);
@@ -827,10 +835,13 @@ public class SchemaMappingPage extends MigrationWizardPage {
                 }
                 tableDataFileListFullName.put(schemaName, tableList);
             } else {
-                dataFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "objects", null));
+                dataFullName.put(
+                        schemaName, config.buildLocalFileFullPath(schemaName, "objects", null));
             }
-            indexFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "indexes", null));
-            updateStatisticFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "updatestatistic", null));
+            indexFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "indexes", null));
+            updateStatisticFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "updatestatistic", null));
         }
 
         if (!checkFileRepository()) {

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -792,15 +792,15 @@ public class SchemaMappingPage extends MigrationWizardPage {
                     config.isAddUserSchema() ? srcTable.getSrcSchema() : config.getSrcConnOwner();
 
             if (splitSchema) {
-                tableFullName.put(schemaName, config.getTableFullName(schemaName));
-                viewFullName.put(schemaName, config.getViewFullName(schemaName));
-                viewQuerySpecFullName.put(schemaName, config.getViewQuerySpecFullName(schemaName));
-                pkFullName.put(schemaName, config.getPkFullName(schemaName));
-                fkFullName.put(schemaName, config.getFkFullName(schemaName));
-                serialFullName.put(schemaName, config.getSequenceFullName(schemaName));
+            	tableFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "class", null));
+            	viewFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "vclass", null));
+            	viewQuerySpecFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "vclass_query_spec", null));
+                pkFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "pk", null));
+                fkFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "fk", null));
+                serialFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "serial", null));
                 schemaFileListFullName.put(
-                        schemaName, config.getSchemaFileListFullName(schemaName));
-                synonymFileListFullName.put(schemaName, config.getSynonymFullName(schemaName));
+                        schemaName, config.buildLocalFileFullPath(schemaName, "info", null));
+                synonymFileListFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "synonym", null));
 
                 List<Grant> grantList = schema.getGrantList();
                 for (Grant grant : grantList) {
@@ -811,11 +811,11 @@ public class SchemaMappingPage extends MigrationWizardPage {
                     if (!grantMap.containsKey(grant.getSourceObjectOwner())) {
                         grantMap.put(
                                 grant.getSourceObjectOwner(),
-                                config.getGrantFullName(schemaName, grant.getSourceObjectOwner()));
+                                config.buildLocalFileFullPath(schemaName, "grant", grant.getSourceObjectOwner()));
                     }
                 }
             } else {
-                schemaFullName.put(schemaName, config.getSchemaFullName(schemaName));
+                schemaFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "schema", null));
             }
             if (config.isOneTableOneFile()) {
                 List<String> tableList = tableDataFileListFullName.get(schemaName);
@@ -823,14 +823,14 @@ public class SchemaMappingPage extends MigrationWizardPage {
                     if (tableList == null) {
                         tableList = new ArrayList<String>();
                     }
-                    tableList.add(config.getTableDataFullName(schemaName, table.getName()));
+                    tableList.add(config.buildLocalFileFullPath(schemaName, table.getName(), null));
                 }
                 tableDataFileListFullName.put(schemaName, tableList);
             } else {
-                dataFullName.put(schemaName, config.getDataFullName(schemaName));
+                dataFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "objects", null));
             }
-            indexFullName.put(schemaName, config.getIndexFullName(schemaName));
-            updateStatisticFullName.put(schemaName, config.getUpdateStatisticFullName(schemaName));
+            indexFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "indexes", null));
+            updateStatisticFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "updatestatistic", null));
         }
 
         if (!checkFileRepository()) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4599

**Purpose**
Generate schema, data, and LOB files in local directories by including script names in the paths for better organization and separation.

**Implementation**
- schema, objects, indexes etc.. 
  - ~/output/{script_name}/{schema_name}
- LOB files
  - ~/output/{script_name}/lob/{schema_name}

**Remarks**
N/A