### PR TITLE
[TOOLS-4601] Table files not recreated and filename appears as null during MySQL and MariaDB migration

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -35,6 +35,7 @@ import com.cubrid.cubridmigration.core.common.PathUtils;
 import com.cubrid.cubridmigration.core.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.dbobject.DBObject;
 import com.cubrid.cubridmigration.core.dbobject.Table;
+import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
 import com.cubrid.cubridmigration.core.engine.MigrationContext;
 import com.cubrid.cubridmigration.core.engine.MigrationDirAndFilesManager;
 import com.cubrid.cubridmigration.core.engine.MigrationStatusManager;
@@ -171,8 +172,10 @@ public class LoadFileImporter extends OfflineImporter {
             MigrationDirAndFilesManager mdfm = mrManager.getDirAndFilesMgr();
 
             final String schemaName;
-            if (config.sourceIsXMLDump()) {
-                schemaName = config.getSrcConnOwner();
+            DatabaseType sourceDBType = config.getSourceDBType();
+            if (sourceDBType == DatabaseType.MYSQL || sourceDBType == DatabaseType.MARIADB) {
+                String srcConnOwner = config.getSrcConnOwner();
+                schemaName = config.isAddUserSchema() ? srcConnOwner.toUpperCase() : srcConnOwner;
             } else {
                 schemaName = config.isAddUserSchema() ? stc.getOwner() : config.getSrcConnOwner();
             }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -35,7 +35,6 @@ import com.cubrid.cubridmigration.core.common.PathUtils;
 import com.cubrid.cubridmigration.core.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.dbobject.DBObject;
 import com.cubrid.cubridmigration.core.dbobject.Table;
-import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
 import com.cubrid.cubridmigration.core.engine.MigrationContext;
 import com.cubrid.cubridmigration.core.engine.MigrationDirAndFilesManager;
 import com.cubrid.cubridmigration.core.engine.MigrationStatusManager;
@@ -170,15 +169,10 @@ public class LoadFileImporter extends OfflineImporter {
             String fileName, final SourceTableConfig stc, final int impCount, final int expCount) {
         synchronized (lockObj) {
             MigrationDirAndFilesManager mdfm = mrManager.getDirAndFilesMgr();
-
-            final String schemaName;
-            DatabaseType sourceDBType = config.getSourceDBType();
-            if (sourceDBType == DatabaseType.MYSQL || sourceDBType == DatabaseType.MARIADB) {
-                String srcConnOwner = config.getSrcConnOwner();
-                schemaName = config.isAddUserSchema() ? srcConnOwner.toUpperCase() : srcConnOwner;
-            } else {
-                schemaName = config.isAddUserSchema() ? stc.getOwner() : config.getSrcConnOwner();
-            }
+            String schemaName =
+                    config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
+                            ? stc.getOwner()
+                            : config.getSrcConnOwner();
 
             if (!tableFiles.containsKey(schemaName + stc.getName())) {
                 tableFiles.put(


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4601

**Purpose**
Fix the issue where NULL appears in the file names when exporting to local files from MySQL and MariaDB.

**Implementation**
N/A

**Remarks**
N/A