### PR TITLE
[TOOLS-4699] Hide PK path on step 6 when actual table has no primary key

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -1347,6 +1347,7 @@ public class MigrationConfiguration {
                                     setc.isChangeTableName(),
                                     srcTable.getOwner(),
                                     srcTable.getName()));
+                    setc.setHasPK(srcTable.hasPK());
 
                     setc.setCreateNewTable(isReset);
                     setc.setCreatePartition(isReset);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/SourceEntryTableConfig.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/SourceEntryTableConfig.java
@@ -42,10 +42,15 @@ import org.apache.commons.collections.CollectionUtils;
  */
 public class SourceEntryTableConfig extends SourceTableConfig {
 
+    /** Whether to create a Primary Key based on user config */
     private boolean createPK;
+
     private boolean createPartition;
     private boolean isEnableExpOpt;
     private boolean startFromTargetMax;
+
+    /** Whether the source table has a Primary Key */
+    private boolean hasPK;
 
     private final List<SourceFKConfig> fks = new ArrayList<SourceFKConfig>();
     private final List<SourceIndexConfig> indexes = new ArrayList<SourceIndexConfig>();
@@ -267,5 +272,13 @@ public class SourceEntryTableConfig extends SourceTableConfig {
 
     public void setEnableExpOpt(boolean isEnableExpOpt) {
         this.isEnableExpOpt = isEnableExpOpt;
+    }
+
+    public boolean isHasPK() {
+        return hasPK;
+    }
+
+    public void setHasPK(boolean hasPK) {
+        this.hasPK = hasPK;
     }
 }

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
@@ -317,7 +317,7 @@ public class ConfirmationPage extends BaseConfirmationPage {
 
                 Set<String> expPKs = new HashSet<>();
                 for (SourceEntryTableConfig expTable : migration.getExpEntryTableCfg()) {
-                    if (!expTable.isCreatePK()) {
+                    if (!expTable.isCreateNewTable() || !expTable.isHasPK()) {
                         continue;
                     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4699

**Purpose**
마이그레이션 마법사에서, 실제 테이블에 PK가 존재하지 않음에도 불구하고 사용자가 PK 생성 옵션을 체크하면, 6페이지에 PK 파일 디렉터리 경로가 표시되는 문제가 있었습니다.
실제 테이블에 PK가 없을 경우, 사용자가 옵션을 선택했더라도 해당 경로가 표시되지 않도록 수정합니다.

**Implementation**
`SourceEntryTableConfig`에 해당 테이블에서 실제로 PK가 있는지 여부를 확인할 수 있도록 `hasPK` 플래그를 추가합니다.

**Remarks**
N/A