### PR TITLE
[TOOLS-4719] Fix ReleaseVersion scope handling in build script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -74,7 +74,7 @@ function Update-BuildVersion {
         "{0:D4}" -f [int](& git rev-list --count HEAD).Trim()
     } else { "0000" }
     $Version = ((Get-Content $VersionFilePath | Select-String "^version=").ToString().Split('=')[1]).Trim()
-    $ReleaseVersion = "$Version.$CommitNumber"
+    $script:ReleaseVersion = "$Version.$CommitNumber"
 
     (Get-Content $ReleaseVersionFilePath |
         Where-Object { $_ -notmatch "^(releaseVersion|buildVersionId)=" }) |


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4719

### Purpose
윈도우 빌드 스크립트로 빌드 시 완성되는 압축 파일명에 릴리스 버전 정보가 누락되는 문제를 해결합니다.

### Implementation
`$script:ReleaseVersion`으로 스코프를 명시하여 스크립트 전역 변수에 값을 설정할 수 있도록 수정합니다.

### Remarks
- #275