### PR TITLE
[TOOLS-4708] Migration Wizard Step 6: Output _uk file only for unique indexes that are not primary keys

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/DBUtils.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/common/DBUtils.java
@@ -31,6 +31,8 @@
 package com.cubrid.cubridmigration.core.common;
 
 import com.cubrid.cubridmigration.core.dbobject.Column;
+import com.cubrid.cubridmigration.core.dbobject.Index;
+import com.cubrid.cubridmigration.core.dbobject.PK;
 import com.cubrid.cubridmigration.core.dbobject.PartitionInfo;
 import com.cubrid.cubridmigration.core.dbobject.Table;
 import java.io.IOException;
@@ -233,6 +235,28 @@ public final class DBUtils {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Determines whether the given index is an additional unique index (i.e., a unique index that
+     * is not the primary key index).
+     *
+     * @param pk
+     * @param index
+     * @return {@code true} if the index is unique and does not exactly match the primary key
+     *     columns; {@code false} if the index is not unique or exactly matches the primary key
+     *     columns
+     */
+    public static boolean isAdditionalUniqueIndex(PK pk, Index index) {
+        if (!index.isUnique()) {
+            return false;
+        }
+
+        if (pk == null) {
+            return true;
+        }
+
+        return !pk.getPkColumns().equals(index.getColumnNames());
     }
 
     /**

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
@@ -607,7 +607,6 @@ public class ConfirmationPage extends BaseConfirmationPage {
                         }
                     }
                 }
-
                 if (styleRanges != null) {
                     styleRanges.add(
                             new StyleRange(

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
@@ -30,10 +30,14 @@
  */
 package com.cubrid.cubridmigration.ui.wizard.page;
 
+import static com.cubrid.cubridmigration.core.common.DBUtils.isAdditionalUniqueIndex;
 import static com.cubrid.cubridmigration.core.dbtype.DatabaseType.getDatabaseTypeByID;
 
 import com.cubrid.cubridmigration.core.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbobject.Index;
+import com.cubrid.cubridmigration.core.dbobject.PK;
+import com.cubrid.cubridmigration.core.dbobject.Table;
 import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import com.cubrid.cubridmigration.core.engine.config.SourceConfig;
@@ -590,7 +594,11 @@ public class ConfirmationPage extends BaseConfirmationPage {
                     }
 
                     for (SourceIndexConfig sic : expTable.getIndexConfigList()) {
-                        if (sic.isUnique()) {
+                        Table table = migration.getSrcTableSchema(owner, expTable.getName());
+                        PK pk = table.getPk();
+                        Index index = table.getIndexByName(sic.getName());
+
+                        if (isAdditionalUniqueIndex(pk, index)) {
                             expUniqueIndex.add(owner);
                             text.append(tabSeparator).append(tabSeparator);
                             text.append(migration.getTargetUniqueIndexFileName(owner));
@@ -599,6 +607,7 @@ public class ConfirmationPage extends BaseConfirmationPage {
                         }
                     }
                 }
+
                 if (styleRanges != null) {
                     styleRanges.add(
                             new StyleRange(


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4708

**Purpose**
마이그레이션 마법사 6페이지에서 PK만 존재해도 `_uk` 파일 경로가 표시되는 문제를 수정합니다.
PK와 사용자가 추가한 Unique Index를 정확히 구분해, PK가 아닌 Unique Index가 있을 때만 마이그레이션 마법사 6페이지에 `_uk` 파일 경로가 출력되도록 합니다.

**Implementation**
- DBUtilsd 클래스에 사용자 정의 Unique Index 구분 메서드 추가
  - Unique Index이고 PK 컬럼, 순서가 완전히 다르면 사용자가 정의한 Unique Index로 판단합니다.

**Remarks**
N/A