### PR TITLE
[TOOLS-4713] Apply .sql extension to the procedure, function files for CSV/XLS target types

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -5499,6 +5499,10 @@ public class MigrationConfiguration {
             case "fk":
             case "serial":
             case "synonym":
+            case "function":
+            case "function_header":
+            case "procedure":
+            case "procedure_header":
             case "info":
             case "updatestatistic":
                 return getDefaultTargetSchemaFileExtName();


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4713

### Purpose
대상 유형이 CSV, XLS인 경우 procedure, procedure_header, function, function_header 파일의 확장자를 .sql로 설정할 수 있도록 파일 확장자 설정 조건 수정
### Implementation
N/A

### Remarks
- #252 