### PR TITLE
[TOOLS-4600] Add depth to file directory when "One table one file" option is selected

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
@@ -81,6 +81,20 @@ public final class PathUtils {
 
         return false;
     }
+    
+    /**
+     * Checks if a directory is empty
+     * 
+     * @param directory the directory to check
+     * @return true if the directory is empty or does not contain any files, false otherwise
+     */
+    public static boolean checkPathEmpty(File directory) {
+    	if (directory.isDirectory()) {
+    		String[] files = directory.list();
+    		return files == null || files.length == 0;
+    	}
+    	return false;
+    }
 
     /**
      * Create file

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
@@ -81,19 +81,19 @@ public final class PathUtils {
 
         return false;
     }
-    
+
     /**
      * Checks if a directory is empty
-     * 
+     *
      * @param directory the directory to check
      * @return true if the directory is empty or does not contain any files, false otherwise
      */
     public static boolean checkPathEmpty(File directory) {
-    	if (directory.isDirectory()) {
-    		String[] files = directory.list();
-    		return files == null || files.length == 0;
-    	}
-    	return false;
+        if (directory.isDirectory()) {
+            String[] files = directory.list();
+            return files == null || files.length == 0;
+        }
+        return false;
     }
 
     /**

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -84,6 +84,8 @@ public class LoadFileImporter extends OfflineImporter {
                             + File.separator
                             + owner
                             + File.separator
+                            + "objects"
+                            + File.separator
                             + prefix
                             + "_"
                             + owner

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
@@ -141,7 +141,7 @@ public class MigrationTasksScheduler {
                 createCreateUserSQL();
             }
         }
-        
+
         clearObjectsDir();
     }
 
@@ -273,20 +273,24 @@ public class MigrationTasksScheduler {
         }
         PathUtils.deleteFile(new File(config.getFileRepositroyPath() + schemaName));
     }
-    
+
     /** Delete objects directory */
     private void clearObjectsDir() {
-   	MigrationConfiguration config = context.getConfig();
-   	Map<String, String> tableDataFiles = config.getTargetDataFileName();
-   	List<String> keys = new ArrayList<>(tableDataFiles.keySet());
-   	
-   	for (String key : keys) {
-   		File objectsFileParentPath = new File(new File(tableDataFiles.get(key)).getParent() + File.separator + "objects");
-   		if (!config.isOneTableOneFile() && PathUtils.checkPathEmpty(objectsFileParentPath)) {
-       		PathUtils.deleteFile(objectsFileParentPath);
-       	}
-   	}
-   }
+        MigrationConfiguration config = context.getConfig();
+        Map<String, String> tableDataFiles = config.getTargetDataFileName();
+        List<String> keys = new ArrayList<>(tableDataFiles.keySet());
+
+        for (String key : keys) {
+            File objectsFileParentPath =
+                    new File(
+                            new File(tableDataFiles.get(key)).getParent()
+                                    + File.separator
+                                    + "objects");
+            if (!config.isOneTableOneFile() && PathUtils.checkPathEmpty(objectsFileParentPath)) {
+                PathUtils.deleteFile(objectsFileParentPath);
+            }
+        }
+    }
 
     /** Waiting for step finished. */
     protected void await() {

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
@@ -141,6 +141,8 @@ public class MigrationTasksScheduler {
                 createCreateUserSQL();
             }
         }
+        
+        clearObjectsDir();
     }
 
     /** Update auto_increment columns current values */
@@ -271,6 +273,20 @@ public class MigrationTasksScheduler {
         }
         PathUtils.deleteFile(new File(config.getFileRepositroyPath() + schemaName));
     }
+    
+    /** Delete objects directory */
+    private void clearObjectsDir() {
+   	MigrationConfiguration config = context.getConfig();
+   	Map<String, String> tableDataFiles = config.getTargetDataFileName();
+   	List<String> keys = new ArrayList<>(tableDataFiles.keySet());
+   	
+   	for (String key : keys) {
+   		File objectsFileParentPath = new File(new File(tableDataFiles.get(key)).getParent() + File.separator + "objects");
+   		if (!config.isOneTableOneFile() && PathUtils.checkPathEmpty(objectsFileParentPath)) {
+       		PathUtils.deleteFile(objectsFileParentPath);
+       	}
+   	}
+   }
 
     /** Waiting for step finished. */
     protected void await() {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4600

**Purpose**
An additional directory depth named "objects" will be added to data files separately when the "One table one file" option is selected. This change will enhance file organization and make it easier to manage large numbers of table files.

**Implementation**

- Update the logic that generates directory paths to include the "objects" directory when the "One table one file" option is selected
- The new directory structure for data files will be ~/output/{script_name}/{schema_name}/objects

**Remarks**
N/A