### PR TITLE
[TOOLS-4692] Add index creation check condition in TableMappingView validate

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/TableMappingView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/TableMappingView.java
@@ -1179,6 +1179,7 @@ public class TableMappingView extends AbstractMappingView {
         }
         for (int i = 0; i < tvTableIndexes.getTable().getItemCount(); i++) {
             Object[] obj = (Object[]) tvTableIndexes.getElementAt(i);
+            if (!(boolean) obj[2]) continue;
             String name = obj[1].toString().toLowerCase(Locale.US);
             if (names.indexOf(name) >= 0) {
                 return new VerifyResultMessages(


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4692

**Purpose**
FK와 INDEX 이름이 동일한 경우 이름 중복으로 에러를 표시합니다.
INDEX 생성을 체크하지 않은 경우에도 INDEX 이름 중복을 검사하여 마이그레이션이 진행되지 않는 문제가 있습니다.
INDEX 생성을 체크하지 않으면 이름 중복 검사를 진행하지 않도록 수정합니다.

**Implementation**
INDEX 생성 여부를 먼저 확인하고, 생성 시 이름 중복 검사를 할 수 있도록 조건을 추가합니다.

**Remarks**
N/A