### PR TITLE
[TOOLS-4624] When changing the script name before starting migration, files are created in the wrong directory

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -231,6 +231,7 @@ public class MigrationConfiguration {
     private boolean implicitEstimate = false;
 
     private String name;
+    private String oldName;
     private String wizardStartDateTime;
     // True by default
     private boolean updateStatistics = true;
@@ -2622,6 +2623,10 @@ public class MigrationConfiguration {
     public String getName() {
         return name;
     }
+    
+    public String getOldName() {
+    	return oldName;
+    }
 
     public String getWizardStartDateTime() {
         return wizardStartDateTime;
@@ -4273,6 +4278,9 @@ public class MigrationConfiguration {
     }
 
     public void setName(String name) {
+    	if (name != null) {
+    		oldName = name;
+    	}
         this.name = name;
     }
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -4279,7 +4279,7 @@ public class MigrationConfiguration {
 
     public void setName(String name) {
         if (this.name != null) {
-            oldName = name;
+            oldName = this.name;
         }
         this.name = name;
     }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -4278,7 +4278,7 @@ public class MigrationConfiguration {
     }
 
     public void setName(String name) {
-        if (name != null) {
+        if (this.name != null) {
             oldName = name;
         }
         this.name = name;

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -2623,9 +2623,9 @@ public class MigrationConfiguration {
     public String getName() {
         return name;
     }
-    
+
     public String getOldName() {
-    	return oldName;
+        return oldName;
     }
 
     public String getWizardStartDateTime() {
@@ -4278,9 +4278,9 @@ public class MigrationConfiguration {
     }
 
     public void setName(String name) {
-    	if (name != null) {
-    		oldName = name;
-    	}
+        if (name != null) {
+            oldName = name;
+        }
         this.name = name;
     }
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
@@ -51,6 +51,7 @@ import com.cubrid.cubridmigration.core.engine.task.MigrationTaskFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -88,6 +89,7 @@ public class MigrationTasksScheduler {
         config.cleanNoUsedConfigForStart();
         initUserDefinedHandlers();
 
+        changeLocalFilePath();
         clearTargetDB();
         createSchema();
         createTables();
@@ -290,6 +292,89 @@ public class MigrationTasksScheduler {
                 PathUtils.deleteFile(objectsFileParentPath);
             }
         }
+    }
+    
+    /** Change the script name part of the local file path */
+    private void changeLocalFilePath() {
+    	MigrationConfiguration config = context.getConfig();
+    	String oldName = config.getOldName();
+    	String newName = config.getName();
+
+    	if (oldName == null) {
+    		return;
+    	}
+
+    	// schema
+    	config.setTargetSchemaFileName(changeOldNameToNewName(config.getTargetSchemaFileName(), oldName, newName));
+
+    	// class
+    	config.setTargetTableFileName(changeOldNameToNewName(config.getTargetTableFileName(), oldName, newName));
+
+    	// vclass
+    	config.setTargetViewFileName(changeOldNameToNewName(config.getTargetViewFileName(), oldName, newName));
+
+    	// vclass_query_spec
+    	config.setTargetViewQuerySpecFileName(changeOldNameToNewName(config.getTargetViewQuerySpecFileName(), oldName, newName));
+
+    	// objects
+    	config.setTargetDataFileName(changeOldNameToNewName(config.getTargetDataFileName(), oldName, newName));
+
+    	// index
+    	config.setTargetIndexFileName(changeOldNameToNewName(config.getTargetIndexFileName(), oldName, newName));
+
+    	// pk
+    	config.setTargetPkFileName(changeOldNameToNewName(config.getTargetPkFileName(), oldName, newName));
+
+    	// fk
+    	config.setTargetFkFileName(changeOldNameToNewName(config.getTargetFkFileName(), oldName, newName));
+
+    	// serial
+    	config.setTargetSerialFileName(changeOldNameToNewName(config.getTargetSerialFileName(), oldName, newName));
+
+    	// synonym
+    	config.setTargetSynonymFileName(changeOldNameToNewName(config.getTargetSynonymFileName(), oldName, newName));
+
+    	// grant
+    	Map<String, Map<String, String>> newGrantFilePathMap = new HashMap<>();
+    	Map<String, Map<String, String>> grantFilePathMap = config.getTargetGrantFileName();
+    	for (String schemaName : grantFilePathMap.keySet()) {
+    		Map<String, String> grantFilePath = grantFilePathMap.get(schemaName);
+    		if (grantFilePath != null) {
+    			newGrantFilePathMap.put(schemaName, changeOldNameToNewName(grantFilePath, oldName, newName));
+    		}
+    	}
+    	config.setTargetGrantFileName(newGrantFilePathMap);
+    	
+    	// updatestatistic
+    	config.setTargetUpdateStatisticFileName(changeOldNameToNewName(config.getTargetUpdateStatisticFileName(), oldName, newName));
+
+    	// info
+    	config.setTargetSchemaFileListName(changeOldNameToNewName(config.getTargetSchemaFileListName(), oldName, newName));
+
+    	// table data file
+    	Map<String, List<String>> newTableDataFilePath = new HashMap<>();
+    	config.getTargetTableDataFileName().forEach((schemaName, tableDataFilePathList) -> {
+    		newTableDataFilePath.put(schemaName, changeOldNameToNewName(tableDataFilePathList, oldName, newName));
+    	});
+    	config.setTargetTableDataFileName(newTableDataFilePath);
+    }
+
+    /** change directory path */
+    private List<String> changeOldNameToNewName(List<String> filePath, String oldName, String newName) {
+    	List<String> newFilePath = new ArrayList<String>();
+    	filePath.forEach(path -> {
+    		newFilePath.add(path.replace(oldName, newName));
+    	});
+    	return newFilePath;
+    }
+
+    /** change directory path */
+    private Map<String, String> changeOldNameToNewName(Map<String, String> filePath, String oldName, String newName) {
+        Map<String, String> newFilePath = new HashMap<>();
+    	filePath.forEach((schemaName, path) -> {
+    		newFilePath.put(schemaName, path.replace(oldName, newName));
+    	});
+    	return newFilePath;
     }
 
     /** Waiting for step finished. */

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
@@ -293,88 +293,111 @@ public class MigrationTasksScheduler {
             }
         }
     }
-    
+
     /** Change the script name part of the local file path */
     private void changeLocalFilePath() {
-    	MigrationConfiguration config = context.getConfig();
-    	String oldName = config.getOldName();
-    	String newName = config.getName();
+        MigrationConfiguration config = context.getConfig();
+        String oldName = config.getOldName();
+        String newName = config.getName();
 
-    	if (oldName == null) {
-    		return;
-    	}
+        if (oldName == null) {
+            return;
+        }
 
-    	// schema
-    	config.setTargetSchemaFileName(changeOldNameToNewName(config.getTargetSchemaFileName(), oldName, newName));
+        // schema
+        config.setTargetSchemaFileName(
+                changeOldNameToNewName(config.getTargetSchemaFileName(), oldName, newName));
 
-    	// class
-    	config.setTargetTableFileName(changeOldNameToNewName(config.getTargetTableFileName(), oldName, newName));
+        // class
+        config.setTargetTableFileName(
+                changeOldNameToNewName(config.getTargetTableFileName(), oldName, newName));
 
-    	// vclass
-    	config.setTargetViewFileName(changeOldNameToNewName(config.getTargetViewFileName(), oldName, newName));
+        // vclass
+        config.setTargetViewFileName(
+                changeOldNameToNewName(config.getTargetViewFileName(), oldName, newName));
 
-    	// vclass_query_spec
-    	config.setTargetViewQuerySpecFileName(changeOldNameToNewName(config.getTargetViewQuerySpecFileName(), oldName, newName));
+        // vclass_query_spec
+        config.setTargetViewQuerySpecFileName(
+                changeOldNameToNewName(config.getTargetViewQuerySpecFileName(), oldName, newName));
 
-    	// objects
-    	config.setTargetDataFileName(changeOldNameToNewName(config.getTargetDataFileName(), oldName, newName));
+        // objects
+        config.setTargetDataFileName(
+                changeOldNameToNewName(config.getTargetDataFileName(), oldName, newName));
 
-    	// index
-    	config.setTargetIndexFileName(changeOldNameToNewName(config.getTargetIndexFileName(), oldName, newName));
+        // index
+        config.setTargetIndexFileName(
+                changeOldNameToNewName(config.getTargetIndexFileName(), oldName, newName));
 
-    	// pk
-    	config.setTargetPkFileName(changeOldNameToNewName(config.getTargetPkFileName(), oldName, newName));
+        // pk
+        config.setTargetPkFileName(
+                changeOldNameToNewName(config.getTargetPkFileName(), oldName, newName));
 
-    	// fk
-    	config.setTargetFkFileName(changeOldNameToNewName(config.getTargetFkFileName(), oldName, newName));
+        // fk
+        config.setTargetFkFileName(
+                changeOldNameToNewName(config.getTargetFkFileName(), oldName, newName));
 
-    	// serial
-    	config.setTargetSerialFileName(changeOldNameToNewName(config.getTargetSerialFileName(), oldName, newName));
+        // serial
+        config.setTargetSerialFileName(
+                changeOldNameToNewName(config.getTargetSerialFileName(), oldName, newName));
 
-    	// synonym
-    	config.setTargetSynonymFileName(changeOldNameToNewName(config.getTargetSynonymFileName(), oldName, newName));
+        // synonym
+        config.setTargetSynonymFileName(
+                changeOldNameToNewName(config.getTargetSynonymFileName(), oldName, newName));
 
-    	// grant
-    	Map<String, Map<String, String>> newGrantFilePathMap = new HashMap<>();
-    	Map<String, Map<String, String>> grantFilePathMap = config.getTargetGrantFileName();
-    	for (String schemaName : grantFilePathMap.keySet()) {
-    		Map<String, String> grantFilePath = grantFilePathMap.get(schemaName);
-    		if (grantFilePath != null) {
-    			newGrantFilePathMap.put(schemaName, changeOldNameToNewName(grantFilePath, oldName, newName));
-    		}
-    	}
-    	config.setTargetGrantFileName(newGrantFilePathMap);
-    	
-    	// updatestatistic
-    	config.setTargetUpdateStatisticFileName(changeOldNameToNewName(config.getTargetUpdateStatisticFileName(), oldName, newName));
+        // grant
+        Map<String, Map<String, String>> newGrantFilePathMap = new HashMap<>();
+        Map<String, Map<String, String>> grantFilePathMap = config.getTargetGrantFileName();
+        for (String schemaName : grantFilePathMap.keySet()) {
+            Map<String, String> grantFilePath = grantFilePathMap.get(schemaName);
+            if (grantFilePath != null) {
+                newGrantFilePathMap.put(
+                        schemaName, changeOldNameToNewName(grantFilePath, oldName, newName));
+            }
+        }
+        config.setTargetGrantFileName(newGrantFilePathMap);
 
-    	// info
-    	config.setTargetSchemaFileListName(changeOldNameToNewName(config.getTargetSchemaFileListName(), oldName, newName));
+        // updatestatistic
+        config.setTargetUpdateStatisticFileName(
+                changeOldNameToNewName(
+                        config.getTargetUpdateStatisticFileName(), oldName, newName));
 
-    	// table data file
-    	Map<String, List<String>> newTableDataFilePath = new HashMap<>();
-    	config.getTargetTableDataFileName().forEach((schemaName, tableDataFilePathList) -> {
-    		newTableDataFilePath.put(schemaName, changeOldNameToNewName(tableDataFilePathList, oldName, newName));
-    	});
-    	config.setTargetTableDataFileName(newTableDataFilePath);
+        // info
+        config.setTargetSchemaFileListName(
+                changeOldNameToNewName(config.getTargetSchemaFileListName(), oldName, newName));
+
+        // table data file
+        Map<String, List<String>> newTableDataFilePath = new HashMap<>();
+        config.getTargetTableDataFileName()
+                .forEach(
+                        (schemaName, tableDataFilePathList) -> {
+                            newTableDataFilePath.put(
+                                    schemaName,
+                                    changeOldNameToNewName(
+                                            tableDataFilePathList, oldName, newName));
+                        });
+        config.setTargetTableDataFileName(newTableDataFilePath);
     }
 
     /** change directory path */
-    private List<String> changeOldNameToNewName(List<String> filePath, String oldName, String newName) {
-    	List<String> newFilePath = new ArrayList<String>();
-    	filePath.forEach(path -> {
-    		newFilePath.add(path.replace(oldName, newName));
-    	});
-    	return newFilePath;
+    private List<String> changeOldNameToNewName(
+            List<String> filePath, String oldName, String newName) {
+        List<String> newFilePath = new ArrayList<String>();
+        filePath.forEach(
+                path -> {
+                    newFilePath.add(path.replace(oldName, newName));
+                });
+        return newFilePath;
     }
 
     /** change directory path */
-    private Map<String, String> changeOldNameToNewName(Map<String, String> filePath, String oldName, String newName) {
+    private Map<String, String> changeOldNameToNewName(
+            Map<String, String> filePath, String oldName, String newName) {
         Map<String, String> newFilePath = new HashMap<>();
-    	filePath.forEach((schemaName, path) -> {
-    		newFilePath.put(schemaName, path.replace(oldName, newName));
-    	});
-    	return newFilePath;
+        filePath.forEach(
+                (schemaName, path) -> {
+                    newFilePath.put(schemaName, path.replace(oldName, newName));
+                });
+        return newFilePath;
     }
 
     /** Waiting for step finished. */

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
@@ -297,6 +297,7 @@ public class MigrationTasksScheduler {
     /** Change the script name part of the local file path */
     private void changeLocalFilePath() {
         MigrationConfiguration config = context.getConfig();
+        String fileRootPath = config.getFileRepositroyPath();
         String oldName = config.getOldName();
         String newName = config.getName();
 
@@ -306,43 +307,53 @@ public class MigrationTasksScheduler {
 
         // schema
         config.setTargetSchemaFileName(
-                changeOldNameToNewName(config.getTargetSchemaFileName(), oldName, newName));
+                changeOldNameToNewName(
+                        config.getTargetSchemaFileName(), fileRootPath, oldName, newName));
 
         // class
         config.setTargetTableFileName(
-                changeOldNameToNewName(config.getTargetTableFileName(), oldName, newName));
+                changeOldNameToNewName(
+                        config.getTargetTableFileName(), fileRootPath, oldName, newName));
 
         // vclass
         config.setTargetViewFileName(
-                changeOldNameToNewName(config.getTargetViewFileName(), oldName, newName));
+                changeOldNameToNewName(
+                        config.getTargetViewFileName(), fileRootPath, oldName, newName));
 
         // vclass_query_spec
         config.setTargetViewQuerySpecFileName(
-                changeOldNameToNewName(config.getTargetViewQuerySpecFileName(), oldName, newName));
+                changeOldNameToNewName(
+                        config.getTargetViewQuerySpecFileName(), fileRootPath, oldName, newName));
 
         // objects
         config.setTargetDataFileName(
-                changeOldNameToNewName(config.getTargetDataFileName(), oldName, newName));
+                changeOldNameToNewName(
+                        config.getTargetDataFileName(), fileRootPath, oldName, newName));
 
         // index
         config.setTargetIndexFileName(
-                changeOldNameToNewName(config.getTargetIndexFileName(), oldName, newName));
+                changeOldNameToNewName(
+                        config.getTargetIndexFileName(), fileRootPath, oldName, newName));
 
         // pk
         config.setTargetPkFileName(
-                changeOldNameToNewName(config.getTargetPkFileName(), oldName, newName));
+                changeOldNameToNewName(
+                        config.getTargetPkFileName(), fileRootPath, oldName, newName));
 
         // fk
         config.setTargetFkFileName(
-                changeOldNameToNewName(config.getTargetFkFileName(), oldName, newName));
+                changeOldNameToNewName(
+                        config.getTargetFkFileName(), fileRootPath, oldName, newName));
 
         // serial
         config.setTargetSerialFileName(
-                changeOldNameToNewName(config.getTargetSerialFileName(), oldName, newName));
+                changeOldNameToNewName(
+                        config.getTargetSerialFileName(), fileRootPath, oldName, newName));
 
         // synonym
         config.setTargetSynonymFileName(
-                changeOldNameToNewName(config.getTargetSynonymFileName(), oldName, newName));
+                changeOldNameToNewName(
+                        config.getTargetSynonymFileName(), fileRootPath, oldName, newName));
 
         // grant
         Map<String, Map<String, String>> newGrantFilePathMap = new HashMap<>();
@@ -351,7 +362,8 @@ public class MigrationTasksScheduler {
             Map<String, String> grantFilePath = grantFilePathMap.get(schemaName);
             if (grantFilePath != null) {
                 newGrantFilePathMap.put(
-                        schemaName, changeOldNameToNewName(grantFilePath, oldName, newName));
+                        schemaName,
+                        changeOldNameToNewName(grantFilePath, fileRootPath, oldName, newName));
             }
         }
         config.setTargetGrantFileName(newGrantFilePathMap);
@@ -359,11 +371,12 @@ public class MigrationTasksScheduler {
         // updatestatistic
         config.setTargetUpdateStatisticFileName(
                 changeOldNameToNewName(
-                        config.getTargetUpdateStatisticFileName(), oldName, newName));
+                        config.getTargetUpdateStatisticFileName(), fileRootPath, oldName, newName));
 
         // info
         config.setTargetSchemaFileListName(
-                changeOldNameToNewName(config.getTargetSchemaFileListName(), oldName, newName));
+                changeOldNameToNewName(
+                        config.getTargetSchemaFileListName(), fileRootPath, oldName, newName));
 
         // table data file
         Map<String, List<String>> newTableDataFilePath = new HashMap<>();
@@ -373,31 +386,49 @@ public class MigrationTasksScheduler {
                             newTableDataFilePath.put(
                                     schemaName,
                                     changeOldNameToNewName(
-                                            tableDataFilePathList, oldName, newName));
+                                            tableDataFilePathList, fileRootPath, oldName, newName));
                         });
         config.setTargetTableDataFileName(newTableDataFilePath);
     }
 
     /** change directory path */
     private List<String> changeOldNameToNewName(
-            List<String> filePath, String oldName, String newName) {
+            List<String> filePath, String fileRootPath, String oldName, String newName) {
         List<String> newFilePath = new ArrayList<String>();
         filePath.forEach(
                 path -> {
-                    newFilePath.add(path.replace(oldName, newName));
+                    String newPath = removeRootPath(path, fileRootPath).replace(oldName, newName);
+                    newFilePath.add(addRootPath(newPath, fileRootPath));
                 });
         return newFilePath;
     }
 
     /** change directory path */
     private Map<String, String> changeOldNameToNewName(
-            Map<String, String> filePath, String oldName, String newName) {
+            Map<String, String> filePath, String fileRootPath, String oldName, String newName) {
         Map<String, String> newFilePath = new HashMap<>();
         filePath.forEach(
                 (schemaName, path) -> {
-                    newFilePath.put(schemaName, path.replace(oldName, newName));
+                    String newPath = removeRootPath(path, fileRootPath).replace(oldName, newName);
+                    newFilePath.put(schemaName, addRootPath(newPath, fileRootPath));
                 });
         return newFilePath;
+    }
+
+    /** add file root path */
+    private String addRootPath(String filePath, String fileRootPath) {
+        if (filePath.startsWith(fileRootPath)) {
+            return filePath;
+        }
+        return fileRootPath + filePath;
+    }
+
+    /** remove file root path */
+    private String removeRootPath(String fileFullPath, String fileRootPath) {
+        if (fileFullPath.startsWith(fileRootPath)) {
+            return fileFullPath.substring(fileRootPath.length());
+        }
+        return fileFullPath;
     }
 
     /** Waiting for step finished. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4624

**Purpose**
Modify to ensure that if the user changes the migration name before the migration starts, the updated migration name is reflected in the directory path.

**Implementation**
Add a "changeLocalFilePath" step to modify all directory paths if the name is changed before the migration starts.

**Remarks**
N/A