### PR TITLE
[TOOLS-4595] Error where windows is cut off in migration tool

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCPatternDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCPatternDialog.java
@@ -31,6 +31,7 @@
 package com.cubrid.cubridmigration.ui.database;
 
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.ui.common.CompositeUtils;
 import com.cubrid.cubridmigration.ui.message.Messages;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jface.dialogs.IDialogConstants;
@@ -69,12 +70,11 @@ public class JDBCPatternDialog extends TitleAreaDialog {
     protected void configureShell(Shell newShell) {
         super.configureShell(newShell);
         newShell.setText(Messages.jdbcPatternTitle);
-        newShell.setSize(480, 240);
         Composite parent = newShell.getParent();
         if (parent == null) {
             parent = newShell;
         }
-        newShell.setBounds(parent.getBounds().x, parent.getBounds().y, 480, 240);
+        CompositeUtils.centerDialog(newShell);
     }
 
     /**
@@ -103,7 +103,7 @@ public class JDBCPatternDialog extends TitleAreaDialog {
         panel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
         Label lblURL = new Label(panel, SWT.NONE);
-        lblURL.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false));
+        lblURL.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
         lblURL.setText("JDBC URL:");
 
         txtURL = new Text(panel, SWT.BORDER);

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/history/dialog/OpenWizardWithHistoryDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/history/dialog/OpenWizardWithHistoryDialog.java
@@ -105,7 +105,6 @@ public class OpenWizardWithHistoryDialog extends Dialog {
     /** constrainShellSize */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(700, 250);
         getShell().setText(Messages.msgErrorMigrationTitle);
     }
 

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/history/dialog/ShowTextDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/history/dialog/ShowTextDialog.java
@@ -38,7 +38,6 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.dialogs.TrayDialog;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/history/dialog/ShowTextDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/history/dialog/ShowTextDialog.java
@@ -163,15 +163,6 @@ public class ShowTextDialog extends TrayDialog {
     }
 
     /**
-     * The initial size of dialog
-     *
-     * @return Point
-     */
-    protected Point getInitialSize() {
-        return new Point(650, 500);
-    }
-
-    /**
      * Remove help button
      *
      * @return false

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/product/CopyrightDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/product/CopyrightDialog.java
@@ -40,7 +40,6 @@ import org.eclipse.jface.dialogs.TrayDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -154,5 +153,4 @@ public class CopyrightDialog extends TrayDialog {
         }
         super.buttonPressed(buttonId);
     }
-
 }

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/product/CopyrightDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/product/CopyrightDialog.java
@@ -155,7 +155,4 @@ public class CopyrightDialog extends TrayDialog {
         super.buttonPressed(buttonId);
     }
 
-    protected Point getInitialSize() {
-        return new Point(650, 500);
-    }
 }

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/CopyScriptDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/CopyScriptDialog.java
@@ -113,7 +113,6 @@ public class CopyScriptDialog extends Dialog {
     /** constrainShellSize */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(450, 162);
         getShell().setText(Messages.titleNewScript);
     }
 

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/EditScriptDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/EditScriptDialog.java
@@ -148,7 +148,6 @@ public class EditScriptDialog extends Dialog {
     /** constrainShellSize */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(450, 162);
         getShell().setText(Messages.titleEditScript);
         CompositeUtils.centerDialog(getShell());
     }

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/KerberosSettingsDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/KerberosSettingsDialog.java
@@ -177,7 +177,6 @@ public class KerberosSettingsDialog extends Dialog {
     /** @param newShell Shell */
     protected void configureShell(Shell newShell) {
         super.configureShell(newShell);
-        newShell.setSize(500, 160);
         CompositeUtils.centerDialog(newShell);
         newShell.setText("Kerberos Environment Settings");
     }

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/SSHProxyDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/SSHProxyDialog.java
@@ -132,7 +132,6 @@ public class SSHProxyDialog extends Dialog {
      */
     protected void configureShell(Shell newShell) {
         newShell.setMinimumSize(300, 330);
-        newShell.setSize(500, 330);
         CompositeUtils.centerDialog(newShell);
         newShell.setText("SSH Proxy Settings");
         super.configureShell(newShell);

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/ScheduleMigrationTaskDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/ScheduleMigrationTaskDialog.java
@@ -45,7 +45,6 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/ScheduleMigrationTaskDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/ScheduleMigrationTaskDialog.java
@@ -320,15 +320,6 @@ public class ScheduleMigrationTaskDialog extends Dialog {
     }
 
     /**
-     * The initial size of dialog
-     *
-     * @return Point
-     */
-    protected Point getInitialSize() {
-        return new Point(400, 300);
-    }
-
-    /**
      * Remove help button
      *
      * @return false

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/TransFileBySSHDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/TransFileBySSHDialog.java
@@ -113,7 +113,6 @@ public class TransFileBySSHDialog extends Dialog {
      */
     protected void configureShell(Shell newShell) {
         newShell.setMinimumSize(300, 600);
-        newShell.setSize(500, 600);
         CompositeUtils.centerDialog(newShell);
         super.configureShell(newShell);
     }

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/AdjustCharColumnDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/AdjustCharColumnDialog.java
@@ -399,7 +399,6 @@ public class AdjustCharColumnDialog extends Dialog {
     /** constrainShellSize */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(820, 540);
         getShell().setText(Messages.titleSettingCharTypeColumns);
     }
 

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CSVImportSettingDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CSVImportSettingDialog.java
@@ -148,7 +148,6 @@ public class CSVImportSettingDialog extends Dialog {
     /** constrainShellSize */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(400, 360);
         getShell().setText(Messages.titleCSVSettings);
     }
 

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CSVSettingsDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CSVSettingsDialog.java
@@ -100,7 +100,6 @@ public class CSVSettingsDialog extends Dialog {
     /** constrainShellSize */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(400, 210);
         getShell().setText(Messages.titleCSVSettings);
     }
 

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CUBRIDHadoopFSExplorer.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CUBRIDHadoopFSExplorer.java
@@ -69,7 +69,6 @@ import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CUBRIDHadoopFSExplorer.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CUBRIDHadoopFSExplorer.java
@@ -565,11 +565,6 @@ public class CUBRIDHadoopFSExplorer extends Dialog {
         return new ArrayList<String>(hdfsFiles);
     }
 
-    /** @return dialog size */
-    protected Point getInitialSize() {
-        return new Point(640, 480);
-    }
-
     /** Refresh root path text */
     private void gotoPath() {
         final String hdfs = getFullPath(txtRootPath.getText().trim());

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CUBRIDHadoopFileDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CUBRIDHadoopFileDialog.java
@@ -119,8 +119,4 @@ public class CUBRIDHadoopFileDialog extends Dialog {
         return new ArrayList<String>(hdfsPath);
     }
 
-    /** @return dialog size */
-    protected Point getInitialSize() {
-        return new Point(480, 160);
-    }
 }

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CUBRIDHadoopFileDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/CUBRIDHadoopFileDialog.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -118,5 +117,4 @@ public class CUBRIDHadoopFileDialog extends Dialog {
     public List<String> getHdfsPath() {
         return new ArrayList<String>(hdfsPath);
     }
-
 }

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/MigrationRunModeDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/MigrationRunModeDialog.java
@@ -67,7 +67,6 @@ public class MigrationRunModeDialog extends Dialog {
     /** constrainShellSize */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(480, 258);
         UICommonTool.centerShell(getShell());
     }
 

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/RenameSchemaDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/RenameSchemaDialog.java
@@ -252,7 +252,6 @@ public class RenameSchemaDialog extends TitleAreaDialog {
     /** constrainShellSize */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(540, 405);
         getShell().setText(Messages.msgSchemaInformation);
     }
 

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/SQLEditorDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/SQLEditorDialog.java
@@ -135,7 +135,6 @@ public class SQLEditorDialog extends TitleAreaDialog {
     /** constrainShellSize */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(700, 480);
         getShell().setText(Messages.addSQLDialogShellTitle);
         // TODO: Show supporting pagination query message.
         if (config.sourceIsOnline() && config.getSourceDBType().equals(DatabaseType.MSSQL)) {

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/SelectSchemaDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/SelectSchemaDialog.java
@@ -99,7 +99,6 @@ public class SelectSchemaDialog extends Dialog {
     protected void configureShell(Shell newShell) {
         super.configureShell(newShell);
         newShell.setText("Select Schemas");
-        newShell.setSize(320, 400);
         // Adjust dialog position.
         if (newShell.getParent() != null) {
             Point location = newShell.getParent().getLocation();

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/TableIndexSelectorDialog.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/dialog/TableIndexSelectorDialog.java
@@ -199,7 +199,6 @@ public class TableIndexSelectorDialog extends Dialog {
     /** constrainShellSize */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(720, 540);
         getShell().setText(Messages.lblSelectIndexes);
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4595

Purpose
Modify not cut off for all dialog windows.

Implementation
- Remove forced window size adjustment for dialog window.

Remarks
N/A