### PR TITLE
[TOOLS-4631] Change default Java memory settings

### DIFF
--- a/com.cubrid.cubridmigration.console/console-tar.xml
+++ b/com.cubrid.cubridmigration.console/console-tar.xml
@@ -11,6 +11,7 @@
        <includes>
          <include>migration.sh</include>
        </includes>
+	   <fileMode>755</fileMode>
      </fileSet>
      
      <fileSet>

--- a/com.cubrid.cubridmigration.console/migration.bat
+++ b/com.cubrid.cubridmigration.console/migration.bat
@@ -1,4 +1,4 @@
 @echo off
 SET fn=%1 %2 %3 %4 %5 %6 %7 %8 %9
-java -Xms40M -Xmx1024M -jar com.cubrid.cubridmigration.command-1.0.0-SNAPSHOT.jar %fn%
+java -Xms1024M -Xmx4096M -jar com.cubrid.cubridmigration.command-1.0.0-SNAPSHOT.jar %fn%
 @echo on

--- a/com.cubrid.cubridmigration.console/migration.sh
+++ b/com.cubrid.cubridmigration.console/migration.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 DIR=$PWD
-java -jar -Xms 1024M -Xmx 4096M $DIR/com.cubrid.cubridmigration.command-1.0.0-SNAPSHOT.jar "$@"
+java -jar -Xms1024M -Xmx4096M $DIR/com.cubrid.cubridmigration.command-1.0.0-SNAPSHOT.jar "$@"

--- a/com.cubrid.cubridmigration.console/migration.sh
+++ b/com.cubrid.cubridmigration.console/migration.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 DIR=$PWD
-java -jar $DIR/com.cubrid.cubridmigration.command-1.0.0-SNAPSHOT.jar "$@"
+java -jar -Xms 1024M -Xmx 4096M $DIR/com.cubrid.cubridmigration.command-1.0.0-SNAPSHOT.jar "$@"

--- a/com.cubrid.cubridmigration.product/cubridmigration.product
+++ b/com.cubrid.cubridmigration.product/cubridmigration.product
@@ -7,13 +7,7 @@
 
    <launcherArgs>
       <programArgsMac>-vm ../Eclipse/jre/Contents/Home/bin/java</programArgsMac>
-      <vmArgs>-Xms400M
--Xmx800M
--XX:PermSize=64M
--XX:MaxPermSize=256M
--XX:+UnlockExperimentalVMOptions 
--XX:+UseG1GC
--XX:+IgnoreUnrecognizedVMOptions --add-modules=ALL-SYSTEM -Dosgi.requiredJavaVersion=1.8</vmArgs>
+      <vmArgs>-Xms1024M -Xmx4096M -Dosgi.requiredJavaVersion=1.8</vmArgs>
       <vmArgsMac>-XstartOnFirstThread </vmArgsMac>
    </launcherArgs>
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4631

**Purpose**
Change the default Java memory settings as follows:

- Xms: 1024M
- Xmx: 4096M
- XX:permSize: remove
- XX:MaxPermSize: remove
- XX:+UnlockExperimentalVMOptions: remove
- +UseG1GC: remove
- XX:+IgnoreUnrecognizedVMOptions: remove
- --add-modules=ALL-SYSTEM: remove

**Implementation**
N/A

**Remarks**
N/A