### PR TITLE
[TOOLS-4607] View query generation fails during migration

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/JDBCImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/JDBCImporter.java
@@ -152,8 +152,10 @@ public class JDBCImporter extends Importer {
                 CUBRIDSQLHelper.getInstance(null).getViewAlterDDL(view, config.isAddUserSchema());
         view.setAlterDDL(viewAlterDDL);
         try {
-            executeDDL(viewAlterDDL);
-            createObjectSuccess(view);
+            if (!viewAlterDDL.equals(CUBRIDSQLHelper.SQL_NULL)) {
+                executeDDL(viewAlterDDL);
+                createObjectSuccess(view);
+            }
         } catch (RuntimeException e) {
             createObjectFailed(view, e);
         }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -714,6 +714,10 @@ public abstract class OfflineImporter extends Importer {
     public void alterView(View view) {
         String viewAlterDDL =
                 CUBRIDSQLHelper.getInstance(null).getViewAlterDDL(view, config.isAddUserSchema());
+        if (viewAlterDDL.equals(CUBRIDSQLHelper.SQL_NULL)) {
+            return;
+        }
+
         view.setAlterDDL(viewAlterDDL);
         executeDDL(
                 viewAlterDDL + "\n",

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/DefaultMigrationReporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/DefaultMigrationReporter.java
@@ -52,6 +52,7 @@ import com.cubrid.cubridmigration.core.engine.event.MigrationStartEvent;
 import com.cubrid.cubridmigration.core.engine.event.MigrationXLSNoSupportEvent;
 import com.cubrid.cubridmigration.core.engine.event.StartExpTableEvent;
 import com.cubrid.cubridmigration.core.engine.template.MigrationTemplateParser;
+import com.cubrid.cubridmigration.cubrid.CUBRIDSQLHelper;
 import com.cubrid.cubridmigration.cubrid.CUBRIDTimeUtil;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -183,7 +184,10 @@ public abstract class DefaultMigrationReporter implements IMigrationReporter {
                 dbor.setSucceed(true);
                 dbor.setDdl(ev.getDbObject().getDDL());
                 if (ev.getDbObject().getObjType() == DBObject.OBJ_TYPE_VIEW) {
-                    dbor.setDdl(dbor.getDdl() + "\n" + ((View) ev.getDbObject()).getAlterDDL());
+                    String viewAlterDDL = ((View) ev.getDbObject()).getAlterDDL();
+                    if (!viewAlterDDL.equals(CUBRIDSQLHelper.SQL_NULL)) {
+                        dbor.setDdl(dbor.getDdl() + "\n" + viewAlterDDL);
+                    }
                 }
             } else {
                 DBObjMigrationResult dbor = report.getDBObjResult(ev.getDbObject());

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
@@ -49,7 +49,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
@@ -79,6 +80,7 @@ public class CUBRIDSQLHelper extends SQLHelper {
     private static final String NEWLINE = "\n";
     private static final String HINT = "/*+ NO_STATS */";
     private static final String END_LINE_CHAR = ";";
+    public static final String SQL_NULL = "null";
 
     private static final CUBRIDSQLHelper HELPER = new CUBRIDSQLHelper();
 
@@ -683,6 +685,11 @@ public class CUBRIDSQLHelper extends SQLHelper {
      * @return String
      */
     public String getViewAlterDDL(View view, boolean addUserSchema) {
+        String viewQuerySpec = view.getQuerySpec();
+        if (viewQuerySpec == null || viewQuerySpec.isEmpty()) {
+            return SQL_NULL;
+        }
+
         StringBuffer sb = new StringBuffer();
         sb.append("ALTER VIEW ");
         String viewName = view.getName();
@@ -692,8 +699,8 @@ public class CUBRIDSQLHelper extends SQLHelper {
             sb.append(getQuotedObjName(viewName));
         }
 
-        sb.append(" ADD").append(" QUERY ").append(view.getQuerySpec());
-        sb.append(END_LINE_CHAR);
+        sb.append(" ADD").append(" QUERY ").append(viewQuerySpec);
+        sb.append(viewQuerySpec.endsWith(END_LINE_CHAR) ? "" : END_LINE_CHAR);
 
         return sb.toString();
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4607

**Purpose**
Fix the view alter query so that it is not executed when migrating a view with empty columns.

**Implementation**
N/A

**Remarks**
N/A