### PR TITLE
[TOOLS-4637] Fix Updatestatistic file generation for Non-Multi-Schema db migration

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/UpdateStatisticsTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/UpdateStatisticsTask.java
@@ -146,7 +146,7 @@ public class UpdateStatisticsTask extends ImportTask {
             return;
         }
 
-        if (config.isAddUserSchema()) {
+        if (config.getSourceDBType().isSupportMultiSchema()) {
             List<Schema> schemaList = config.getTargetSchemaList();
             for (Schema schema : schemaList) {
                 writeFile(schema.getName(), schema.getTargetSchemaName());


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4637

**Purpose**
The issue where the Updatestatistic file was not generated during the migration of db that do not support multiple schema has been further fixed.

**Implementation**
N/A

**Remarks**
N/A