### PR TITLE
[TOOLS-4720] Fix grant query to support db_auth change in CUBRID 11.4+

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -98,6 +98,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
     private final int COMMENT_SUPPORT_VERSION = 100;
     private final int USERSCHEMA_VERSION = 112;
     private final int DB_SERIAL_ATTR_NAME = 114;
+    private final int DB_AUTH_CLASS_NAME = 114;
 
     /**
      * Retrieves the lower case of type, and some type may be changed into stand format.
@@ -2186,13 +2187,17 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
         ResultSet rs = null; // NOPMD
 
         boolean isUserSchema = getDBVersion(conn) >= USERSCHEMA_VERSION;
+        String classNameCol =
+                getDBVersion(conn) >= DB_AUTH_CLASS_NAME ? "object_name" : "class_name";
 
         StringBuffer sql = new StringBuffer();
         sql.append(
-                        "SELECT a.grantor_name, a.grantee_name, a.class_name, a.auth_type, a.is_grantable")
+                        "SELECT a.grantor_name, a.grantee_name, a."
+                                + classNameCol
+                                + ", a.auth_type, a.is_grantable")
                 .append(isUserSchema ? ", a.owner_name" : "")
                 .append(" FROM db_auth a, db_class c")
-                .append(" WHERE a.class_name=c.class_name")
+                .append(" WHERE a." + classNameCol + "=c.class_name")
                 .append(isUserSchema ? " AND a.owner_name=c.owner_name" : "")
                 .append(" AND c.is_system_class='NO'")
                 .append(" AND a.grantee_name=?");
@@ -2208,7 +2213,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 grant.setOwner(schema.getName());
                 grant.setGrantorName(rs.getString("grantor_name"));
                 grant.setGranteeName(rs.getString("grantee_name"));
-                grant.setClassName(rs.getString("class_name"));
+                grant.setClassName(rs.getString(classNameCol));
                 grant.setAuthType(rs.getString("auth_type"));
                 grant.setGrantable(rs.getString("is_grantable").equals("NO") ? false : true);
                 grant.setClassOwner(isUserSchema ? rs.getString("owner_name") : null);


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4720

### Purpose
CUBRID 11.4 버전부터 db_auth 테이블의 class_name 컬럼명이 object_name으로 변경되었습니다.
이에 따라 CMT에서 CUBRID 버전에 따라 올바른 컬럼 이름을 사용하여 Grant 권한 조회 SQL이 정상 동작하도록 수정합니다.

### Implementation

- `DB_AUTH_CLASS_NAME` 상수를 추가하여 CUBRID 버전 (11.4 이상) 판별
- getDBVersion(conn) 결과가 `DB_AUTH_CLASS_NAME` 이상일 경우 `"object_name"`, 그렇지 않은 경우 `"class_name"`을 사용하도록 수정

### Remarks
- cubrid/cubrid#5377