### PR TITLE
[TOOLS-4662] Packaging JRE 1.8 to run CMT in Java 1.7 or lower environment

### DIFF
--- a/com.cubrid.common.configuration/pom.xml
+++ b/com.cubrid.common.configuration/pom.xml
@@ -14,7 +14,7 @@
   <packaging>eclipse-plugin</packaging>
 
   <properties>
-    <jre.download.url>https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08</jre.download.url>
+    <jre.download.url>https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05</jre.download.url>
   </properties>
 
   <build>
@@ -31,9 +31,9 @@
             </goals>
             <configuration>
               <target>
-                <get src="${jre.download.url}/OpenJDK8U-jre_x64_windows_hotspot_8u412b08.zip" dest="${project.build.directory}/win-jre.zip"/>
-                <get src="${jre.download.url}/OpenJDK8U-jre_x64_linux_hotspot_8u412b08.tar.gz" dest="${project.build.directory}/linux-jre.tar.gz"/>
-                <get src="${jre.download.url}/OpenJDK8U-jre_x64_mac_hotspot_8u412b08.tar.gz" dest="${project.build.directory}/mac-jre.tar.gz"/>
+                <get src="${jre.download.url}/OpenJDK8U-jre_x64_windows_hotspot_8u422b05.zip" dest="${project.build.directory}/win-jre.zip"/>
+                <get src="${jre.download.url}/OpenJDK8U-jre_x64_linux_hotspot_8u422b05.tar.gz" dest="${project.build.directory}/linux-jre.tar.gz"/>
+                <get src="${jre.download.url}/OpenJDK8U-jre_x64_mac_hotspot_8u422b05.tar.gz" dest="${project.build.directory}/mac-jre.tar.gz"/>
               </target>
             </configuration>
           </execution>

--- a/com.cubrid.common.configuration/pom.xml
+++ b/com.cubrid.common.configuration/pom.xml
@@ -17,32 +17,29 @@
     <jre.download.url>https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08</jre.download.url>
   </properties>
 
-
   <build>
-      <sourceDirectory>src/</sourceDirectory>
-
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-antrun-plugin</artifactId>
-          <executions>
-            <execution>
-              <phase>generate-resources</phase>
-              <goals>
-                <goal>run</goal>
-              </goals>
-              <configuration>
-                <target>
-                  <get src="${jre.download.url}/OpenJDK8U-jre_x64_windows_hotspot_8u412b08.zip" dest="${project.build.directory}/win-jre.zip"/>
-                  <get src="${jre.download.url}/OpenJDK8U-jre_x64_linux_hotspot_8u412b08.tar.gz" dest="${project.build.directory}/linux-jre.tar.gz"/>
-                  <get src="${jre.download.url}/OpenJDK8U-jre_x64_mac_hotspot_8u412b08.tar.gz" dest="${project.build.directory}/mac-jre.tar.gz"/>
-                </target>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>      
-
+    <sourceDirectory>src/</sourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <get src="${jre.download.url}/OpenJDK8U-jre_x64_windows_hotspot_8u412b08.zip" dest="${project.build.directory}/win-jre.zip"/>
+                <get src="${jre.download.url}/OpenJDK8U-jre_x64_linux_hotspot_8u412b08.tar.gz" dest="${project.build.directory}/linux-jre.tar.gz"/>
+                <get src="${jre.download.url}/OpenJDK8U-jre_x64_mac_hotspot_8u412b08.tar.gz" dest="${project.build.directory}/mac-jre.tar.gz"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>      
   </build>
   
   <profiles>

--- a/com.cubrid.common.configuration/pom.xml
+++ b/com.cubrid.common.configuration/pom.xml
@@ -13,9 +13,36 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
+  <properties>
+    <jre.download.url>https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08</jre.download.url>
+  </properties>
+
 
   <build>
       <sourceDirectory>src/</sourceDirectory>
+
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <executions>
+            <execution>
+              <phase>generate-resources</phase>
+              <goals>
+                <goal>run</goal>
+              </goals>
+              <configuration>
+                <target>
+                  <get src="${jre.download.url}/OpenJDK8U-jre_x64_windows_hotspot_8u412b08.zip" dest="${project.build.directory}/win-jre.zip"/>
+                  <get src="${jre.download.url}/OpenJDK8U-jre_x64_linux_hotspot_8u412b08.tar.gz" dest="${project.build.directory}/linux-jre.tar.gz"/>
+                  <get src="${jre.download.url}/OpenJDK8U-jre_x64_mac_hotspot_8u412b08.tar.gz" dest="${project.build.directory}/mac-jre.tar.gz"/>
+                </target>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>      
+
   </build>
   
   <profiles>

--- a/com.cubrid.cubridmigration.console/console-tar.xml
+++ b/com.cubrid.cubridmigration.console/console-tar.xml
@@ -29,6 +29,11 @@
      		<include>**/*.jar</include>
      	</includes>
      </fileSet>
+
+     <fileSet>
+      <directory>${basedir}/target/jre/linux/jdk8u412-b08-jre</directory>
+      <outputDirectory>jre</outputDirectory>
+     </fileSet>
    </fileSets>
 
     <dependencySets>

--- a/com.cubrid.cubridmigration.console/console-tar.xml
+++ b/com.cubrid.cubridmigration.console/console-tar.xml
@@ -31,8 +31,8 @@
      </fileSet>
 
      <fileSet>
-      <directory>${basedir}/target/jre/linux/jdk8u412-b08-jre</directory>
-      <outputDirectory>jre</outputDirectory>
+       <directory>${basedir}/target/jre/linux/jdk8u412-b08-jre</directory>
+       <outputDirectory>jre</outputDirectory>
      </fileSet>
    </fileSets>
 

--- a/com.cubrid.cubridmigration.console/console-tar.xml
+++ b/com.cubrid.cubridmigration.console/console-tar.xml
@@ -31,7 +31,7 @@
      </fileSet>
 
      <fileSet>
-       <directory>${basedir}/target/jre/linux/jdk8u412-b08-jre</directory>
+       <directory>${basedir}/target/jre/linux/jdk8u422-b05-jre</directory>
        <outputDirectory>jre</outputDirectory>
      </fileSet>
    </fileSets>

--- a/com.cubrid.cubridmigration.console/console-zip.xml
+++ b/com.cubrid.cubridmigration.console/console-zip.xml
@@ -27,6 +27,11 @@
      		<include>**/*.jar</include>
      	</includes>
      </fileSet>
+
+     <fileSet>
+      <directory>${basedir}/target/jre/win/jdk8u412-b08-jre</directory>
+      <outputDirectory>jre</outputDirectory>
+     </fileSet>
    </fileSets>
 
     <dependencySets>

--- a/com.cubrid.cubridmigration.console/console-zip.xml
+++ b/com.cubrid.cubridmigration.console/console-zip.xml
@@ -29,7 +29,7 @@
      </fileSet>
 
      <fileSet>
-       <directory>${basedir}/target/jre/win/jdk8u412-b08-jre</directory>
+       <directory>${basedir}/target/jre/win/jdk8u422-b05-jre</directory>
        <outputDirectory>jre</outputDirectory>
      </fileSet>
    </fileSets>

--- a/com.cubrid.cubridmigration.console/console-zip.xml
+++ b/com.cubrid.cubridmigration.console/console-zip.xml
@@ -29,8 +29,8 @@
      </fileSet>
 
      <fileSet>
-      <directory>${basedir}/target/jre/win/jdk8u412-b08-jre</directory>
-      <outputDirectory>jre</outputDirectory>
+       <directory>${basedir}/target/jre/win/jdk8u412-b08-jre</directory>
+       <outputDirectory>jre</outputDirectory>
      </fileSet>
    </fileSets>
 

--- a/com.cubrid.cubridmigration.console/migration.bat
+++ b/com.cubrid.cubridmigration.console/migration.bat
@@ -1,4 +1,8 @@
 @echo off
-SET fn=%1 %2 %3 %4 %5 %6 %7 %8 %9
-java -Xms1024M -Xmx4096M -jar com.cubrid.cubridmigration.command-1.0.0-SNAPSHOT.jar %fn%
+set DIR=%CD%
+set JRE=%DIR%\jre
+set JAVA=%JRE%\bin\java
+set ARGS=%*
+
+%JAVA% -cp %JRE%\lib\*;%DIR%\lib\* -Xms1024M -Xmx4096M -jar %DIR%\com.cubrid.cubridmigration.command-1.0.0-SNAPSHOT.jar %ARGS%
 @echo on

--- a/com.cubrid.cubridmigration.console/migration.sh
+++ b/com.cubrid.cubridmigration.console/migration.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
 DIR=$PWD
-java -jar -Xms1024M -Xmx4096M $DIR/com.cubrid.cubridmigration.command-1.0.0-SNAPSHOT.jar "$@"
+JRE=$DIR/jre
+JAVA=$JRE/bin/java
+
+$JAVA -cp $JRE/lib/*:$DIR/lib/* -Xms1024M -Xmx4096M -jar $DIR/com.cubrid.cubridmigration.command-1.0.0-SNAPSHOT.jar "$@"

--- a/com.cubrid.cubridmigration.console/pom.xml
+++ b/com.cubrid.cubridmigration.console/pom.xml
@@ -16,6 +16,31 @@
     <build>
         <plugins>
             <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <property name="output.dir" value="${project.build.directory}/jre"/>
+                                <unzip src="../com.cubrid.common.configuration/target/win-jre.zip" dest="${project.build.directory}/jre/win"/>
+                                <mkdir dir="${output.dir}/linux" />
+                                <exec executable="tar">
+                                  <arg value="xzf"/>
+                                  <arg value="../com.cubrid.common.configuration/target/linux-jre.tar.gz"/>
+                                  <arg value="-C"/>
+                                  <arg value="${output.dir}/linux"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>

--- a/com.cubrid.cubridmigration.product/linux.xml
+++ b/com.cubrid.cubridmigration.product/linux.xml
@@ -45,7 +45,7 @@
      </fileSet>
 
      <fileSet>
-      <directory>${basedir}/target/jre/linux/jdk8u412-b08-jre</directory>
+      <directory>${basedir}/target/jre/linux/jdk8u422-b05-jre</directory>
       <outputDirectory>jre</outputDirectory>
      </fileSet>
    </fileSets>

--- a/com.cubrid.cubridmigration.product/linux.xml
+++ b/com.cubrid.cubridmigration.product/linux.xml
@@ -43,5 +43,10 @@
      		<include>**/*.jar</include>
      	</includes>
      </fileSet>
+
+     <fileSet>
+      <directory>${basedir}/target/jre/linux/jdk8u412-b08-jre</directory>
+      <outputDirectory>jre</outputDirectory>
+     </fileSet>
    </fileSets>
 </assembly>

--- a/com.cubrid.cubridmigration.product/mac.xml
+++ b/com.cubrid.cubridmigration.product/mac.xml
@@ -60,7 +60,7 @@
      </fileSet>
 
     <fileSet>
-      <directory>${basedir}/target/jre/linux/jdk8u412-b08-jre</directory>
+      <directory>${basedir}/target/jre/linux/jdk8u422-b05-jre</directory>
       <outputDirectory>jre</outputDirectory>
      </fileSet>
    </fileSets>

--- a/com.cubrid.cubridmigration.product/mac.xml
+++ b/com.cubrid.cubridmigration.product/mac.xml
@@ -58,5 +58,10 @@
      		<include>**/*.jar</include>
      	</includes>
      </fileSet>
+
+    <fileSet>
+      <directory>${basedir}/target/jre/linux/jdk8u412-b08-jre</directory>
+      <outputDirectory>jre</outputDirectory>
+     </fileSet>
    </fileSets>
 </assembly>

--- a/com.cubrid.cubridmigration.product/pom.xml
+++ b/com.cubrid.cubridmigration.product/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+ <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -58,6 +58,39 @@
                 <configuration>
                     <createArtifactRepository>false</createArtifactRepository>
                 </configuration>
+            </plugin>
+
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <property name="output.dir" value="${project.build.directory}/jre"/>
+                                <unzip src="../com.cubrid.common.configuration/target/win-jre.zip" dest="${output.dir}/win"/>
+                                <mkdir dir="${output.dir}/linux"/>
+                                <exec executable="tar">
+                                  <arg value="xzf"/>
+                                  <arg value="../com.cubrid.common.configuration/target/linux-jre.tar.gz"/>
+                                  <arg value="-C"/>
+                                  <arg value="${output.dir}/linux"/>
+                                </exec>
+                                <mkdir dir="${output.dir}/mac"/>
+                                <exec executable="tar">
+                                  <arg value="xzf"/>
+                                  <arg value="../com.cubrid.common.configuration/target/mac-jre.tar.gz"/>
+                                  <arg value="-C"/>
+                                  <arg value="${output.dir}/mac"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             
             <plugin>

--- a/com.cubrid.cubridmigration.product/pom.xml
+++ b/com.cubrid.cubridmigration.product/pom.xml
@@ -1,4 +1,4 @@
- <?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -61,7 +61,7 @@
             </plugin>
 
             <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
@@ -75,17 +75,17 @@
                                 <unzip src="../com.cubrid.common.configuration/target/win-jre.zip" dest="${output.dir}/win"/>
                                 <mkdir dir="${output.dir}/linux"/>
                                 <exec executable="tar">
-                                  <arg value="xzf"/>
-                                  <arg value="../com.cubrid.common.configuration/target/linux-jre.tar.gz"/>
-                                  <arg value="-C"/>
-                                  <arg value="${output.dir}/linux"/>
+                                    <arg value="xzf"/>
+                                    <arg value="../com.cubrid.common.configuration/target/linux-jre.tar.gz"/>
+                                    <arg value="-C"/>
+                                    <arg value="${output.dir}/linux"/>
                                 </exec>
                                 <mkdir dir="${output.dir}/mac"/>
                                 <exec executable="tar">
-                                  <arg value="xzf"/>
-                                  <arg value="../com.cubrid.common.configuration/target/mac-jre.tar.gz"/>
-                                  <arg value="-C"/>
-                                  <arg value="${output.dir}/mac"/>
+                                    <arg value="xzf"/>
+                                    <arg value="../com.cubrid.common.configuration/target/mac-jre.tar.gz"/>
+                                    <arg value="-C"/>
+                                    <arg value="${output.dir}/mac"/>
                                 </exec>
                             </target>
                         </configuration>

--- a/com.cubrid.cubridmigration.product/windows.xml
+++ b/com.cubrid.cubridmigration.product/windows.xml
@@ -43,5 +43,10 @@
      		<include>**/*.jar</include>
      	</includes>
      </fileSet>
+
+    <fileSet>
+      <directory>${basedir}/target/jre/win/jdk8u412-b08-jre</directory>
+      <outputDirectory>jre</outputDirectory>
+     </fileSet>
    </fileSets>
 </assembly>

--- a/com.cubrid.cubridmigration.product/windows.xml
+++ b/com.cubrid.cubridmigration.product/windows.xml
@@ -45,7 +45,7 @@
      </fileSet>
 
     <fileSet>
-      <directory>${basedir}/target/jre/win/jdk8u412-b08-jre</directory>
+      <directory>${basedir}/target/jre/win/jdk8u422-b05-jre</directory>
       <outputDirectory>jre</outputDirectory>
      </fileSet>
    </fileSets>


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4662

**Purpose**
Due to the Eclipse RCP version upgrade, JDK 1.8 must be used during the build process. As a result, CMT can only be executed on Java 1.8 or higher. To enable the use of CMT in environments with Java 1.7 or lower, we plan to include JRE 1.8 in the packaging.

**Implementation**
N/A

**Remarks**
N/A