### PR TITLE
[TOOLS-4629] Oracle view comments not migrating to console

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -515,7 +515,8 @@ public class MigrationConfiguration {
      * @param viewName String
      * @param target String
      */
-    public void addExpViewCfg(String schema, String viewName, String target, String comment) {
+    public void addExpViewCfg(
+            String schema, String viewName, String target, String targetOwner, String comment) {
         if (srcCatalog != null) {
             throw new RuntimeException("Source database was specified.");
         }
@@ -528,6 +529,7 @@ public class MigrationConfiguration {
             expViews.add(sc);
         }
         sc.setTarget(StringUtils.lowerCase(target));
+        sc.setTargetOwner(targetOwner);
     }
 
     /**
@@ -3264,7 +3266,7 @@ public class MigrationConfiguration {
     public List<String> getTargetTableDataFileName(String schemaName) {
         return this.targetTableDataFileName.get(schemaName) != null
                 ? new ArrayList<String>(this.targetTableDataFileName.get(schemaName))
-                : null;
+                : new ArrayList<String>();
     }
 
     /**

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateHandler.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateHandler.java
@@ -718,6 +718,7 @@ public final class MigrationTemplateHandler extends DefaultHandler {
                     attributes.getValue(TemplateTags.ATTR_OWNER),
                     attributes.getValue(TemplateTags.ATTR_NAME),
                     attributes.getValue(TemplateTags.ATTR_TARGET),
+                    attributes.getValue(TemplateTags.ATTR_TARGET_OWNER),
                     attributes.getValue(TemplateTags.ATTR_COMMENT));
         } else if (TemplateTags.TAG_GRANT.equals(qName)) {
             config.addExpGrantCfg(

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateParser.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/MigrationTemplateParser.java
@@ -334,6 +334,7 @@ public final class MigrationTemplateParser {
             view.setAttribute(TemplateTags.ATTR_OWNER, tt.getOwner());
             view.setAttribute(TemplateTags.ATTR_TARGET_OWNER, tt.getOwner());
             view.setAttribute(TemplateTags.ATTR_SOURCE_OWNER, tt.getSourceOwner());
+            view.setAttribute(TemplateTags.ATTR_COMMENT, tt.getComment());
             Element viewQuerySQL = createElement(document, view, TemplateTags.TAG_VIEWQUERYSQL);
             viewQuerySQL.setTextContent(tt.getQuerySpec());
             Element createViewSQL = createElement(document, view, TemplateTags.TAG_CREATEVIEWSQL);
@@ -973,6 +974,7 @@ public final class MigrationTemplateParser {
                 vwNode.setAttribute(TemplateTags.ATTR_OWNER, sc.getOwner());
                 vwNode.setAttribute(TemplateTags.ATTR_NAME, sc.getName());
                 vwNode.setAttribute(TemplateTags.ATTR_TARGET, sc.getTarget());
+                vwNode.setAttribute(TemplateTags.ATTR_TARGET_OWNER, sc.getTargetOwner());
                 vwNode.setAttribute(TemplateTags.ATTR_COMMENT, sc.getComment());
             }
         }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4629

**Purpose**
When migrating Oracle to the console, view comments are not being migration. This modify addresses the problem to ensure view comments are correctly migrated.

**Implementation**
N/A

**Remarks**
N/A