### PR TITLE
[TOOLS-4689] Fix issue where characters after END are deleted

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
@@ -1011,7 +1011,6 @@ public class CUBRIDSQLHelper extends SQLHelper {
 
     private String replaceBody(String sql) {
         String body = replaceIsWithAs(sql);
-        body = removeEndName(body);
         return body;
     }
 
@@ -1044,10 +1043,5 @@ public class CUBRIDSQLHelper extends SQLHelper {
         Matcher matcher = pattern.matcher(sql);
 
         return matcher.replaceAll(" AS");
-    }
-
-    private String removeEndName(String sql) {
-        String regex = "(?i)(END)\\s+[a-zA-Z0-9_#]+;";
-        return sql.replaceAll(regex, "$1;");
     }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4689

**Purpose**
- Oracle PL/SQL Procedure에서 END 키워드 뒤에 있는 문자(IF, LOOP)가 삭제되는 문제로 변환된 CUBRID의 PL/CSQL Procedure DDL 코드가 정상적으로 작동하지 않습니다.
- END 키워드 뒤 문자가 삭제되지 않도록 수정합니다.

**Implementation**
- removeEndName 메서드는 DDL 맨 끝 END 뒤에 Procedure의 이름을 제거하는 역할의 메서드입니다.
```sql
CREATE PROCEDURE sample_proc AS
BEGIN
    DBMS_OUTPUT.PUT_LINE('This procedure is sample.');
END sample_proc;
```
- 맨 끝 END 뒤에 Procedure 이름이 한번 더 추가되어도 CUBRID에서 정상적으로 생성이 가능합니다.
- 이 메서드로 인해 END 뒤에 필수로 작성되어야 하는 키워드가 삭제되므로 해당 메서드를 사용하지 않고 삭제하도록 하겠습니다.

**Remarks**
N/A