### PR TITLE
[TOOLS-4626] When exporting the script, the 'schemas' tag is output in an incomplete state

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateParser.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateParser.java
@@ -819,6 +819,19 @@ public final class MigrationTemplateParser {
                 schemaElement.setAttribute(
                         TemplateTags.ATTR_TARGET_SCHEMA, schema.getTargetSchemaName());
             }
+        } else {
+            config.getScriptSchemaMapping()
+                    .forEach(
+                            (schemaName, schema) -> {
+                                Element schemaElement =
+                                        createElement(
+                                                document, schemas, TemplateTags.TAG_SCHEMA_INFO);
+                                schemaElement.setAttribute(
+                                        TemplateTags.ATTR_SCHEMA_NAME, schema.getName());
+                                schemaElement.setAttribute(
+                                        TemplateTags.ATTR_TARGET_SCHEMA,
+                                        schema.getTargetSchemaName());
+                            });
         }
 
         // tables


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4626

**Purpose**
When exporting a saved script, the 'schemas' tag is output in an incomplete state. Modify to ensure the tag is generated correctly.

**Implementation**
N/A

**Remarks**
N/A