### PR TITLE
[TOOLS-4633] View query creation fails due to quotation marks twice in comments

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -1522,10 +1522,6 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
 
                 column.setPrecision(prec);
                 column.setScale(scale);
-
-                if (comment != null) {
-                    comment = "\'" + comment + "\'";
-                }
                 column.setComment(comment);
                 table.addColumn(column);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4633

**Purpose**
Fixing a problem that fails to create a view query by using quotation marks twice in comments

**Implementation**
N/A

**Remarks**
N/A