### PR TITLE
[TOOLS-4706] Fix PL/SQL procedure and function DDL schema name not updating when target schema changes

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -986,11 +986,7 @@ public class MigrationConfiguration {
                 SourcePlcsqlProcedureConfig sc =
                         getExpPlcsqlProcedureCfg(procedure.getOwner(), procedure.getName());
 
-                if (isNull(sc)
-                        || (nonNull(sourceDBSchema.getTargetSchemaName())
-                                && !sourceDBSchema
-                                        .getTargetSchemaName()
-                                        .equals(sc.getTargetOwner()))) {
+                if (isNull(sc)) {
                     sc =
                             new SourcePlcsqlProcedureConfig(
                                     procedure.getOwner(),
@@ -1005,6 +1001,22 @@ public class MigrationConfiguration {
                                     procedure.getDDL());
                     sc.setCreate(isReset);
                     sc.setReplace(isReset);
+                } else if (nonNull(sourceDBSchema.getTargetSchemaName())
+                        && !sourceDBSchema.getTargetSchemaName().equals(sc.getTargetOwner())) {
+                    sc =
+                            new SourcePlcsqlProcedureConfig(
+                                    sc.getOwner(),
+                                    sourceDBSchema.getTargetSchemaName(),
+                                    sc.getName(),
+                                    sc.getTarget(),
+                                    sc.getAuthid(),
+                                    sc.isAuthidChagned(),
+                                    sc.getSourceDDL(),
+                                    sc.getHeaderDDL(),
+                                    sc.getBodyDDL(),
+                                    sc.getProcedureDDL());
+                    sc.setCreate(sc.isCreate());
+                    sc.setReplace(sc.isReplace());
                 }
                 tempList.add(sc);
 
@@ -1047,11 +1059,7 @@ public class MigrationConfiguration {
                 SourcePlcsqlFunctionConfig sc =
                         getExpPlcsqlFunctionCfg(function.getOwner(), function.getName());
 
-                if (isNull(sc)
-                        || (nonNull(sourceDBSchema.getTargetSchemaName())
-                                && !sourceDBSchema
-                                        .getTargetSchemaName()
-                                        .equals(sc.getTargetOwner()))) {
+                if (isNull(sc)) {
                     sc =
                             new SourcePlcsqlFunctionConfig(
                                     function.getOwner(),
@@ -1066,8 +1074,23 @@ public class MigrationConfiguration {
                                     function.getDDL());
                     sc.setCreate(isReset);
                     sc.setReplace(isReset);
+                } else if (nonNull(sourceDBSchema.getTargetSchemaName())
+                        && !sourceDBSchema.getTargetSchemaName().equals(sc.getTargetOwner())) {
+                    sc =
+                            new SourcePlcsqlFunctionConfig(
+                                    sc.getOwner(),
+                                    sourceDBSchema.getTargetSchemaName(),
+                                    sc.getName(),
+                                    sc.getTarget(),
+                                    sc.getAuthid(),
+                                    sc.isAuthidChanged(),
+                                    sc.getSourceDDL(),
+                                    sc.getHeaderDDL(),
+                                    sc.getBodyDDL(),
+                                    sc.getFunctionDDL());
+                    sc.setCreate(sc.isCreate());
+                    sc.setReplace(sc.isReplace());
                 }
-
                 tempList.add(sc);
 
                 PlcsqlFunction tfunction = null;


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4706

### Purpose
Step5에서 "Back" 버튼으로 Step4로 이동하여 Target Schema명을 변경한 후 다시 Step5로 돌아갈 때 Procedure, Function의 DDL에 변경된 스키마명이 반영되지 않는 문제를 해결합니다.

### Implementation
- 객체가 `null`일 때와 `targetOwner`가 변경됐을 때를 분리하여 처리
- `targetOwner` 변경 분기에서 기존 객체의 모든 필드를 꺼내 동일한 값으로 새 인스턴스를 생성하고, 변경된 `targetOwner`만 적용
- 불변으로 설계된 `SourcePlcsqlProcedureConfig`의 특성상, setter 없이 스키마명만 업데이트하기 위해 **인스턴스 재생성** 방식을 선택

### Remarks
N/A