### PR TITLE
[TOOLS-4644] Incorrect SQL generation due to single quotes in Oracle DEFAULT values

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -208,7 +208,8 @@ public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
         // if char is char , add '' to default value
         if (dataTypeHelper.isString(cubCol.getDataType())
                 && StringUtils.isNotEmpty(cubCol.getDefaultValue())
-                && !cubCol.getDefaultValue().startsWith("'")) {
+                && !cubCol.getDefaultValue().startsWith("'")
+                && !cubCol.getDefaultValue().startsWith("(")) {
             cubCol.setDefaultValue("'" + cubCol.getDefaultValue() + "'");
         }
         initPecisionScale(mapping, srcColumn, cubCol);
@@ -393,7 +394,7 @@ public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
         String lowerCaseDefaultValue = defaultValue.toLowerCase(Locale.US);
 
         // Function names should be lowerCases
-        String[] functions = {"to_char", "to_date", "cast"};
+        String[] functions = {"(", "to_char", "to_date", "cast"};
 
         for (String function : functions) {
             if (lowerCaseDefaultValue.startsWith(function)) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4644

**Purpose**
When specifying a value like ('0') after DEFAULT in Oracle, it leads to incorrect SQL conversion for CUBRID. The goal is to fix the issue to ensure correct SQL generation.

**Implementation**
N/A

**Remarks**
N/A