### PR TITLE
[TOOLS-4702] Add desktop option to build.sh script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -162,10 +162,10 @@ check_configuration
 update_build_version
 
 if [ $PROFILE = "all" ] || [ $PROFILE = "a" ]; then
-  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION $MVN_DEBUG
+  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pdesktop $MVN_DEBUG
   $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pconsole $MVN_DEBUG
 elif [ $PROFILE = "desktop" ] || [ $PROFILE = "d" ]; then
-  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION $MVN_DEBUG
+  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pdesktop $MVN_DEBUG
 elif [ $PROFILE = "console" ] || [ $PROFILE = "c" ]; then
   $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pconsole $MVN_DEBUG
 else


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4702

**Purpose**

- Maven을 이용해 빌드 시 `desktop` 프로파일 명시가 없으면 빌드에 실패하는 오류를 수정합니다.

**Implementation**

- build.sh 스크립트에 `-Pdesktop` 옵션을 명시적으로 작성하여 ANTLR4 플러그인이 사용될 수 있도록 수정합니다.

**Remarks**
N/A