### PR TITLE
[TOOLS-4637] Fix for Updatestatistic file not generated

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/UpdateStatisticsTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/UpdateStatisticsTask.java
@@ -75,7 +75,7 @@ public class UpdateStatisticsTask extends ImportTask {
         }
         List<String> objectsToBeUpdated = new ArrayList<String>();
 
-        if (config.isAddUserSchema()) {
+        if (config.getSourceDBType().isSupportMultiSchema()) {
             if (config.sourceIsCSV()) {
                 List<SourceCSVConfig> csvConfigs = config.getCSVConfigs();
                 for (SourceCSVConfig csvf : csvConfigs) {
@@ -209,6 +209,15 @@ public class UpdateStatisticsTask extends ImportTask {
      * @return repository exist true, no repository false boolean
      */
     private boolean checkDataFileRepository(String schemaName) {
+        if (config.isOneTableOneFile()) {
+            for (String file : config.getTargetTableDataFileName(schemaName)) {
+                if (new File(file).exists()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         String fileRepository = config.getTargetDataFileName(schemaName);
         return fileRepository != null ? new File(fileRepository).exists() : false;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4637

**Purpose**
When migrating with CUBRID Dump, the Updatestatistic file is not generated if "One table one file" or versions below 11.0 are selected in Step 3 of the migration wizard. This fix addresses the issue.

**Implementation**
N/A

**Remarks**
N/A