### PR TITLE
[TOOLS-4628] File not created during XLS migration

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/FileMergeRunnable.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/FileMergeRunnable.java
@@ -103,6 +103,11 @@ public class FileMergeRunnable implements Runnable, IMigrationTask {
             srcWB = Workbook.getWorkbook(new File(sourceFile));
             Sheet sheet = srcWB.getSheet(0);
 
+            File targetXLSFile = new File(targetFile);
+            if (!targetXLSFile.exists()) {
+                PathUtils.createFile(targetXLSFile);
+            }
+
             WorkbookSettings tarWS = new WorkbookSettings();
             tarWS.setEncoding(targetCharset);
             final File tarFile = new File(targetFile);


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4628

**Purpose**
Add file creation confirmation logic to create a file if it does not exist.

**Implementation**
N/A

**Remarks**
N/A