### PR TITLE
[TOOLS-4685] Fix Oracle procedure DDL file output to use UTF-8

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/CUBRIDIOUtils.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/CUBRIDIOUtils.java
@@ -763,6 +763,7 @@ public final class CUBRIDIOUtils {
      */
     public static void writeLines(Writer writer, String[] lines) throws IOException {
         BufferedWriter bw = new BufferedWriter(writer, BUFFER_SIZE);
+
         try {
             for (String line : lines) {
                 bw.write(line);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/CUBRIDIOUtils.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/CUBRIDIOUtils.java
@@ -763,8 +763,8 @@ public final class CUBRIDIOUtils {
      */
     public static void writeLines(Writer writer, String[] lines) throws IOException {
         BufferedWriter bw = new BufferedWriter(writer, BUFFER_SIZE);
-
         try {
+
             for (String line : lines) {
                 bw.write(line);
                 bw.newLine();

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/CUBRIDIOUtils.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/CUBRIDIOUtils.java
@@ -722,12 +722,12 @@ public final class CUBRIDIOUtils {
      * @param lines the content to append
      * @throws IOException when IO errors.
      */
-    public static void writeLines(File file, String[] lines, boolean appendMode)
+    public static void writeLines(File file, String[] lines, String fileCharset, boolean appendMode)
             throws IOException {
         FileOutputStream fos = null;
         try {
             fos = new FileOutputStream(file, appendMode);
-            writeLines(fos, lines);
+            writeLines(fos, lines, fileCharset);
         } finally {
             Closer.close(fos);
         }
@@ -764,7 +764,6 @@ public final class CUBRIDIOUtils {
     public static void writeLines(Writer writer, String[] lines) throws IOException {
         BufferedWriter bw = new BufferedWriter(writer, BUFFER_SIZE);
         try {
-
             for (String line : lines) {
                 bw.write(line);
                 bw.newLine();

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlFunctionDDLTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlFunctionDDLTask.java
@@ -69,7 +69,7 @@ public class AllPlcsqlFunctionDDLTask extends ImportTask {
             File functionFile = new File(functionFiles.get(owner));
 
             try {
-                CUBRIDIOUtils.writeLines(functionFile, new String[] {ddl}, true);
+                CUBRIDIOUtils.writeLines(functionFile, new String[] {ddl}, "UTF-8", true);
             } catch (IOException e) {
                 LOG.error("AllPlcsqlFunctionDDLTask");
             }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlFunctionHeaderDDLTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlFunctionHeaderDDLTask.java
@@ -71,7 +71,7 @@ public class AllPlcsqlFunctionHeaderDDLTask extends ImportTask {
             File functionFile = new File(functionFiles.get(owner));
 
             try {
-                CUBRIDIOUtils.writeLines(functionFile, new String[] {ddl}, true);
+                CUBRIDIOUtils.writeLines(functionFile, new String[] {ddl}, "UTF-8", true);
             } catch (IOException e) {
                 LOG.error("AllPlcsqlFunctionHeaderDDLTask");
             }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlProcedureDDLTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlProcedureDDLTask.java
@@ -70,7 +70,7 @@ public class AllPlcsqlProcedureDDLTask extends ImportTask {
             File procedureFile = new File(procedureFiles.get(owner));
 
             try {
-                CUBRIDIOUtils.writeLines(procedureFile, new String[] {ddl}, true);
+                CUBRIDIOUtils.writeLines(procedureFile, new String[] {ddl}, "UTF-8", true);
             } catch (IOException e) {
                 LOG.error("AllPlcsqlProcedureDDLTask");
             }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlProcedureHeaderDDLTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlProcedureHeaderDDLTask.java
@@ -71,7 +71,7 @@ public class AllPlcsqlProcedureHeaderDDLTask extends ImportTask {
             File procedureFile = new File(procedureFiles.get(owner));
 
             try {
-                CUBRIDIOUtils.writeLines(procedureFile, new String[] {ddl}, true);
+                CUBRIDIOUtils.writeLines(procedureFile, new String[] {ddl}, "UTF-8", true);
             } catch (IOException e) {
                 LOG.error("AllPlcsqlProcedureHeaderDDLTask");
             }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/PlcsqlFunctionSourceAndDropDDLTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/PlcsqlFunctionSourceAndDropDDLTask.java
@@ -74,7 +74,7 @@ public class PlcsqlFunctionSourceAndDropDDLTask extends ImportTask {
             File functionFile = new File(functionFiles.get(owner).get(name));
 
             try {
-                CUBRIDIOUtils.writeLines(functionFile, sourceCreateAndDropSQL, true);
+                CUBRIDIOUtils.writeLines(functionFile, sourceCreateAndDropSQL, "UTF-8", true);
             } catch (IOException e) {
                 LOG.error("PlcsqlFunctionSourceAndDropDDLTask");
             }

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/PlcsqlProcedureSourceAndDropDDLTask.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/PlcsqlProcedureSourceAndDropDDLTask.java
@@ -74,7 +74,7 @@ public class PlcsqlProcedureSourceAndDropDDLTask extends ImportTask {
             File procedureFile = new File(procedureFiles.get(owner).get(name));
 
             try {
-                CUBRIDIOUtils.writeLines(procedureFile, sourceCreateAndDropSQL, true);
+                CUBRIDIOUtils.writeLines(procedureFile, sourceCreateAndDropSQL, "UTF-8", true);
             } catch (IOException e) {
                 LOG.error("PlcsqlProcedureSourceAndDropDDLTask");
             }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4685

**Purpose**
오라클 원본 프로시저 DDL을 파일에 출력할 때 UTF-8로 인코딩하여 출력할 수 있도록 수정합니다.

**Implementation**
N/A

**Remarks**
N/A