### PR TITLE
[TOOLS-4635] Fix incorrect file directory creation after renaming to 'Save New Script' in Step 6

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
@@ -30,10 +30,15 @@
  */
 package com.cubrid.cubridmigration.core.common;
 
+import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -499,6 +504,142 @@ public final class PathUtils {
         for (File ff : files) {
             CUBRIDIOUtils.clearFileOrDir(ff);
         }
+    }
+
+    /** Change the script name part of the local file path */
+    public static void changeLocalFilePath(MigrationConfiguration config) {
+        String fileRootPath = config.getFileRepositroyPath();
+        String oldName = config.getOldName();
+        String newName = config.getName();
+
+        if (oldName == null) {
+            return;
+        }
+
+        // schema
+        config.setTargetSchemaFileName(
+                changeOldNameToNewName(
+                        config.getTargetSchemaFileName(), fileRootPath, oldName, newName));
+
+        // class
+        config.setTargetTableFileName(
+                changeOldNameToNewName(
+                        config.getTargetTableFileName(), fileRootPath, oldName, newName));
+
+        // vclass
+        config.setTargetViewFileName(
+                changeOldNameToNewName(
+                        config.getTargetViewFileName(), fileRootPath, oldName, newName));
+
+        // vclass_query_spec
+        config.setTargetViewQuerySpecFileName(
+                changeOldNameToNewName(
+                        config.getTargetViewQuerySpecFileName(), fileRootPath, oldName, newName));
+
+        // objects
+        config.setTargetDataFileName(
+                changeOldNameToNewName(
+                        config.getTargetDataFileName(), fileRootPath, oldName, newName));
+
+        // index
+        config.setTargetIndexFileName(
+                changeOldNameToNewName(
+                        config.getTargetIndexFileName(), fileRootPath, oldName, newName));
+
+        // pk
+        config.setTargetPkFileName(
+                changeOldNameToNewName(
+                        config.getTargetPkFileName(), fileRootPath, oldName, newName));
+
+        // fk
+        config.setTargetFkFileName(
+                changeOldNameToNewName(
+                        config.getTargetFkFileName(), fileRootPath, oldName, newName));
+
+        // serial
+        config.setTargetSerialFileName(
+                changeOldNameToNewName(
+                        config.getTargetSerialFileName(), fileRootPath, oldName, newName));
+
+        // synonym
+        config.setTargetSynonymFileName(
+                changeOldNameToNewName(
+                        config.getTargetSynonymFileName(), fileRootPath, oldName, newName));
+
+        // grant
+        Map<String, Map<String, String>> newGrantFilePathMap = new HashMap<>();
+        Map<String, Map<String, String>> grantFilePathMap = config.getTargetGrantFileName();
+        for (String schemaName : grantFilePathMap.keySet()) {
+            Map<String, String> grantFilePath = grantFilePathMap.get(schemaName);
+            if (grantFilePath != null) {
+                newGrantFilePathMap.put(
+                        schemaName,
+                        changeOldNameToNewName(grantFilePath, fileRootPath, oldName, newName));
+            }
+        }
+        config.setTargetGrantFileName(newGrantFilePathMap);
+
+        // updatestatistic
+        config.setTargetUpdateStatisticFileName(
+                changeOldNameToNewName(
+                        config.getTargetUpdateStatisticFileName(), fileRootPath, oldName, newName));
+
+        // info
+        config.setTargetSchemaFileListName(
+                changeOldNameToNewName(
+                        config.getTargetSchemaFileListName(), fileRootPath, oldName, newName));
+
+        // table data file
+        Map<String, List<String>> newTableDataFilePath = new HashMap<>();
+        config.getTargetTableDataFileName()
+                .forEach(
+                        (schemaName, tableDataFilePathList) -> {
+                            newTableDataFilePath.put(
+                                    schemaName,
+                                    changeOldNameToNewName(
+                                            tableDataFilePathList, fileRootPath, oldName, newName));
+                        });
+        config.setTargetTableDataFileName(newTableDataFilePath);
+    }
+
+    /** change directory path */
+    private static List<String> changeOldNameToNewName(
+            List<String> filePath, String fileRootPath, String oldName, String newName) {
+        List<String> newFilePath = new ArrayList<String>();
+        filePath.forEach(
+                path -> {
+                    String newPath = removeRootPath(path, fileRootPath).replace(oldName, newName);
+                    newFilePath.add(addRootPath(newPath, fileRootPath));
+                });
+        return newFilePath;
+    }
+
+    /** change directory path */
+    private static Map<String, String> changeOldNameToNewName(
+            Map<String, String> filePath, String fileRootPath, String oldName, String newName) {
+        Map<String, String> newFilePath = new HashMap<>();
+        filePath.forEach(
+                (schemaName, path) -> {
+                    String newPath = removeRootPath(path, fileRootPath).replace(oldName, newName);
+                    newFilePath.put(schemaName, addRootPath(newPath, fileRootPath));
+                });
+        return newFilePath;
+    }
+
+    /** add file root path */
+    private static String addRootPath(String filePath, String fileRootPath) {
+        if (filePath.startsWith(fileRootPath)) {
+            return filePath;
+        }
+        return fileRootPath + filePath;
+    }
+
+    /** remove file root path */
+    private static String removeRootPath(String fileFullPath, String fileRootPath) {
+        if (fileFullPath.startsWith(fileRootPath)) {
+            return fileFullPath.substring(fileRootPath.length());
+        }
+        return fileFullPath;
     }
 
     // Constructor

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
@@ -51,7 +51,6 @@ import com.cubrid.cubridmigration.core.engine.task.MigrationTaskFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -89,7 +88,7 @@ public class MigrationTasksScheduler {
         config.cleanNoUsedConfigForStart();
         initUserDefinedHandlers();
 
-        changeLocalFilePath();
+        PathUtils.changeLocalFilePath(config);
         clearTargetDB();
         createSchema();
         createTables();
@@ -292,143 +291,6 @@ public class MigrationTasksScheduler {
                 PathUtils.deleteFile(objectsFileParentPath);
             }
         }
-    }
-
-    /** Change the script name part of the local file path */
-    private void changeLocalFilePath() {
-        MigrationConfiguration config = context.getConfig();
-        String fileRootPath = config.getFileRepositroyPath();
-        String oldName = config.getOldName();
-        String newName = config.getName();
-
-        if (oldName == null) {
-            return;
-        }
-
-        // schema
-        config.setTargetSchemaFileName(
-                changeOldNameToNewName(
-                        config.getTargetSchemaFileName(), fileRootPath, oldName, newName));
-
-        // class
-        config.setTargetTableFileName(
-                changeOldNameToNewName(
-                        config.getTargetTableFileName(), fileRootPath, oldName, newName));
-
-        // vclass
-        config.setTargetViewFileName(
-                changeOldNameToNewName(
-                        config.getTargetViewFileName(), fileRootPath, oldName, newName));
-
-        // vclass_query_spec
-        config.setTargetViewQuerySpecFileName(
-                changeOldNameToNewName(
-                        config.getTargetViewQuerySpecFileName(), fileRootPath, oldName, newName));
-
-        // objects
-        config.setTargetDataFileName(
-                changeOldNameToNewName(
-                        config.getTargetDataFileName(), fileRootPath, oldName, newName));
-
-        // index
-        config.setTargetIndexFileName(
-                changeOldNameToNewName(
-                        config.getTargetIndexFileName(), fileRootPath, oldName, newName));
-
-        // pk
-        config.setTargetPkFileName(
-                changeOldNameToNewName(
-                        config.getTargetPkFileName(), fileRootPath, oldName, newName));
-
-        // fk
-        config.setTargetFkFileName(
-                changeOldNameToNewName(
-                        config.getTargetFkFileName(), fileRootPath, oldName, newName));
-
-        // serial
-        config.setTargetSerialFileName(
-                changeOldNameToNewName(
-                        config.getTargetSerialFileName(), fileRootPath, oldName, newName));
-
-        // synonym
-        config.setTargetSynonymFileName(
-                changeOldNameToNewName(
-                        config.getTargetSynonymFileName(), fileRootPath, oldName, newName));
-
-        // grant
-        Map<String, Map<String, String>> newGrantFilePathMap = new HashMap<>();
-        Map<String, Map<String, String>> grantFilePathMap = config.getTargetGrantFileName();
-        for (String schemaName : grantFilePathMap.keySet()) {
-            Map<String, String> grantFilePath = grantFilePathMap.get(schemaName);
-            if (grantFilePath != null) {
-                newGrantFilePathMap.put(
-                        schemaName,
-                        changeOldNameToNewName(grantFilePath, fileRootPath, oldName, newName));
-            }
-        }
-        config.setTargetGrantFileName(newGrantFilePathMap);
-
-        // updatestatistic
-        config.setTargetUpdateStatisticFileName(
-                changeOldNameToNewName(
-                        config.getTargetUpdateStatisticFileName(), fileRootPath, oldName, newName));
-
-        // info
-        config.setTargetSchemaFileListName(
-                changeOldNameToNewName(
-                        config.getTargetSchemaFileListName(), fileRootPath, oldName, newName));
-
-        // table data file
-        Map<String, List<String>> newTableDataFilePath = new HashMap<>();
-        config.getTargetTableDataFileName()
-                .forEach(
-                        (schemaName, tableDataFilePathList) -> {
-                            newTableDataFilePath.put(
-                                    schemaName,
-                                    changeOldNameToNewName(
-                                            tableDataFilePathList, fileRootPath, oldName, newName));
-                        });
-        config.setTargetTableDataFileName(newTableDataFilePath);
-    }
-
-    /** change directory path */
-    private List<String> changeOldNameToNewName(
-            List<String> filePath, String fileRootPath, String oldName, String newName) {
-        List<String> newFilePath = new ArrayList<String>();
-        filePath.forEach(
-                path -> {
-                    String newPath = removeRootPath(path, fileRootPath).replace(oldName, newName);
-                    newFilePath.add(addRootPath(newPath, fileRootPath));
-                });
-        return newFilePath;
-    }
-
-    /** change directory path */
-    private Map<String, String> changeOldNameToNewName(
-            Map<String, String> filePath, String fileRootPath, String oldName, String newName) {
-        Map<String, String> newFilePath = new HashMap<>();
-        filePath.forEach(
-                (schemaName, path) -> {
-                    String newPath = removeRootPath(path, fileRootPath).replace(oldName, newName);
-                    newFilePath.put(schemaName, addRootPath(newPath, fileRootPath));
-                });
-        return newFilePath;
-    }
-
-    /** add file root path */
-    private String addRootPath(String filePath, String fileRootPath) {
-        if (filePath.startsWith(fileRootPath)) {
-            return filePath;
-        }
-        return fileRootPath + filePath;
-    }
-
-    /** remove file root path */
-    private String removeRootPath(String fileFullPath, String fileRootPath) {
-        if (fileFullPath.startsWith(fileRootPath)) {
-            return fileFullPath.substring(fileRootPath.length());
-        }
-        return fileFullPath;
     }
 
     /** Waiting for step finished. */

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/BaseConfirmationPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/BaseConfirmationPage.java
@@ -30,6 +30,7 @@
  */
 package com.cubrid.cubridmigration.ui.wizard.page;
 
+import com.cubrid.cubridmigration.core.common.PathUtils;
 import com.cubrid.cubridmigration.core.dbobject.Column;
 import com.cubrid.cubridmigration.core.dbobject.FK;
 import com.cubrid.cubridmigration.core.dbobject.Index;
@@ -170,7 +171,9 @@ public class BaseConfirmationPage extends MigrationWizardPage {
                         if (StringUtils.isBlank(name)) {
                             return;
                         }
-                        getMigrationWizard().getMigrationConfig().setName(name);
+                        MigrationConfiguration config = getMigrationWizard().getMigrationConfig();
+                        config.setName(name);
+                        PathUtils.changeLocalFilePath(config);
                         getMigrationWizard().saveMigrationScript(true, isSaveSchema());
                         btnUpdateScript.setEnabled(
                                 getMigrationWizard().getMigrationScript() != null);


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4635

**Purpose**
Addresses the issue where, after renaming to 'Save New Script' in Step 6 and performing the migration, the file directory is not created with the new script name.

**Implementation**
N/A

**Remarks**
N/A

Addresses the issue where, after renaming to 'Save New Script' in Step 6 and performing the migration, the file directory is not created with the new script name.