### PR TITLE
[TOOLS-4705] Update PL/CSQL procedure, function and unique index file paths when the script name changes

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
@@ -585,7 +585,6 @@ public final class PathUtils {
 
         // plcsql_procedure
         replaceNestedMap(
-                config,
                 config::getTargetPlcsqlProcedureFileName,
                 config::setTargetPlcsqlProcedureFileName,
                 fileRootPath,
@@ -594,7 +593,6 @@ public final class PathUtils {
 
         // plcsql_function
         replaceNestedMap(
-                config,
                 config::getTargetPlcsqlFunctionFileName,
                 config::setTargetPlcsqlFunctionFileName,
                 fileRootPath,
@@ -603,7 +601,6 @@ public final class PathUtils {
 
         // plcsql_procedure_header
         replaceMap(
-                config,
                 config::getTargetAllPlcsqlProcedureHeaderFileName,
                 config::setTargetAllPlcsqlProcedureHeaderFileName,
                 fileRootPath,
@@ -612,7 +609,6 @@ public final class PathUtils {
 
         // plcsql_procedure_all
         replaceMap(
-                config,
                 config::getTargetAllPlcsqlProcedureFileName,
                 config::setTargetAllPlcsqlProcedureFileName,
                 fileRootPath,
@@ -621,7 +617,6 @@ public final class PathUtils {
 
         // plcsql_function_header
         replaceMap(
-                config,
                 config::getTargetAllPlcsqlFunctionHeaderFileName,
                 config::setTargetAllPlcsqlFunctionHeaderFileName,
                 fileRootPath,
@@ -630,7 +625,6 @@ public final class PathUtils {
 
         // plcsql_function_all
         replaceMap(
-                config,
                 config::getTargetAllPlcsqlFunctionFileName,
                 config::setTargetAllPlcsqlFunctionFileName,
                 fileRootPath,
@@ -662,7 +656,6 @@ public final class PathUtils {
 
     /** Replace all paths in Map<String, String> with new object names and store the result */
     private static void replaceMap(
-            MigrationConfiguration config,
             Supplier<Map<String, String>> getter,
             Consumer<Map<String, String>> setter,
             String fileRootPath,
@@ -673,7 +666,6 @@ public final class PathUtils {
 
     /** Replace every path inside a nested Map and store the result */
     private static void replaceNestedMap(
-            MigrationConfiguration config,
             Supplier<Map<String, Map<String, String>>> getter,
             Consumer<Map<String, Map<String, String>>> setter,
             String fileRootPath,

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
@@ -30,6 +30,8 @@
  */
 package com.cubrid.cubridmigration.core.common;
 
+import static java.util.stream.Collectors.toMap;
+
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import java.io.File;
 import java.io.IOException;
@@ -39,7 +41,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -581,66 +584,58 @@ public final class PathUtils {
         config.setTargetGrantFileName(newGrantFilePathMap);
 
         // plcsql_procedure
-        Map<String, Map<String, String>> newPlcsqlProcedureFiles =
-                config.getTargetPlcsqlProcedureFileName().entrySet().stream()
-                        .filter(entry -> entry.getValue() != null)
-                        .collect(
-                                Collectors.toMap(
-                                        Map.Entry::getKey,
-                                        entry ->
-                                                changeOldNameToNewName(
-                                                        entry.getValue(),
-                                                        fileRootPath,
-                                                        oldName,
-                                                        newName)));
-        config.setTargetPlcsqlProcedureFileName(newPlcsqlProcedureFiles);
+        replaceNestedMap(
+                config,
+                config::getTargetPlcsqlProcedureFileName,
+                config::setTargetPlcsqlProcedureFileName,
+                fileRootPath,
+                oldName,
+                newName);
 
         // plcsql_function
-        Map<String, Map<String, String>> newPlcsqlFunctionFiles =
-                config.getTargetPlcsqlFunctionFileName().entrySet().stream()
-                        .filter(entry -> entry.getValue() != null)
-                        .collect(
-                                Collectors.toMap(
-                                        Map.Entry::getKey,
-                                        entry ->
-                                                changeOldNameToNewName(
-                                                        entry.getValue(),
-                                                        fileRootPath,
-                                                        oldName,
-                                                        newName)));
-        config.setTargetPlcsqlFunctionFileName(newPlcsqlFunctionFiles);
+        replaceNestedMap(
+                config,
+                config::getTargetPlcsqlFunctionFileName,
+                config::setTargetPlcsqlFunctionFileName,
+                fileRootPath,
+                oldName,
+                newName);
 
         // plcsql_procedure_header
-        config.setTargetAllPlcsqlProcedureHeaderFileName(
-                changeOldNameToNewName(
-                        config.getTargetAllPlcsqlProcedureHeaderFileName(),
-                        fileRootPath,
-                        oldName,
-                        newName));
+        replaceMap(
+                config,
+                config::getTargetAllPlcsqlProcedureHeaderFileName,
+                config::setTargetAllPlcsqlProcedureHeaderFileName,
+                fileRootPath,
+                oldName,
+                newName);
 
         // plcsql_procedure_all
-        config.setTargetAllPlcsqlProcedureFileName(
-                changeOldNameToNewName(
-                        config.getTargetAllPlcsqlProcedureFileName(),
-                        fileRootPath,
-                        oldName,
-                        newName));
+        replaceMap(
+                config,
+                config::getTargetAllPlcsqlProcedureFileName,
+                config::setTargetAllPlcsqlProcedureFileName,
+                fileRootPath,
+                oldName,
+                newName);
 
         // plcsql_function_header
-        config.setTargetAllPlcsqlFunctionHeaderFileName(
-                changeOldNameToNewName(
-                        config.getTargetAllPlcsqlFunctionHeaderFileName(),
-                        fileRootPath,
-                        oldName,
-                        newName));
+        replaceMap(
+                config,
+                config::getTargetAllPlcsqlFunctionHeaderFileName,
+                config::setTargetAllPlcsqlFunctionHeaderFileName,
+                fileRootPath,
+                oldName,
+                newName);
 
         // plcsql_function_all
-        config.setTargetAllPlcsqlFunctionFileName(
-                changeOldNameToNewName(
-                        config.getTargetAllPlcsqlFunctionFileName(),
-                        fileRootPath,
-                        oldName,
-                        newName));
+        replaceMap(
+                config,
+                config::getTargetAllPlcsqlFunctionFileName,
+                config::setTargetAllPlcsqlFunctionFileName,
+                fileRootPath,
+                oldName,
+                newName);
 
         // updatestatistic
         config.setTargetUpdateStatisticFileName(
@@ -663,6 +658,40 @@ public final class PathUtils {
                                             tableDataFilePathList, fileRootPath, oldName, newName));
                         });
         config.setTargetTableDataFileName(newTableDataFilePath);
+    }
+
+    /** Replace all paths in Map<String, String> with new object names and store the result */
+    private static void replaceMap(
+            MigrationConfiguration config,
+            Supplier<Map<String, String>> getter,
+            Consumer<Map<String, String>> setter,
+            String fileRootPath,
+            String oldName,
+            String newName) {
+        setter.accept(changeOldNameToNewName(getter.get(), fileRootPath, oldName, newName));
+    }
+
+    /** Replace every path inside a nested Map and store the result */
+    private static void replaceNestedMap(
+            MigrationConfiguration config,
+            Supplier<Map<String, Map<String, String>>> getter,
+            Consumer<Map<String, Map<String, String>>> setter,
+            String fileRootPath,
+            String oldName,
+            String newName) {
+        Map<String, Map<String, String>> replaced =
+                getter.get().entrySet().stream()
+                        .filter(e -> e.getValue() != null)
+                        .collect(
+                                toMap(
+                                        Map.Entry::getKey,
+                                        e ->
+                                                changeOldNameToNewName(
+                                                        e.getValue(),
+                                                        fileRootPath,
+                                                        oldName,
+                                                        newName)));
+        setter.accept(replaced);
     }
 
     /** change directory path */

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -578,6 +579,68 @@ public final class PathUtils {
             }
         }
         config.setTargetGrantFileName(newGrantFilePathMap);
+
+        // plcsql_procedure
+        Map<String, Map<String, String>> newPlcsqlProcedureFiles =
+                config.getTargetPlcsqlProcedureFileName().entrySet().stream()
+                        .filter(entry -> entry.getValue() != null)
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        entry ->
+                                                changeOldNameToNewName(
+                                                        entry.getValue(),
+                                                        fileRootPath,
+                                                        oldName,
+                                                        newName)));
+        config.setTargetPlcsqlProcedureFileName(newPlcsqlProcedureFiles);
+
+        // plcsql_function
+        Map<String, Map<String, String>> newPlcsqlFunctionFiles =
+                config.getTargetPlcsqlFunctionFileName().entrySet().stream()
+                        .filter(entry -> entry.getValue() != null)
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        entry ->
+                                                changeOldNameToNewName(
+                                                        entry.getValue(),
+                                                        fileRootPath,
+                                                        oldName,
+                                                        newName)));
+        config.setTargetPlcsqlFunctionFileName(newPlcsqlFunctionFiles);
+
+        // plcsql_procedure_header
+        config.setTargetAllPlcsqlProcedureHeaderFileName(
+                changeOldNameToNewName(
+                        config.getTargetAllPlcsqlProcedureHeaderFileName(),
+                        fileRootPath,
+                        oldName,
+                        newName));
+
+        // plcsql_procedure_all
+        config.setTargetAllPlcsqlProcedureFileName(
+                changeOldNameToNewName(
+                        config.getTargetAllPlcsqlProcedureFileName(),
+                        fileRootPath,
+                        oldName,
+                        newName));
+
+        // plcsql_function_header
+        config.setTargetAllPlcsqlFunctionHeaderFileName(
+                changeOldNameToNewName(
+                        config.getTargetAllPlcsqlFunctionHeaderFileName(),
+                        fileRootPath,
+                        oldName,
+                        newName));
+
+        // plcsql_function_all
+        config.setTargetAllPlcsqlFunctionFileName(
+                changeOldNameToNewName(
+                        config.getTargetAllPlcsqlFunctionFileName(),
+                        fileRootPath,
+                        oldName,
+                        newName));
 
         // updatestatistic
         config.setTargetUpdateStatisticFileName(

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/PathUtils.java
@@ -550,6 +550,14 @@ public final class PathUtils {
                 changeOldNameToNewName(
                         config.getTargetIndexFileName(), fileRootPath, oldName, newName));
 
+        // unique index
+        replaceMap(
+                config::getTargetUniqueIndexFileName,
+                config::setTargetUniqueIndexFileName,
+                fileRootPath,
+                oldName,
+                newName);
+
         // pk
         config.setTargetPkFileName(
                 changeOldNameToNewName(


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4705

**Purpose**
- 마이그레이션 스크립트 이름 변경 시 변경된 이름으로 PL/CSQL Procedure, Function과 Unique index 파일 디렉터리가 생성될 수 있도록 기능 추가

**Implementation**
- config 객체 내부 PL/CSQL Procedure, Function과 Unique index 파일 경로 필드 일관 갱신
- 중복되는 코드 헬퍼 메서드로 분리
  - "파일 경로 가져오기 -> `changeOldNameToNewName()`로 치환 ->  저장" 부분이 계속 반복되어 헬퍼 메서드를 생성해 따로 분리