### PR TITLE
[TOOLS-4589] NullPointerException when all three options are checked in Output file settings

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -37,7 +37,6 @@ import com.cubrid.cubridmigration.core.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
 import com.cubrid.cubridmigration.core.dbobject.Grant;
 import com.cubrid.cubridmigration.core.dbobject.Schema;
-import com.cubrid.cubridmigration.core.dbobject.Table;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import com.cubrid.cubridmigration.ui.common.CompositeUtils;
 import com.cubrid.cubridmigration.ui.common.dialog.DetailMessageDialog;
@@ -827,7 +826,12 @@ public class SchemaMappingPage extends MigrationWizardPage {
             }
             if (config.isOneTableOneFile()) {
                 List<String> tableList = new ArrayList<>();
-                schema.getTables().forEach(table -> tableList.add(config.buildDataFileFullPath(schemaName, table.getName())));
+                schema.getTables()
+                        .forEach(
+                                table ->
+                                        tableList.add(
+                                                config.buildDataFileFullPath(
+                                                        schemaName, table.getName())));
                 tableDataFileListFullName.put(schemaName, tableList);
             }
             dataFullName.put(schemaName, config.buildDataFileFullPath(schemaName, "objects"));

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -826,13 +826,8 @@ public class SchemaMappingPage extends MigrationWizardPage {
                         schemaName, config.buildLocalFileFullPath(schemaName, "schema", null));
             }
             if (config.isOneTableOneFile()) {
-                List<String> tableList = tableDataFileListFullName.get(schemaName);
-                for (Table table : srcCatalog.getSchemaByName(schemaName).getTables()) {
-                    if (tableList == null) {
-                        tableList = new ArrayList<String>();
-                    }
-                    tableList.add(config.buildDataFileFullPath(schemaName, table.getName()));
-                }
+                List<String> tableList = new ArrayList<>();
+                schema.getTables().forEach(table -> tableList.add(config.buildDataFileFullPath(schemaName, table.getName())));
                 tableDataFileListFullName.put(schemaName, tableList);
             }
             dataFullName.put(schemaName, config.buildDataFileFullPath(schemaName, "objects"));


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4589

**Purpose**
On the Local migration page 3 of the migration wizard, when selecting a version 11.0 under and choosing the 'One table one file' option, a NullPointerException occurs on page 5. Resolve this issue.

**Implementation**
N/A

**Remarks**
N/A