### PR TITLE
[TOOLS-4547] Fix duplicate unsupported objects in migration

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -629,18 +629,21 @@ public class MigrationConfiguration {
                 prefix = sourceDBSchema.getName() + ".";
             }
             for (Function fun : sourceDBSchema.getFunctions()) {
-                if (expFunctions.indexOf(fun.getName()) < 0) {
-                    expFunctions.add(prefix + fun.getName());
+                String funName = prefix + fun.getName();
+                if (expFunctions.indexOf(funName) < 0) {
+                    expFunctions.add(funName);
                 }
             }
             for (Procedure pro : sourceDBSchema.getProcedures()) {
-                if (expProcedures.indexOf(pro.getName()) < 0) {
-                    expProcedures.add(prefix + pro.getName());
+                String proName = prefix + pro.getName();
+                if (expProcedures.indexOf(proName) < 0) {
+                    expProcedures.add(proName);
                 }
             }
             for (Trigger tri : sourceDBSchema.getTriggers()) {
-                if (expTriggers.indexOf(tri.getName()) < 0) {
-                    expTriggers.add(prefix + tri.getName());
+                String triName = prefix + tri.getName();
+                if (expTriggers.indexOf(triName) < 0) {
+                    expTriggers.add(triName);
                 }
             }
         }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4547

**Purpose**
When rerunning the migration script, unsupported objects(procedure, function, trigger) appear multiple times in the migration report log tab. This fix resolves the issue to prevent duplication of unsupported objects in the log.

**Implementation**
N/A

**Remarks**
N/A