### PR TITLE
[TOOLS-4630] Setting default conversion type size for Informix BLOB and CLOB

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/trans/INFORMIX2CUBRID.xml
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/trans/INFORMIX2CUBRID.xml
@@ -496,7 +496,7 @@
 		</SourceDataType>
 		<TargetDataType>
 			<type>varchar</type>
-			<precision>n</precision>
+			<precision>1073741823</precision>
 			<scale></scale>
 		</TargetDataType>
 		<TargetDataType>
@@ -514,7 +514,7 @@
 		</SourceDataType>
 		<TargetDataType>
 			<type>bit varying</type>
-			<precision>n</precision>
+			<precision>1073741823</precision>
 			<scale></scale>
 		</TargetDataType>
 		<TargetDataType>


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4630

**Purpose**
Modify the default size settings for Informix BLOB and CLOB conversion types bit varying and varchar.

**Implementation**
N/A

**Remarks**
N/A