### PR TITLE
[TOOLS-4629] Fix Oracle comments not migrating during console migration

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -515,7 +515,7 @@ public class MigrationConfiguration {
      * @param viewName String
      * @param target String
      */
-    public void addExpViewCfg(String schema, String viewName, String target) {
+    public void addExpViewCfg(String schema, String viewName, String target, String comment) {
         if (srcCatalog != null) {
             throw new RuntimeException("Source database was specified.");
         }
@@ -524,6 +524,7 @@ public class MigrationConfiguration {
             sc = new SourceViewConfig();
             sc.setName(viewName);
             sc.setOwner(schema);
+            sc.setComment(comment);
             expViews.add(sc);
         }
         sc.setTarget(StringUtils.lowerCase(target));
@@ -1082,7 +1083,7 @@ public class MigrationConfiguration {
         for (Schema sourceDBSchema : schemas) {
             String prefix = "";
             if (StringUtils.isNotBlank(sourceDBSchema.getName())) {
-                prefix = sourceDBSchema.getTargetSchemaName() + ".";
+                prefix = sourceDBSchema.getName() + ".";
             }
             for (Table srcTable : sourceDBSchema.getTables()) {
                 SourceEntryTableConfig setc =

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateHandler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateHandler.java
@@ -277,6 +277,7 @@ public final class MigrationTemplateHandler extends DefaultHandler {
         if (StringUtils.isEmpty(type)) {
             System.out.println(targetTable.getName() + ":" + column.getName());
         }
+        column.setComment(attributes.getValue(TemplateTags.ATTR_COMMENT));
         dtHelper.setColumnDataType(type, column);
         targetTable.addColumn(column);
         // column.setUnique(unique);
@@ -462,7 +463,7 @@ public final class MigrationTemplateHandler extends DefaultHandler {
                 targetTable.setOwner(null);
             }
         }
-
+        targetTable.setComment(attributes.getValue(TemplateTags.ATTR_COMMENT));
         config.addTargetTableSchema(targetTable);
     }
 
@@ -477,6 +478,7 @@ public final class MigrationTemplateHandler extends DefaultHandler {
         targetView.setTargetOwner(attributes.getValue(TemplateTags.ATTR_TARGET_OWNER));
         targetView.setName(attributes.getValue(TemplateTags.ATTR_NAME));
         targetView.setSourceOwner(attributes.getValue(TemplateTags.ATTR_SOURCE_OWNER));
+        targetView.setComment(attributes.getValue(TemplateTags.ATTR_COMMENT));
         config.addTargetViewSchema(targetView);
     }
 
@@ -490,6 +492,7 @@ public final class MigrationTemplateHandler extends DefaultHandler {
         targetView.addColumn(column);
         column.setTableOrView(targetView);
         column.setName(attributes.getValue(TemplateTags.ATTR_NAME));
+        column.setComment(attributes.getValue(TemplateTags.ATTR_COMMENT));
         dtHelper.setColumnDataType(attributes.getValue(TemplateTags.ATTR_TYPE), column);
     }
 
@@ -653,6 +656,7 @@ public final class MigrationTemplateHandler extends DefaultHandler {
                     getBoolean(attributes.getValue(TemplateTags.ATTR_EXP_OPT_COL), true));
             setc.setStartFromTargetMax(
                     getBoolean(attributes.getValue(TemplateTags.ATTR_START_TAR_MAX), false));
+            setc.setComment(attributes.getValue(TemplateTags.ATTR_COMMENT));
             config.addExpEntryTableCfg(setc);
 
         } else if (TemplateTags.TAG_COLUMN.equals(qName)) {
@@ -663,6 +667,7 @@ public final class MigrationTemplateHandler extends DefaultHandler {
             scc.setNeedTrim(getBoolean(attributes.getValue(TemplateTags.ATTR_TRIM), false));
             scc.setReplaceExpression(attributes.getValue(TemplateTags.ATTR_REPLACE_EXPRESSION));
             scc.setUserDataHandler(attributes.getValue(TemplateTags.ATTR_USER_DATA_HANDLER));
+            scc.setComment(attributes.getValue(TemplateTags.ATTR_COMMENT));
         } else if (TemplateTags.TAG_FK.equals(qName)) {
             ((SourceEntryTableConfig) srcTableCfg)
                     .addFKConfig(
@@ -712,7 +717,8 @@ public final class MigrationTemplateHandler extends DefaultHandler {
             config.addExpViewCfg(
                     attributes.getValue(TemplateTags.ATTR_OWNER),
                     attributes.getValue(TemplateTags.ATTR_NAME),
-                    attributes.getValue(TemplateTags.ATTR_TARGET));
+                    attributes.getValue(TemplateTags.ATTR_TARGET),
+                    attributes.getValue(TemplateTags.ATTR_COMMENT));
         } else if (TemplateTags.TAG_GRANT.equals(qName)) {
             config.addExpGrantCfg(
                     attributes.getValue(TemplateTags.ATTR_OWNER),

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateParser.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateParser.java
@@ -346,6 +346,7 @@ public final class MigrationTemplateParser {
                 colNode.setAttribute(TemplateTags.ATTR_NAME, col.getName());
                 colNode.setAttribute(TemplateTags.ATTR_TYPE, col.getShownDataType());
                 colNode.setAttribute(TemplateTags.ATTR_BASE_TYPE, col.getDataType());
+                colNode.setAttribute(TemplateTags.ATTR_COMMENT, col.getComment());
                 if (col.getSubDataType() != null) {
                     colNode.setAttribute(TemplateTags.ATTR_SUB_TYPE, col.getSubDataType());
                 }
@@ -449,6 +450,7 @@ public final class MigrationTemplateParser {
             table.setAttribute(
                     TemplateTags.ATTR_REUSE_OID, getBooleanString(targetTable.isReuseOID()));
             table.setAttribute(TemplateTags.ATTR_SOURCE_OWNER, targetTable.getSourceOwner());
+            table.setAttribute(TemplateTags.ATTR_COMMENT, targetTable.getComment());
 
             Element columns = createElement(document, table, TemplateTags.TAG_COLUMNS);
             List<Column> cols = targetTable.getColumns();
@@ -460,6 +462,7 @@ public final class MigrationTemplateParser {
                 colNode.setAttribute(TemplateTags.ATTR_NULL, getBooleanString(col.isNullable()));
                 colNode.setAttribute(
                         TemplateTags.ATTR_AUTO_INCREMENT, getBooleanString(col.isAutoIncrement()));
+                colNode.setAttribute(TemplateTags.ATTR_COMMENT, col.getComment());
 
                 colNode.setAttribute(TemplateTags.ATTR_UNIQUE, getBooleanString(col.isUnique()));
                 colNode.setAttribute(TemplateTags.ATTR_SHARED, getBooleanString(col.isShared()));
@@ -864,6 +867,7 @@ public final class MigrationTemplateParser {
             tbe.setAttribute(TemplateTags.ATTR_TARGET_SCHEMA, setc.getTargetOwner());
             tbe.setAttribute(
                     TemplateTags.ATTR_CHANGE_NAME, getBooleanString(setc.isChangeTableName()));
+            tbe.setAttribute(TemplateTags.ATTR_COMMENT, setc.getComment());
             if (setc.isEnableExpOpt()) {
                 tbe.setAttribute(
                         TemplateTags.ATTR_EXP_OPT_COL, getBooleanString(setc.isEnableExpOpt()));
@@ -881,6 +885,7 @@ public final class MigrationTemplateParser {
                 col.setAttribute(TemplateTags.ATTR_TRIM, getBooleanString(scc.isNeedTrim()));
                 col.setAttribute(TemplateTags.ATTR_REPLACE_EXPRESSION, scc.getReplaceExp());
                 col.setAttribute(TemplateTags.ATTR_USER_DATA_HANDLER, scc.getUserDataHandler());
+                col.setAttribute(TemplateTags.ATTR_COMMENT, scc.getComment());
             }
 
             List<SourceIndexConfig> indexConfigList = setc.getIndexConfigList();
@@ -971,6 +976,7 @@ public final class MigrationTemplateParser {
                 vwNode.setAttribute(TemplateTags.ATTR_OWNER, sc.getOwner());
                 vwNode.setAttribute(TemplateTags.ATTR_NAME, sc.getName());
                 vwNode.setAttribute(TemplateTags.ATTR_TARGET, sc.getTarget());
+                vwNode.setAttribute(TemplateTags.ATTR_COMMENT, sc.getComment());
             }
         }
         // source grants

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
@@ -50,6 +50,7 @@ public final class TemplateTags {
     public static final String ATTR_CACHE_SIZE = "cache_size";
     public static final String ATTR_CHANGE_NAME = "change_name";
     public static final String ATTR_CHARSET = "charset";
+    public static final String ATTR_COMMENT = "comment";
     public static final String ATTR_COMMIT_COUNT = "commit_count";
     public static final String ATTR_CREATE = "create";
     public static final String ATTR_CREATE_USER_SQL = "create_user_sql";

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
@@ -150,8 +150,8 @@ public class CUBRIDSQLHelper extends SQLHelper {
         if (!column.isNullable() && isNotPKColumn) {
             bf.append(" NOT NULL");
         }
-        if (column.getComment() != null) {
-            bf.append(" comment \'" + column.getComment() + "\'");
+        if (column.getComment() != null && !column.getComment().isEmpty()) {
+            bf.append(" COMMENT \'" + column.getComment() + "\'");
         }
         if (column.isShared() || !column.isUnique() || !isNotPKColumn) {
             return bf.toString();
@@ -490,8 +490,8 @@ public class CUBRIDSQLHelper extends SQLHelper {
         if (table.isReuseOID()) {
             bf.append(" REUSE_OID");
         }
-        if (table.getComment() != null) {
-            bf.append(" comment = \'" + table.getComment() + "\'");
+        if (table.getComment() != null && !table.getComment().isEmpty()) {
+            bf.append(" COMMENT = \'" + table.getComment() + "\'");
         }
         if (DBUtils.supportedCubridPartition(table.getPartitionInfo())) {
             bf.append(NEWLINE).append(table.getPartitionInfo().getDDL());
@@ -662,14 +662,14 @@ public class CUBRIDSQLHelper extends SQLHelper {
                 sb.append(getQuotedObjName(col.getName()));
                 sb.append(" ").append(col.getShownDataType());
 
-                if (col.getComment() != null) {
-                    sb.append(" COMMENT ").append(col.getComment());
+                if (col.getComment() != null && !col.getComment().isEmpty()) {
+                    sb.append(" COMMENT \'").append(col.getComment()).append("\'");
                 }
             }
             sb.append(NEWLINE).append(")");
         }
 
-        if (view.getComment() != null) {
+        if (view.getComment() != null && !view.getComment().isEmpty()) {
             sb.append(" ").append("COMMENT \'" + view.getComment() + "\'");
         }
         sb.append(NEWLINE).append(END_LINE_CHAR);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -1299,7 +1299,7 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 comment = commentEditor(comment);
             }
 
-            return "\'" + comment + "\'";
+            return comment;
         } catch (Exception e) {
             e.printStackTrace();
             return null;


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4629

**Purpose**
Fixes the issue where comments on tables, views, and columns in Oracle databases are not migrated during the console migration process.

**Implementation**
N/A

**Remarks**
N/A