### PR TITLE
[TOOLS-4501] Remove driver file name check condition

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbtype/DatabaseType.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbtype/DatabaseType.java
@@ -229,14 +229,6 @@ public abstract class DatabaseType {
             for (JDBCData jdbcData : jdbcDatas) {
                 if (jdbcData.getJdbcDriverPath().indexOf(fullName) >= 0) {
                     return jdbcData;
-                } else if (fullName.endsWith(jdbcData.getJdbcDriverName())) {
-                    return jdbcData;
-                }
-            }
-            // If file exists and did not find the JDBC data in the list, search it by file name
-            for (JDBCData jdbcData : jdbcDatas) {
-                if (jdbcData.getJdbcDriverPath().indexOf(file.getName()) >= 0) {
-                    return jdbcData;
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4501

**Purpose**
이전에는 드라이버가 있는 디렉터리 위치가 다르더라도 파일 이름만 동일하면 같은 드라이버로 판단되었습니다.
이번 수정으로 드라이버를 등록하거나 삭제할 때, 디렉터리 경로까지 동일해야만 같은 드라이버로 인식되도록 변경합니다.

**Implementation**
저장된 드라이버를 찾는 조건 중, 파일 이름만을 비교하여 같은 드라이버인지 판단하는 조건들을 제거했습니다.

**Remarks**
N/A