### PR TITLE
[TOOLS-4625] Directory not created with changed script name during console migration after script export

### DIFF
--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
@@ -152,7 +152,6 @@ public class StartCommandHandler implements ConsoleCommandHandler {
     private MigrationConfiguration getConfig(String file) {
         try {
             MigrationConfiguration config = MigrationTemplateParser.parse(file);
-            config.setName(new File(file).getName());
             if (!initializeSource(config) || !initializeTarget(config)) {
                 printHelp();
                 return null;


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4625

**Purpose**
Modify the script export functionality so that if the user changes the name of the script, a directory is created with the new name.

**Implementation**
N/A

**Remarks**
N/A