### PR TITLE
[TOOLS-4695] Remove comments that come after DEFAULT value

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -205,6 +205,9 @@ public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
         Integer elementDataTypeID =
                 elemDataType == null ? null : dataTypeHelper.getCUBRIDDataTypeID(elemDataType);
         cubCol.setJdbcIDOfSubDataType(elementDataTypeID);
+
+        cubCol.setDefaultValue(removeCommentsFromDefaultValue(cubCol.getDefaultValue()));
+
         // if char is char , add '' to default value
         if (dataTypeHelper.isString(cubCol.getDataType())
                 && StringUtils.isNotEmpty(cubCol.getDefaultValue())
@@ -421,6 +424,40 @@ public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
         }
 
         return false;
+    }
+
+    /**
+     * Remove comments from default value
+     *
+     * @param defaultValue default value
+     * @return default value without comments
+     */
+    private String removeCommentsFromDefaultValue(String defaultValue) {
+        if (defaultValue == null) {
+            return null;
+        }
+        return removeLineComment(removeBlockComment(defaultValue));
+    }
+
+    /**
+     * Block comment removal
+     *
+     * @param defaultValue default value
+     * @return block comment removed string
+     */
+    private String removeBlockComment(String defaultValue) {
+        String result = defaultValue.replaceAll("/\\*[\\s\\S]*?\\*/", " ");
+        return result.trim().replaceAll("\\s+", " ");
+    }
+
+    /**
+     * Line comment removal
+     *
+     * @param defaultValue default value
+     * @return line comment removed string
+     */
+    private String removeLineComment(String defaultValue) {
+        return defaultValue.replaceAll("\\s*--.*$", "");
     }
 
     /**


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4695

**Purpose**
오라클 컬럼 DEFAULT 값 뒤에 있는 주석 제거 기능 추가

**Implementation**
`/* */`, `--` 으로 생성된 주석 제거

다음과 같은 케이스들을 테스트 했습니다.

```
// {입력값, 예상결과}

{"0", "0"},                                           // 1. 주석 없음
{"0 /* 삭제 유무 */", "0"},                           // 2. 블록 주석 (값 뒤에 주석)
{"0 -- 삭제 유무", "0"},                              // 3. 라인 주석 (값 뒤에 주석)
{"0 /* 주석1 */ -- 주석2", "0"},                       // 4. 블록 주석과 라인 주석 함께 사용
{"/* 앞 주석 */ 0 /* 뒤 주석 */", "0"},               // 5. 앞뒤에 주석 있음 (주석을 모두 제거하면 0만 남음)
{"0/* 붙어있는 주석 */", "0"},                         // 6. 값과 주석이 붙어있는 경우
{"/*/ 특수한 주석 */0", "0"},                         // 7. 특수한 형태의 블록 주석 (주석 시작 부분에 "/"가 포함됨)
{"   0    /* 주석 */   ", "0"},                       // 8. 여분의 공백과 주석이 있는 경우
{"'text' /* 주석 */", "'text'"},                      // 9. 문자열 리터럴 뒤에 주석
{"(123) /* 주석 */", "(123)"},                        // 10. 괄호로 묶인 식에 주석
{"0--주석", "0"},                                    // 11. 값 뒤에 붙은 라인 주석
{"-1 /* negative */", "-1"},                         // 12. 음수 값에 주석
{"'It''s a test' /* comment */", "'It''s a test'"},   // 13. 내부에 이스케이프된 따옴표가 있는 문자열
{"1/* 중간에 */+2", "1 +2"},                           // 14. 산술식 중간에 주석 삽입 (주석 제거 후 "1+2")
{"(SYSDATE) /* default date */", "(SYSDATE)"},        // 15. 함수 호출 식에 주석 
{"1/2 /* division */", "1/2"},                       // 16. 나눗셈 식에 주석
{"'a'||'b' /* concat */", "'a'||'b'"},               // 17. 문자열 결합 식에 주석
{"(1 /* comment */ + 2) /* more */", "(1 + 2)"},       // 18. 복합 식에 여러 주석이 있는 경우
```

**Remarks**
N/A