### PR TITLE
[TOOLS-4711] Apply .sql extension to the 'uk' file in CSV/XLS

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -5520,6 +5520,7 @@ public class MigrationConfiguration {
             case "vclass_query_spec":
             case "pk":
             case "fk":
+            case "uk":
             case "serial":
             case "synonym":
             case "info":


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4711

**Purpose**
대상 유형이 CSV, XLS인 경우 uk 파일의 확장자를 .sql로 설정할 수 있도록 파일 확장자 설정 조건 수정

**Implementation**
N/A

**Remarks**
- #264 