### PR TITLE
[TOOLS-4653] Oracle sequence last_number not releasing connection resource

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/export/OracleExportHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/export/OracleExportHelper.java
@@ -31,6 +31,7 @@
 package com.cubrid.cubridmigration.oracle.export;
 
 import com.cubrid.cubridmigration.core.common.Closer;
+import com.cubrid.cubridmigration.core.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
 import com.cubrid.cubridmigration.core.dbobject.Column;
 import com.cubrid.cubridmigration.core.dbobject.PK;
@@ -51,6 +52,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import org.apache.log4j.Logger;
 
 /**
  * a class help to export Oracle data and verify Oracle sql statement
@@ -58,7 +60,7 @@ import java.sql.Types;
  * @author moulinwang
  */
 public class OracleExportHelper extends DBExportHelper {
-    // private static final Logger LOG = LogUtil.getLogger(OracleExportHelper.class);
+    private static final Logger LOG = LogUtil.getLogger(OracleExportHelper.class);
 
     // private static final String ORACAL_ROW_NUMBER = "OracleRowNumber";
 
@@ -202,6 +204,8 @@ public class OracleExportHelper extends DBExportHelper {
                 }
             }
         } catch (SQLException e) {
+            LOG.error("ORACLE_SERIAL_CURRENT_VALUE_SQL", e);
+        } finally {
             Closer.close(conn);
         }
         return null;

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/export/OracleExportHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/export/OracleExportHelper.java
@@ -177,7 +177,7 @@ public class OracleExportHelper extends DBExportHelper {
         return DatabaseType.ORACLE;
     }
 
-    private static final String SERIAL_CURRENT_VALUE_SQL =
+    private static final String SEQUENCE_LAST_NUMBER_SQL =
             "SELECT S.LAST_NUMBER,S.SEQUENCE_OWNER FROM ALL_SEQUENCES S "
                     + "WHERE S.SEQUENCE_NAME=? ORDER BY S.SEQUENCE_OWNER";
 
@@ -192,7 +192,7 @@ public class OracleExportHelper extends DBExportHelper {
         Connection conn = null;
         try {
             conn = sourceConParams.createConnection();
-            PreparedStatement stmt = conn.prepareStatement(SERIAL_CURRENT_VALUE_SQL);
+            PreparedStatement stmt = conn.prepareStatement(SEQUENCE_LAST_NUMBER_SQL);
             stmt.setString(1, sq.getName());
             ResultSet rs = stmt.executeQuery();
             while (rs.next()) {
@@ -204,7 +204,7 @@ public class OracleExportHelper extends DBExportHelper {
                 }
             }
         } catch (SQLException e) {
-            LOG.error("ORACLE_SERIAL_CURRENT_VALUE_SQL", e);
+            LOG.error("ORACLE_SEQUENCE_LAST_NUMBER_SQL", e);
         } finally {
             Closer.close(conn);
         }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4653

**Purpose**
When migrating Oracle, the connection made to get the last_number value of a sequence is not being closed after use. This causes the resource not to be released. Modify to use and close the connection, ensuring resources are released.

**Implementation**
N/A

**Remarks**
N/A