### PR TITLE
[TOOLS-4716] Add PowerShell build script for Windows support

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -23,14 +23,14 @@ function show_usage {
 "@ | Write-Output
 }
 
-$Profile = switch ($ProfileArg.ToLower()) {
+$SelectedProfile = switch ($ProfileArg.ToLower()) {
     'a' { 'all' }
     'd' { 'desktop' }
     'c' { 'console' }
     Default { $_ }
 }
 
-if ($Profile -notin @('all','desktop','console')) {
+if ($SelectedProfile -notin @('all','desktop','console')) {
     show_usage
     exit 1
 }
@@ -113,7 +113,7 @@ function copy_consolecmt_to_directory {
 
 function copy_cmt_to_directory {
     if (-not (Test-Path $TARGET)) { New-Item -ItemType Directory -Path $TARGET | Out-Null }
-    switch ($Profile) {
+    switch ($SelectedProfile) {
         "all" { copy_desktopcmt_to_directory; copy_consolecmt_to_directory }
         "desktop" { copy_desktopcmt_to_directory }
         "console" { copy_consolecmt_to_directory }
@@ -142,7 +142,7 @@ $MVN_DEBUG = if ($Debug) { @("-Dtycho.debug.resolver=true", "-X") } else { @() }
 print_env
 update_build_version
 
-switch ($Profile) {
+switch ($SelectedProfile) {
     "all" {
         & $MVN clean package "-Dcubridmigration-version=$RELEASE_VERSION" -Pdesktop $MVN_DEBUG
         & $MVN clean package "-Dcubridmigration-version=$RELEASE_VERSION" -Pconsole $MVN_DEBUG

--- a/build.ps1
+++ b/build.ps1
@@ -55,7 +55,6 @@ function Resolve-Maven {
         $Path = Join-Path $env:MAVEN_HOME "bin" "mvn"
         if (Test-Path $Path) { return $Path }
     }
-
     Write-Error "Maven not found in PATH or MAVEN_HOME"
 }
 
@@ -67,7 +66,6 @@ function Show-Env {
 function Update-BuildVersion {
     [CmdletBinding(SupportsShouldProcess=$true)]
     param()
-
     if (-not $PSCmdlet.ShouldProcess("version.properties", "update build version")) { return }
 
     Write-Output "Version File Update....  (com.cubrid.cubridmigration.ui/version.properties)"
@@ -75,16 +73,13 @@ function Update-BuildVersion {
     $CommitNumber = if (Test-Path ".git") {
         "{0:D4}" -f [int](& git rev-list --count HEAD).Trim()
     } else { "0000" }
-
     $Version = ((Get-Content $VersionFilePath | Select-String "^version=").ToString().Split('=')[1]).Trim()
+    $ReleaseVersion = "$Version.$CommitNumber"
 
     (Get-Content $ReleaseVersionFilePath |
         Where-Object { $_ -notmatch "^(releaseVersion|buildVersionId)=" }) |
         Set-Content $ReleaseVersionFilePath
-
     Add-Content $ReleaseVersionFilePath "releaseVersion=$Version"
-
-    $ReleaseVersion = "$Version.$CommitNumber"
     Add-Content $ReleaseVersionFilePath "buildVersionId=$ReleaseVersion"
 
     Write-Output "VERSION= $Version"

--- a/build.ps1
+++ b/build.ps1
@@ -59,7 +59,7 @@ function Resolve-Maven {
     Write-Error "Maven not found in PATH or MAVEN_HOME"
 }
 
-function Print-Env {
+function Show-Env {
     if ($env:JAVA_HOME) { Write-Output "JAVA_HOME: $($env:JAVA_HOME)" }
     if ($env:MAVEN_HOME) { Write-Output "MAVEN_HOME: $($env:MAVEN_HOME)" }
 }
@@ -140,7 +140,7 @@ function Show-CMTBanner {
 Show-CMTBanner
 $Mvn = Resolve-Maven
 $MvnDebug = if ($Debug) { @("-Dtycho.debug.resolver=true", "-X") } else { @() }
-Print-Env
+Show-Env
 Update-BuildVersion
 
 switch ($SelectedProfile) {

--- a/build.ps1
+++ b/build.ps1
@@ -20,7 +20,7 @@ function show_usage {
   build.ps1 -p desktop -X
   build.ps1 -p c -X
   build.ps1
-"@ | Write-Host
+"@ | Write-Output
 }
 
 $Profile = switch ($ProfileArg.ToLower()) {
@@ -59,12 +59,12 @@ function resolve_maven {
 }
 
 function print_env {
-    if ($env:JAVA_HOME) { Write-Host "JAVA_HOME: $($env:JAVA_HOME)" }
-    if ($env:MAVEN_HOME) { Write-Host "MAVEN_HOME: $($env:MAVEN_HOME)" }
+    if ($env:JAVA_HOME) { Write-Output "JAVA_HOME: $($env:JAVA_HOME)" }
+    if ($env:MAVEN_HOME) { Write-Output "MAVEN_HOME: $($env:MAVEN_HOME)" }
 }
 
 function update_build_version {
-    Write-Host "Version File Update....  (com.cubrid.cubridmigration.ui/version.properties)"
+    Write-Output "Version File Update....  (com.cubrid.cubridmigration.ui/version.properties)"
 
     $COMMIT_NUMBER = if (Test-Path ".git") {
         "{0:D4}" -f [int](& git rev-list --count HEAD).Trim()
@@ -81,9 +81,9 @@ function update_build_version {
     $script:RELEASE_VERSION = "$VERSION.$COMMIT_NUMBER"
     Add-Content $RELEASE_VERSION_FILE_PATH "buildVersionId=$RELEASE_VERSION"
 
-    Write-Host "VERSION= $VERSION"
-    Write-Host "COMMIT_NUMBER= $COMMIT_NUMBER"
-    Write-Host "RELEASE_VERSION= $RELEASE_VERSION"
+    Write-Output "VERSION= $VERSION"
+    Write-Output "COMMIT_NUMBER= $COMMIT_NUMBER"
+    Write-Output "RELEASE_VERSION= $RELEASE_VERSION"
 }
 
 function copy_desktopcmt_to_directory {
@@ -132,7 +132,7 @@ function cmt_banner {
     \/___/    \/_/ \/_/      \/_/
 
 
-'@ | Write-Host
+'@ | Write-Output
 }
 
 # ----------------------------- MAIN ----------------------------- #

--- a/build.ps1
+++ b/build.ps1
@@ -65,6 +65,11 @@ function Show-Env {
 }
 
 function Update-BuildVersion {
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param()
+
+    if (-not $PSCmdlet.ShouldProcess("version.properties", "update build version")) { return }
+
     Write-Output "Version File Update....  (com.cubrid.cubridmigration.ui/version.properties)"
 
     $CommitNumber = if (Test-Path ".git") {

--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,7 @@ Param(
 
 $ErrorActionPreference = "Stop"
 
-function show_usage {
+function Show-Usage {
 @"
  OPTIONS
   -p [all(a)/desktop(d)/console(c)]       select profile
@@ -31,96 +31,97 @@ $SelectedProfile = switch ($ProfileArg.ToLower()) {
 }
 
 if ($SelectedProfile -notin @('all','desktop','console')) {
-    show_usage
+    Show-Usage
     exit 1
 }
 
-$DIR                       = (Get-Location).Path
-$TARGET                    = Join-Path $DIR "target"
-$PRODUCT_TARGET            = Join-Path $DIR "com.cubrid.cubridmigration.product/target"
-$CONSOLE_TARGET            = Join-Path $DIR "com.cubrid.cubridmigration.console/target"
-$VERSION_FILE_PATH         = Join-Path $DIR "VERSION"
-$RELEASE_VERSION_FILE_PATH = Join-Path $DIR "com.cubrid.cubridmigration.ui/version.properties"
-$RELEASE_VERSION           = ""
-$CMT_PRODUCT_NAME          = "CUBRID-Migration-Toolkit"
-$CMT_CONSOLE_NAME          = "$CMT_PRODUCT_NAME-console"
-$CMT_SITE_NAME             = "$CMT_PRODUCT_NAME-site"
+$Dir                      = (Get-Location).Path
+$Target                   = Join-Path $Dir "target"
+$ProductTarget            = Join-Path $Dir "com.cubrid.cubridmigration.product/target"
+$ConsoleTarget            = Join-Path $Dir "com.cubrid.cubridmigration.console/target"
+$VersionFilePath          = Join-Path $Dir "VERSION"
+$RelaseVersionFilePath    = Join-Path $Dir "com.cubrid.cubridmigration.ui/version.properties"
+$ReleaseVersion           = ""
 
-function resolve_maven {
-    $cmd = Get-Command mvn -ErrorAction SilentlyContinue
-    if ($cmd) { return $cmd.Source }
+$CmtProductName           = "CUBRID-Migration-Toolkit"
+$CmtConsoleName           = "$CmtProductName-console"
+$CmtSiteName              = "$CmtProductName-site"
+
+function Resolve-Maven {
+    $Cmd = Get-Command mvn -ErrorAction SilentlyContinue
+    if ($Cmd) { return $Cmd.Source }
 
     if ($env:MAVEN_HOME) {
-        $path = Join-Path $env:MAVEN_HOME "bin" "mvn"
-        if (Test-Path $path) { return $path }
+        $Path = Join-Path $env:MAVEN_HOME "bin" "mvn"
+        if (Test-Path $Path) { return $Path }
     }
 
     Write-Error "Maven not found in PATH or MAVEN_HOME"
 }
 
-function print_env {
+function Print-Env {
     if ($env:JAVA_HOME) { Write-Output "JAVA_HOME: $($env:JAVA_HOME)" }
     if ($env:MAVEN_HOME) { Write-Output "MAVEN_HOME: $($env:MAVEN_HOME)" }
 }
 
-function update_build_version {
+function Update-BuildVersion {
     Write-Output "Version File Update....  (com.cubrid.cubridmigration.ui/version.properties)"
 
-    $COMMIT_NUMBER = if (Test-Path ".git") {
+    $CommitNumber = if (Test-Path ".git") {
         "{0:D4}" -f [int](& git rev-list --count HEAD).Trim()
     } else { "0000" }
 
-    $VERSION = ((Get-Content $VERSION_FILE_PATH | Select-String "^version=").ToString().Split('=')[1]).Trim()
+    $Version = ((Get-Content $VersionFilePath | Select-String "^version=").ToString().Split('=')[1]).Trim()
 
-    (Get-Content $RELEASE_VERSION_FILE_PATH |
+    (Get-Content $RelaseVersionFilePath |
         Where-Object { $_ -notmatch "^(releaseVersion|buildVersionId)=" }) |
-        Set-Content $RELEASE_VERSION_FILE_PATH
+        Set-Content $RelaseVersionFilePath
 
-    Add-Content $RELEASE_VERSION_FILE_PATH "releaseVersion=$VERSION"
+    Add-Content $RelaseVersionFilePath "releaseVersion=$Version"
 
-    $script:RELEASE_VERSION = "$VERSION.$COMMIT_NUMBER"
-    Add-Content $RELEASE_VERSION_FILE_PATH "buildVersionId=$RELEASE_VERSION"
+    $ReleaseVersion = "$Version.$CommitNumber"
+    Add-Content $RelaseVersionFilePath "buildVersionId=$ReleaseVersion"
 
-    Write-Output "VERSION= $VERSION"
-    Write-Output "COMMIT_NUMBER= $COMMIT_NUMBER"
-    Write-Output "RELEASE_VERSION= $RELEASE_VERSION"
+    Write-Output "VERSION= $Version"
+    Write-Output "COMMIT_NUMBER= $CommitNumber"
+    Write-Output "RELEASE_VERSION= $ReleaseVersion"
 }
 
-function copy_desktopcmt_to_directory {
-    $CMT_LINUX = Join-Path $PRODUCT_TARGET "$CMT_PRODUCT_NAME-$RELEASE_VERSION-linux-x86_64.tar.gz"
-    if (Test-Path $CMT_LINUX) { Copy-Item $CMT_LINUX -Destination $TARGET -Force -Verbose }
+function Copy-DesktopCMTToDirectory {
+    $CmtLinux = Join-Path $ProductTarget "$CmtProductName-$ReleaseVersion-linux-x86_64.tar.gz"
+    if (Test-Path $CmtLinux) { Copy-Item $CmtLinux -Destination $Target -Force -Verbose }
 
-    $CMT_MAC = Join-Path $PRODUCT_TARGET "$CMT_PRODUCT_NAME-$RELEASE_VERSION-macosx-cocoa-x86_64.tar.gz"
-    if (Test-Path $CMT_MAC) { Copy-Item $CMT_MAC -Destination $TARGET -Force -Verbose }
+    $CmtMac = Join-Path $ProductTarget "$CmtProductName-$ReleaseVersion-macosx-cocoa-x86_64.tar.gz"
+    if (Test-Path $CmtMac) { Copy-Item $CmtMac -Destination $Target -Force -Verbose }
 
-    $CMT_WINDOWS = Join-Path $PRODUCT_TARGET "$CMT_PRODUCT_NAME-$RELEASE_VERSION-windows-x64.zip"
-    if (Test-Path $CMT_WINDOWS) { Copy-Item $CMT_WINDOWS -Destination $TARGET -Force -Verbose }
+    $CmtWindows = Join-Path $ProductTarget "$CmtProductName-$ReleaseVersion-windows-x64.zip"
+    if (Test-Path $CmtWindows) { Copy-Item $CmtWindows -Destination $Target -Force -Verbose }
 
-    $CMT_SITE_TAR_GZ = Join-Path $PRODUCT_TARGET "$CMT_SITE_NAME-$RELEASE_VERSION.tar.gz"
-    if (Test-Path $CMT_SITE_TAR_GZ) { Copy-Item $CMT_SITE_TAR_GZ -Destination $TARGET -Force -Verbose }
+    $CmtSiteTargz = Join-Path $ProductTarget "$CmtSiteName-$ReleaseVersion.tar.gz"
+    if (Test-Path $CmtSiteTargz) { Copy-Item $CmtSiteTargz -Destination $Target -Force -Verbose }
 
-    $CMT_SITE_ZIP = Join-Path $PRODUCT_TARGET "$CMT_SITE_NAME-$RELEASE_VERSION.zip"
-    if (Test-Path $CMT_SITE_ZIP) { Copy-Item $CMT_SITE_ZIP -Destination $TARGET -Force -Verbose }
+    $CmtSiteZip = Join-Path $ProductTarget "$CmtSiteName-$ReleaseVersion.zip"
+    if (Test-Path $CmtSiteZip) { Copy-Item $CmtSiteZip -Destination $Target -Force -Verbose }
 }
 
-function copy_consolecmt_to_directory {
-    $CONSOLE_LINUX = Join-Path $CONSOLE_TARGET "$CMT_CONSOLE_NAME-$RELEASE_VERSION-linux.tar.gz"
-    if (Test-Path $CONSOLE_LINUX) { Copy-Item $CONSOLE_LINUX -Destination $TARGET -Force -Verbose }
+function Copy-ConsoleCMTToDirectory {
+    $ConsoleLinux = Join-Path $ConsoleTarget "$CmtConsoleName-$ReleaseVersion-linux.tar.gz"
+    if (Test-Path $ConsoleLinux) { Copy-Item $ConsoleLinux -Destination $Target -Force -Verbose }
 
-    $CONSOLE_WINDOWS = Join-Path $CONSOLE_TARGET "$CMT_CONSOLE_NAME-$RELEASE_VERSION-windows.zip"
-    if (Test-Path $CONSOLE_WINDOWS) { Copy-Item $CONSOLE_WINDOWS -Destination $TARGET -Force -Verbose }
+    $ConsoleWindows = Join-Path $ConsoleTarget "$CmtConsoleName-$ReleaseVersion-windows.zip"
+    if (Test-Path $ConsoleWindows) { Copy-Item $ConsoleWindows -Destination $Target -Force -Verbose }
 }
 
-function copy_cmt_to_directory {
-    if (-not (Test-Path $TARGET)) { New-Item -ItemType Directory -Path $TARGET | Out-Null }
+function Copy-CMTToDirectory {
+    if (-not (Test-Path $Target)) { New-Item -ItemType Directory -Path $Target | Out-Null }
     switch ($SelectedProfile) {
-        "all" { copy_desktopcmt_to_directory; copy_consolecmt_to_directory }
-        "desktop" { copy_desktopcmt_to_directory }
-        "console" { copy_consolecmt_to_directory }
+        "all" { Copy-DesktopCMTToDirectory; Copy-ConsoleCMTToDirectory }
+        "desktop" { Copy-DesktopCMTToDirectory }
+        "console" { Copy-ConsoleCMTToDirectory }
     }
 }
 
-function cmt_banner {
+function Show-CMTBanner {
 @'
 
  ____                   ______
@@ -136,23 +137,23 @@ function cmt_banner {
 }
 
 # ----------------------------- MAIN ----------------------------- #
-cmt_banner
-$MVN = resolve_maven
-$MVN_DEBUG = if ($Debug) { @("-Dtycho.debug.resolver=true", "-X") } else { @() }
-print_env
-update_build_version
+Show-CMTBanner
+$Mvn = Resolve-Maven
+$MvnDebug = if ($Debug) { @("-Dtycho.debug.resolver=true", "-X") } else { @() }
+Print-Env
+Update-BuildVersion
 
 switch ($SelectedProfile) {
     "all" {
-        & $MVN clean package "-Dcubridmigration-version=$RELEASE_VERSION" -Pdesktop $MVN_DEBUG
-        & $MVN clean package "-Dcubridmigration-version=$RELEASE_VERSION" -Pconsole $MVN_DEBUG
+        & $Mvn clean package "-Dcubridmigration-version=$ReleaseVersion" -Pdesktop $MvnDebug
+        & $Mvn clean package "-Dcubridmigration-version=$ReleaseVersion" -Pconsole $MvnDebug
     }
     "desktop" {
-        & $MVN clean package "-Dcubridmigration-version=$RELEASE_VERSION" -Pdesktop $MVN_DEBUG
+        & $Mvn clean package "-Dcubridmigration-version=$ReleaseVersion" -Pdesktop $MvnDebug
     }
     "console" {
-        & $MVN clean package "-Dcubridmigration-version=$RELEASE_VERSION" -Pconsole $MVN_DEBUG
+        & $Mvn clean package "-Dcubridmigration-version=$ReleaseVersion" -Pconsole $MvnDebug
     }
 }
 
-copy_cmt_to_directory
+Copy-CMTToDirectory

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,158 @@
+#!/usr/bin/env pwsh
+
+Param(
+    [Alias('p')]
+    [string]$ProfileArg = "all",
+
+    [Alias('X')]
+    [switch]$Debug
+)
+
+$ErrorActionPreference = "Stop"
+
+function show_usage {
+@"
+ OPTIONS
+  -p [all(a)/desktop(d)/console(c)]       select profile
+  -X                                      enable debug log
+
+ EXAMPLES
+  build.ps1 -p desktop -X
+  build.ps1 -p c -X
+  build.ps1
+"@ | Write-Host
+}
+
+$Profile = switch ($ProfileArg.ToLower()) {
+    'a' { 'all' }
+    'd' { 'desktop' }
+    'c' { 'console' }
+    Default { $_ }
+}
+
+if ($Profile -notin @('all','desktop','console')) {
+    show_usage
+    exit 1
+}
+
+$DIR                       = (Get-Location).Path
+$TARGET                    = Join-Path $DIR "target"
+$PRODUCT_TARGET            = Join-Path $DIR "com.cubrid.cubridmigration.product/target"
+$CONSOLE_TARGET            = Join-Path $DIR "com.cubrid.cubridmigration.console/target"
+$VERSION_FILE_PATH         = Join-Path $DIR "VERSION"
+$RELEASE_VERSION_FILE_PATH = Join-Path $DIR "com.cubrid.cubridmigration.ui/version.properties"
+$RELEASE_VERSION           = ""
+$CMT_PRODUCT_NAME          = "CUBRID-Migration-Toolkit"
+$CMT_CONSOLE_NAME          = "$CMT_PRODUCT_NAME-console"
+$CMT_SITE_NAME             = "$CMT_PRODUCT_NAME-site"
+
+function resolve_maven {
+    $cmd = Get-Command mvn -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+
+    if ($env:MAVEN_HOME) {
+        $path = Join-Path $env:MAVEN_HOME "bin" "mvn"
+        if (Test-Path $path) { return $path }
+    }
+
+    Write-Error "Maven not found in PATH or MAVEN_HOME"
+}
+
+function print_env {
+    if ($env:JAVA_HOME) { Write-Host "JAVA_HOME: $($env:JAVA_HOME)" }
+    if ($env:MAVEN_HOME) { Write-Host "MAVEN_HOME: $($env:MAVEN_HOME)" }
+}
+
+function update_build_version {
+    Write-Host "Version File Update....  (com.cubrid.cubridmigration.ui/version.properties)"
+
+    $COMMIT_NUMBER = if (Test-Path ".git") {
+        "{0:D4}" -f [int](& git rev-list --count HEAD).Trim()
+    } else { "0000" }
+
+    $VERSION = ((Get-Content $VERSION_FILE_PATH | Select-String "^version=").ToString().Split('=')[1]).Trim()
+
+    (Get-Content $RELEASE_VERSION_FILE_PATH |
+        Where-Object { $_ -notmatch "^(releaseVersion|buildVersionId)=" }) |
+        Set-Content $RELEASE_VERSION_FILE_PATH
+
+    Add-Content $RELEASE_VERSION_FILE_PATH "releaseVersion=$VERSION"
+
+    $script:RELEASE_VERSION = "$VERSION.$COMMIT_NUMBER"
+    Add-Content $RELEASE_VERSION_FILE_PATH "buildVersionId=$RELEASE_VERSION"
+
+    Write-Host "VERSION= $VERSION"
+    Write-Host "COMMIT_NUMBER= $COMMIT_NUMBER"
+    Write-Host "RELEASE_VERSION= $RELEASE_VERSION"
+}
+
+function copy_desktopcmt_to_directory {
+    $CMT_LINUX = Join-Path $PRODUCT_TARGET "$CMT_PRODUCT_NAME-$RELEASE_VERSION-linux-x86_64.tar.gz"
+    if (Test-Path $CMT_LINUX) { Copy-Item $CMT_LINUX -Destination $TARGET -Force -Verbose }
+
+    $CMT_MAC = Join-Path $PRODUCT_TARGET "$CMT_PRODUCT_NAME-$RELEASE_VERSION-macosx-cocoa-x86_64.tar.gz"
+    if (Test-Path $CMT_MAC) { Copy-Item $CMT_MAC -Destination $TARGET -Force -Verbose }
+
+    $CMT_WINDOWS = Join-Path $PRODUCT_TARGET "$CMT_PRODUCT_NAME-$RELEASE_VERSION-windows-x64.zip"
+    if (Test-Path $CMT_WINDOWS) { Copy-Item $CMT_WINDOWS -Destination $TARGET -Force -Verbose }
+
+    $CMT_SITE_TAR_GZ = Join-Path $PRODUCT_TARGET "$CMT_SITE_NAME-$RELEASE_VERSION.tar.gz"
+    if (Test-Path $CMT_SITE_TAR_GZ) { Copy-Item $CMT_SITE_TAR_GZ -Destination $TARGET -Force -Verbose }
+
+    $CMT_SITE_ZIP = Join-Path $PRODUCT_TARGET "$CMT_SITE_NAME-$RELEASE_VERSION.zip"
+    if (Test-Path $CMT_SITE_ZIP) { Copy-Item $CMT_SITE_ZIP -Destination $TARGET -Force -Verbose }
+}
+
+function copy_consolecmt_to_directory {
+    $CONSOLE_LINUX = Join-Path $CONSOLE_TARGET "$CMT_CONSOLE_NAME-$RELEASE_VERSION-linux.tar.gz"
+    if (Test-Path $CONSOLE_LINUX) { Copy-Item $CONSOLE_LINUX -Destination $TARGET -Force -Verbose }
+
+    $CONSOLE_WINDOWS = Join-Path $CONSOLE_TARGET "$CMT_CONSOLE_NAME-$RELEASE_VERSION-windows.zip"
+    if (Test-Path $CONSOLE_WINDOWS) { Copy-Item $CONSOLE_WINDOWS -Destination $TARGET -Force -Verbose }
+}
+
+function copy_cmt_to_directory {
+    if (-not (Test-Path $TARGET)) { New-Item -ItemType Directory -Path $TARGET | Out-Null }
+    switch ($Profile) {
+        "all" { copy_desktopcmt_to_directory; copy_consolecmt_to_directory }
+        "desktop" { copy_desktopcmt_to_directory }
+        "console" { copy_consolecmt_to_directory }
+    }
+}
+
+function cmt_banner {
+@'
+
+ ____                   ______
+/\  _`\     /`\_/`\    /\__  _\
+\ \ \/\_\  /\      \   \/_\/\ \/
+ \ \ \/_/_ \ \ \__\ \     \ \ \
+  \ \ \L\ \ \ \ \_/\ \     \ \ \
+   \ \____/  \ \_\\ \_\     \ \_\
+    \/___/    \/_/ \/_/      \/_/
+
+
+'@ | Write-Host
+}
+
+# ----------------------------- MAIN ----------------------------- #
+cmt_banner
+$MVN = resolve_maven
+$MVN_DEBUG = if ($Debug) { @("-Dtycho.debug.resolver=true", "-X") } else { @() }
+print_env
+update_build_version
+
+switch ($Profile) {
+    "all" {
+        & $MVN clean package "-Dcubridmigration-version=$RELEASE_VERSION" -Pdesktop $MVN_DEBUG
+        & $MVN clean package "-Dcubridmigration-version=$RELEASE_VERSION" -Pconsole $MVN_DEBUG
+    }
+    "desktop" {
+        & $MVN clean package "-Dcubridmigration-version=$RELEASE_VERSION" -Pdesktop $MVN_DEBUG
+    }
+    "console" {
+        & $MVN clean package "-Dcubridmigration-version=$RELEASE_VERSION" -Pconsole $MVN_DEBUG
+    }
+}
+
+copy_cmt_to_directory

--- a/build.ps1
+++ b/build.ps1
@@ -40,7 +40,7 @@ $Target                   = Join-Path $Dir "target"
 $ProductTarget            = Join-Path $Dir "com.cubrid.cubridmigration.product/target"
 $ConsoleTarget            = Join-Path $Dir "com.cubrid.cubridmigration.console/target"
 $VersionFilePath          = Join-Path $Dir "VERSION"
-$RelaseVersionFilePath    = Join-Path $Dir "com.cubrid.cubridmigration.ui/version.properties"
+$ReleaseVersionFilePath   = Join-Path $Dir "com.cubrid.cubridmigration.ui/version.properties"
 $ReleaseVersion           = ""
 
 $CmtProductName           = "CUBRID-Migration-Toolkit"
@@ -73,14 +73,14 @@ function Update-BuildVersion {
 
     $Version = ((Get-Content $VersionFilePath | Select-String "^version=").ToString().Split('=')[1]).Trim()
 
-    (Get-Content $RelaseVersionFilePath |
+    (Get-Content $ReleaseVersionFilePath |
         Where-Object { $_ -notmatch "^(releaseVersion|buildVersionId)=" }) |
-        Set-Content $RelaseVersionFilePath
+        Set-Content $ReleaseVersionFilePath
 
-    Add-Content $RelaseVersionFilePath "releaseVersion=$Version"
+    Add-Content $ReleaseVersionFilePath "releaseVersion=$Version"
 
     $ReleaseVersion = "$Version.$CommitNumber"
-    Add-Content $RelaseVersionFilePath "buildVersionId=$ReleaseVersion"
+    Add-Content $ReleaseVersionFilePath "buildVersionId=$ReleaseVersion"
 
     Write-Output "VERSION= $Version"
     Write-Output "COMMIT_NUMBER= $CommitNumber"


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4716

### Purpose
- Windows에서도 CMT를 손쉽게 빌드할 수 있도록 PowerShell 기반의 스크립트를 추가합니다.
- PowerShell 5.x 이상이 설치된 환경에서 정상적으로 동작합니다.

### Implementation
- Maven, Git 기반으로 빌드 버전을 자동 생성하며, desktop, console, all 세 가지 프로파일 중 하나를 선택하여 빌드할 수 있습니다.
- `-X` 플래그를 통해 Maven의 디버그 로깅을 활성화할 수 있으며, 빌드 결과물은 target 디렉터리에 정리됩니다.

예시 사용법:
```powershell
# 전체 빌드
.\build.ps1

# 데스크탑 전용 빌드 (디버그 로그 포함)
.\build.ps1 -p desktop -X

# 콘솔 전용 빌드
.\build.ps1 -p console
```

### Remarks
N/A