### PR TITLE
[TOOLS-4612] CSV file migration outputs data into a null schema folder

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -687,7 +687,9 @@ public abstract class OfflineImporter extends Importer {
                 sql.toString(),
                 DBObject.OBJ_TYPE_TABLE,
                 createResultHandler(table),
-                config.isAddUserSchema() ? table.getSourceOwner() : config.getSrcConnOwner());
+                config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
+                        ? table.getSourceOwner()
+                        : config.getSrcConnOwner());
     }
 
     /**
@@ -703,7 +705,9 @@ public abstract class OfflineImporter extends Importer {
                 viewDDL + "\n",
                 DBObject.OBJ_TYPE_VIEW,
                 createResultHandler(view),
-                config.isAddUserSchema() ? view.getSourceOwner() : config.getSrcConnOwner());
+                config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
+                        ? view.getSourceOwner()
+                        : config.getSrcConnOwner());
     }
 
     /**
@@ -719,7 +723,9 @@ public abstract class OfflineImporter extends Importer {
                 viewAlterDDL + "\n",
                 DBObject.OBJ_TYPE_VIEW_QUERY_SPEC,
                 createResultHandler(view),
-                config.isAddUserSchema() ? view.getSourceOwner() : config.getSrcConnOwner());
+                config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
+                        ? view.getSourceOwner()
+                        : config.getSrcConnOwner());
     }
 
     /**
@@ -741,7 +747,7 @@ public abstract class OfflineImporter extends Importer {
                 ddl + ";\n",
                 DBObject.OBJ_TYPE_PK,
                 createResultHandler(pk),
-                config.isAddUserSchema()
+                config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
                         ? pk.getTable().getSourceOwner()
                         : config.getSrcConnOwner());
     }
@@ -764,7 +770,7 @@ public abstract class OfflineImporter extends Importer {
                 ddl + ";\n",
                 DBObject.OBJ_TYPE_FK,
                 createResultHandler(fk),
-                config.isAddUserSchema()
+                config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
                         ? fk.getTable().getSourceOwner()
                         : config.getSrcConnOwner());
     }
@@ -789,7 +795,7 @@ public abstract class OfflineImporter extends Importer {
                 ddl + ";\n",
                 DBObject.OBJ_TYPE_INDEX,
                 createResultHandler(index),
-                config.isAddUserSchema()
+                config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
                         ? index.getTable().getSourceOwner()
                         : config.getSrcConnOwner());
     }
@@ -806,7 +812,9 @@ public abstract class OfflineImporter extends Importer {
                 ddl + ";\n",
                 DBObject.OBJ_TYPE_SEQUENCE,
                 createResultHandler(sq),
-                config.isAddUserSchema() ? sq.getSourceOwner() : config.getSrcConnOwner());
+                config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
+                        ? sq.getSourceOwner()
+                        : config.getSrcConnOwner());
     }
 
     /**
@@ -821,7 +829,9 @@ public abstract class OfflineImporter extends Importer {
                 ddl + ";\n",
                 DBObject.OBJ_TYPE_SYNONYM,
                 createResultHandler(sn),
-                config.isAddUserSchema() ? sn.getSourceOwner() : config.getSrcConnOwner());
+                config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
+                        ? sn.getSourceOwner()
+                        : config.getSrcConnOwner());
     }
 
     /**
@@ -836,7 +846,9 @@ public abstract class OfflineImporter extends Importer {
                 ddl + ";\n",
                 DBObject.OBJ_TYPE_GRANT,
                 createResultHandler(gr),
-                config.isAddUserSchema() ? gr.getSourceOwner() : config.getSrcConnOwner(),
+                config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
+                        ? gr.getSourceOwner()
+                        : config.getSrcConnOwner(),
                 gr.getSourceObjectOwner());
     }
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
@@ -221,7 +221,7 @@ public class MigrationTasksScheduler {
                 schemaList = new ArrayList<Schema>(schemas);
             }
 
-            if (config.isAddUserSchema()) {
+            if (config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()) {
                 for (Schema schema : schemaList) {
                     deleteFile(config, schema.getName());
                 }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/CleanDBTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/CleanDBTask.java
@@ -80,6 +80,8 @@ public class CleanDBTask extends ImportTask {
         Map<String, List<String>> tbTruncateQueryBySchemaMap = new HashMap<String, List<String>>();
 
         String conUser = config.getSrcConnOwner();
+        boolean isSourceDBSupportMultiSchema =
+                config.getSrcCatalog().getDatabaseType().isSupportMultiSchema();
 
         for (SourceEntryTableConfig setc : config.getExpEntryTableCfg()) {
             if (!setc.isCreateNewTable()) {
@@ -102,7 +104,7 @@ public class CleanDBTask extends ImportTask {
 
                     divideQueryBySchema(
                             fkDropQueryBySchemaMap,
-                            config.isAddUserSchema() ? setc.getTargetOwner() : conUser,
+                            isSourceDBSupportMultiSchema ? setc.getTargetOwner() : conUser,
                             query.toString());
                     execDDL(query.toString());
                 }
@@ -124,7 +126,7 @@ public class CleanDBTask extends ImportTask {
 
                     divideQueryBySchema(
                             dropQueryBySchemaMap,
-                            config.isAddUserSchema() ? setc.getTargetOwner() : conUser,
+                            isSourceDBSupportMultiSchema ? setc.getTargetOwner() : conUser,
                             query.toString());
                     execDDL(query.toString());
                 }
@@ -143,11 +145,11 @@ public class CleanDBTask extends ImportTask {
 
                 divideQueryBySchema(
                         dropQueryBySchemaMap,
-                        config.isAddUserSchema() ? setc.getTargetOwner() : conUser,
+                        isSourceDBSupportMultiSchema ? setc.getTargetOwner() : conUser,
                         query.toString());
                 divideQueryBySchema(
                         tbTruncateQueryBySchemaMap,
-                        config.isAddUserSchema() ? setc.getTargetOwner() : conUser,
+                        isSourceDBSupportMultiSchema ? setc.getTargetOwner() : conUser,
                         query.toString().replaceAll("DROP", "TRUNCATE"));
                 execDDL(query.toString());
             }
@@ -165,11 +167,11 @@ public class CleanDBTask extends ImportTask {
 
                 divideQueryBySchema(
                         dropQueryBySchemaMap,
-                        config.isAddUserSchema() ? sstc.getTargetOwner() : conUser,
+                        isSourceDBSupportMultiSchema ? sstc.getTargetOwner() : conUser,
                         query.toString());
                 divideQueryBySchema(
                         tbTruncateQueryBySchemaMap,
-                        sstc.getTargetOwner(),
+                        isSourceDBSupportMultiSchema ? sstc.getTargetOwner() : conUser,
                         query.toString().replaceAll("DROP", "TRUNCATE"));
                 execDDL(query.toString());
             }
@@ -187,11 +189,11 @@ public class CleanDBTask extends ImportTask {
 
                 divideQueryBySchema(
                         dropQueryBySchemaMap,
-                        config.isAddUserSchema() ? scc.getTargetOwner() : conUser,
+                        isSourceDBSupportMultiSchema ? scc.getTargetOwner() : conUser,
                         query.toString());
                 divideQueryBySchema(
                         tbTruncateQueryBySchemaMap,
-                        config.isAddUserSchema() ? scc.getTargetOwner() : conUser,
+                        isSourceDBSupportMultiSchema ? scc.getTargetOwner() : conUser,
                         query.toString().replaceAll("DROP", "TRUNCATE"));
                 execDDL(query.toString());
             }
@@ -209,7 +211,7 @@ public class CleanDBTask extends ImportTask {
 
                 divideQueryBySchema(
                         dropQueryBySchemaMap,
-                        config.isAddUserSchema() ? sc.getTargetOwner() : conUser,
+                        isSourceDBSupportMultiSchema ? sc.getTargetOwner() : conUser,
                         query.toString());
                 execDDL(query.toString());
             }
@@ -227,7 +229,7 @@ public class CleanDBTask extends ImportTask {
 
                 divideQueryBySchema(
                         dropQueryBySchemaMap,
-                        config.isAddUserSchema() ? sc.getTargetOwner() : conUser,
+                        isSourceDBSupportMultiSchema ? sc.getTargetOwner() : conUser,
                         query.toString());
                 execDDL(query.toString());
             }
@@ -245,7 +247,7 @@ public class CleanDBTask extends ImportTask {
 
                 divideQueryBySchema(
                         dropQueryBySchemaMap,
-                        config.isAddUserSchema() ? sc.getTargetOwner() : conUser,
+                        isSourceDBSupportMultiSchema ? sc.getTargetOwner() : conUser,
                         query.toString());
                 execDDL(query.toString());
             }
@@ -260,7 +262,7 @@ public class CleanDBTask extends ImportTask {
                 schemaList = new ArrayList<Schema>(schemas);
             }
 
-            if (config.isAddUserSchema()) {
+            if (isSourceDBSupportMultiSchema) {
                 for (Schema schema : schemaList) {
                     String ownerName = schema.getName();
                     writeFile(dropQueryBySchemaMap, ownerName, CLEAR_SQL);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/SchemaFileListTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/SchemaFileListTask.java
@@ -63,7 +63,7 @@ public class SchemaFileListTask extends ImportTask {
     /** Execute import */
     @Override
     protected void executeImport() {
-        if (config.isAddUserSchema()) {
+        if (config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()) {
             List<Schema> schemaList = config.getTargetSchemaList();
             for (Schema schema : schemaList) {
                 String schemaName = schema.getName();

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -2373,7 +2373,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
             rs = stmt.executeQuery();
 
             while (rs.next()) {
-                schemaNames.add(rs.getString("name"));
+                schemaNames.add(rs.getString("name").toUpperCase(Locale.US));
             }
 
             if (schemaNames.isEmpty()) {
@@ -2406,7 +2406,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
         //		} else {
         //			result.add(cp.getDbName());
         //		}
-        result.add(cp.getConUser());
+        result.add(cp.getConUser().toUpperCase(Locale.US));
         return result;
     }
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/meta/InformixSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/meta/InformixSchemaFetcher.java
@@ -58,6 +58,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import org.apache.log4j.Logger;
 
@@ -140,7 +141,7 @@ public class InformixSchemaFetcher extends AbstractJDBCSchemaFetcher {
         List<String> result = new ArrayList<String>();
         ResultSet resultSet = conn.getMetaData().getSchemas();
         while (resultSet.next()) {
-            String name = resultSet.getString("TABLE_SCHEM");
+            String name = resultSet.getString("TABLE_SCHEM").toUpperCase(Locale.US);
             result.add(name);
         }
         return result;

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mssql/meta/MSSQLSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mssql/meta/MSSQLSchemaFetcher.java
@@ -67,6 +67,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -672,7 +673,7 @@ public final class MSSQLSchemaFetcher extends AbstractJDBCSchemaFetcher {
             stmt = conn.prepareStatement(SHOW_SCHEMA_ID.replace(CATALOG_NAME, cp.getDbName()));
             rs = stmt.executeQuery();
             while (rs.next()) {
-                String schemaName = rs.getString(2);
+                String schemaName = rs.getString(2).toUpperCase(Locale.US);
                 Integer schemaID = rs.getInt(1);
                 schemaNameIDMap.put(schemaName, schemaID);
                 schemaNames.add(schemaName);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -1773,7 +1773,7 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
             stmt = conn.createStatement();
             rs = stmt.executeQuery(sql);
             while (rs.next()) {
-                schemaNames.add(rs.getString(1));
+                schemaNames.add(rs.getString(1).toUpperCase(Locale.US));
             }
         } finally {
             Closer.close(rs);

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
@@ -236,7 +236,8 @@ public class ConfirmationPage extends BaseConfirmationPage {
 
             int oldLength;
             boolean isCreateFileRepository = false;
-            boolean isAddUserSchema = migration.isAddUserSchema();
+            boolean isAddUserSchema =
+                    migration.getSrcCatalog().getDatabaseType().isSupportMultiSchema();
             String conUser = migration.getSrcConnOwner();
 
             if (migration.isSplitSchema()) {

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -788,7 +788,9 @@ public class SchemaMappingPage extends MigrationWizardPage {
             targetSchemaList.add(schema);
 
             String schemaName =
-                    config.isAddUserSchema() ? srcTable.getSrcSchema() : config.getSrcConnOwner();
+                    srcCatalog.getDatabaseType().isSupportMultiSchema()
+                            ? srcTable.getSrcSchema()
+                            : config.getSrcConnOwner();
 
             if (splitSchema) {
                 tableFullName.put(
@@ -881,7 +883,7 @@ public class SchemaMappingPage extends MigrationWizardPage {
     private boolean checkFileRepository() {
         StringBuffer buffer = new StringBuffer();
 
-        if (config.isAddUserSchema()) {
+        if (srcCatalog.getDatabaseType().isSupportMultiSchema()) {
             for (SrcTable srcTable : srcTableList) {
                 if (!srcTable.isSelected) {
                     continue;


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4612

**Purpose**
This problem occurs because the case is not uniform when importing the schema name from the source database.
We would like to solve the problem by unifying the database schema names supported by CMT so that they can all be imported in uppercase letters.

**Implementation**
- Change schema name received from source DB to uppercase
- Changed to check whether the source DB supports multi-schema

**Remarks**
N/A