### PR TITLE
[TOOLS-4703] Change GitHub Action ruuner image to 'ubuntu 24.04'

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   license:
     name: license
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1
@@ -66,14 +66,14 @@ jobs:
           test $result = "PASS"
   pr-style:
     name: pr-style
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
           regex: '^\[[A-Z]+-\d+\]\s.+'
   code-style:
     name: code-style
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - id: files


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4703

**Purpose**
GitHub Action에 사용되는 OS 이미지 버전을 `ubuntu-24.04`로 변경합니다.

**Implementation**
N/A

**Remarks**
N/A