### PR TITLE
[TOOLS-4704] when migration using SQL, the target schema enters null pt.2

### DIFF
--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -559,6 +559,11 @@ public class MigrationConfiguration {
         }
         // Build target schema
         Table tt = getDBTransformHelper().createCUBRIDTable(sstc, sqlSchema, this);
+        
+        if (tt.getSourceOwner() == null) {
+        	tt.setSourceOwner(getSrcConnOwner().toUpperCase());
+        }
+        
         srcSQLSchemas.add(sqlSchema);
         targetTables.add(tt);
         expSQLTables.add(sstc);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -5003,9 +5003,15 @@ public class MigrationConfiguration {
     public void setTarCatalog(Catalog tarCatalog) {
         this.tarCatalog = tarCatalog;
     }
-
-    public Catalog getTarCatalog() {
-        return tarCatalog;
+    
+    
+    /**
+     * Get target catalog. target catalog can be null
+     *
+     * @return Optional<Catalog> tarCatalog
+     */
+    public Optional<Catalog> getTarCatalog() {
+        return Optional.ofNullable(tarCatalog);
     }
 
     /**

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -1325,6 +1325,8 @@ public class MigrationConfiguration {
         if (sqlList != null) {
             for (SourceSQLTableConfig sqlCfg : sqlList) {
                 sqlCfg.setCreateNewTable(false);
+                String schemaName = sqlCfg.getOwner() == null ? defSchemaName : sqlCfg.getOwner();
+                sqlCfg.setOwner(schemaName);
             }
         }
 
@@ -4989,14 +4991,11 @@ public class MigrationConfiguration {
     }
 
     /**
-     * set target catalog.
+     * set target catalog. target catalog can be null
      *
      * @param tarCatalog
      */
     public void setTarCatalog(Catalog tarCatalog) {
-        if (tarCatalog == null) {
-            throw new IllegalArgumentException("Target Catalog cannot be null");
-        }
         this.tarCatalog = tarCatalog;
     }
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -561,7 +561,7 @@ public class MigrationConfiguration {
         Table tt = getDBTransformHelper().createCUBRIDTable(sstc, sqlSchema, this);
 
         if (tt.getSourceOwner() == null) {
-            tt.setSourceOwner(getSrcConnOwner().toUpperCase());
+            tt.setSourceOwner(getSrcConnOwner().toUpperCase(Locale.US));
         }
 
         srcSQLSchemas.add(sqlSchema);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -559,11 +559,11 @@ public class MigrationConfiguration {
         }
         // Build target schema
         Table tt = getDBTransformHelper().createCUBRIDTable(sstc, sqlSchema, this);
-        
+
         if (tt.getSourceOwner() == null) {
-        	tt.setSourceOwner(getSrcConnOwner().toUpperCase());
+            tt.setSourceOwner(getSrcConnOwner().toUpperCase());
         }
-        
+
         srcSQLSchemas.add(sqlSchema);
         targetTables.add(tt);
         expSQLTables.add(sstc);

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -5003,8 +5003,7 @@ public class MigrationConfiguration {
     public void setTarCatalog(Catalog tarCatalog) {
         this.tarCatalog = tarCatalog;
     }
-    
-    
+
     /**
      * Get target catalog. target catalog can be null
      *

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -175,7 +175,7 @@ public class LoadFileImporter extends OfflineImporter {
         synchronized (lockObj) {
             MigrationDirAndFilesManager mdfm = mrManager.getDirAndFilesMgr();
             String schemaName =
-                    config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
+                    config.getSrcCatalog().getDatabaseType().isSupportMultiSchema() && !(stc.getOwner() == null)
                             ? stc.getOwner()
                             : config.getSrcConnOwner();
 
@@ -183,7 +183,8 @@ public class LoadFileImporter extends OfflineImporter {
                 tableFiles.put(
                         schemaName + stc.getName(),
                         new CurrentDataFileInfo(
-                                config.getTargetDataFileName(schemaName),
+                        		// TODO: toUpperCase()
+                                config.getTargetDataFileName(schemaName.toUpperCase()),
                                 mdfm.getMergeFilesDir(),
                                 config.getTargetFilePrefix(),
                                 schemaName,

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -47,6 +47,7 @@ import com.cubrid.cubridmigration.cubrid.Data2StrTranslator;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.log4j.Logger;
 
@@ -184,7 +185,7 @@ public class LoadFileImporter extends OfflineImporter {
                 tableFiles.put(
                         schemaName + stc.getName(),
                         new CurrentDataFileInfo(
-                                config.getTargetDataFileName(schemaName.toUpperCase()),
+                                config.getTargetDataFileName(schemaName.toUpperCase(Locale.US)),
                                 mdfm.getMergeFilesDir(),
                                 config.getTargetFilePrefix(),
                                 schemaName,

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -175,7 +175,8 @@ public class LoadFileImporter extends OfflineImporter {
         synchronized (lockObj) {
             MigrationDirAndFilesManager mdfm = mrManager.getDirAndFilesMgr();
             String schemaName =
-                    config.getSrcCatalog().getDatabaseType().isSupportMultiSchema() && !(stc.getOwner() == null)
+                    config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
+                                    && !(stc.getOwner() == null)
                             ? stc.getOwner()
                             : config.getSrcConnOwner();
 
@@ -183,7 +184,6 @@ public class LoadFileImporter extends OfflineImporter {
                 tableFiles.put(
                         schemaName + stc.getName(),
                         new CurrentDataFileInfo(
-                        		// TODO: toUpperCase()
                                 config.getTargetDataFileName(schemaName.toUpperCase()),
                                 mdfm.getMergeFilesDir(),
                                 config.getTargetFilePrefix(),

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -176,7 +176,7 @@ public class LoadFileImporter extends OfflineImporter {
             MigrationDirAndFilesManager mdfm = mrManager.getDirAndFilesMgr();
             String schemaName =
                     config.getSrcCatalog().getDatabaseType().isSupportMultiSchema()
-                                    && !(stc.getOwner() == null)
+                                    && stc.getOwner() != null
                             ? stc.getOwner()
                             : config.getSrcConnOwner();
 

--- a/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/io/RmInvalidXMLCharReader.java
+++ b/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/io/RmInvalidXMLCharReader.java
@@ -30,7 +30,6 @@
  */
 package com.cubrid.cubridmigration.core.io;
 
-import com.sun.org.apache.xml.internal.utils.XMLChar;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -38,6 +37,8 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.util.List;
+
+import org.apache.xmlbeans.impl.common.XMLChar;
 
 /**
  * a reader to read characters from a xml file but remove invalid characters

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -104,7 +104,7 @@ public class SQLTableManageView extends AbstractMappingView {
     private Button btnRemoveSQL;
 
     private String[] tarSchemaList = {""};
-    
+
     private final IAction actNew =
             new Action() {
 
@@ -610,30 +610,26 @@ public class SQLTableManageView extends AbstractMappingView {
         }
     }
 
-    /** setup real combo box value(target schema name list) */
+    /** setup combo box value(target schema name list) */
     protected void setupCombobox() {
-    	String[] schemaNameArr = {""};
-    	
-    	if (config.getTarCatalog() != null) {
-    		if (config.isAddUserSchema() != false) {
-        		schemaNameArr =
-        				config.getTarCatalog().getSchemas().stream()
-        				.map(Schema::getName)
-        				.toArray(String[]::new);
-        		this.tarSchemaList = schemaNameArr;
-    		}
-    	} else {
-    		if (config.isAddUserSchema() != false) {
-        		schemaNameArr =
-        				config.getSrcCatalog().getSchemas().stream()
-        				.map(Schema::getName)
-        				.toArray(String[]::new);
-           		this.tarSchemaList = schemaNameArr;
-    		}
-    	}
-    	
-   		CellEditor[] cellEditorArray = tvSQL.getCellEditors();
-		((ComboBoxCellEditor) cellEditorArray[2]).setItems(tarSchemaList);
+        if (config.getTarCatalog() != null) {
+            if (config.isAddUserSchema() != false) {
+            	this.tarSchemaList =
+                        config.getTarCatalog().getSchemas().stream()
+                                .map(Schema::getName)
+                                .toArray(String[]::new);
+            }
+        } else {
+            if (config.isAddUserSchema() != false) {
+                this.tarSchemaList =
+                        config.getSrcCatalog().getSchemas().stream()
+                                .map(Schema::getName)
+                                .toArray(String[]::new);
+            }
+        }
+
+        CellEditor[] cellEditorArray = tvSQL.getCellEditors();
+        ((ComboBoxCellEditor) cellEditorArray[2]).setItems(tarSchemaList);
     }
 
     protected int getValueIndex(String targetOwner) {
@@ -674,10 +670,10 @@ public class SQLTableManageView extends AbstractMappingView {
             SourceSQLTableConfig sstc = (SourceSQLTableConfig) obj[obj.length - 1];
             config.replaceSQL(sstc, (String) obj[0], sstc.getSql());
             if (tarSchemaList[(int) obj[2]].isEmpty() || !config.isAddUserSchema()) {
-            	config.changeSQLOwner(sstc, config.getSrcConnOwner().toUpperCase());
-            	sstc.setTargetOwner(config.getSrcConnOwner().toUpperCase());
+                config.changeSQLOwner(sstc, config.getSrcConnOwner().toUpperCase());
+                sstc.setTargetOwner(config.getSrcConnOwner().toUpperCase());
             } else {
-            	config.changeSQLOwner(sstc, this.tarSchemaList[(int) obj[2]]);
+                config.changeSQLOwner(sstc, this.tarSchemaList[(int) obj[2]]);
                 sstc.setTargetOwner(this.tarSchemaList[(int) obj[2]]);
             }
             config.changeTarget(sstc, (String) obj[3]);

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -668,8 +668,8 @@ public class SQLTableManageView extends AbstractMappingView {
             SourceSQLTableConfig sstc = (SourceSQLTableConfig) obj[obj.length - 1];
             config.replaceSQL(sstc, (String) obj[0], sstc.getSql());
             if (tarSchemaList[(int) obj[2]].isEmpty() || !config.isAddUserSchema()) {
-                config.changeSQLOwner(sstc, config.getSrcConnOwner().toUpperCase());
-                sstc.setTargetOwner(config.getSrcConnOwner().toUpperCase());
+                config.changeSQLOwner(sstc, config.getSrcConnOwner().toUpperCase(Locale.US));
+                sstc.setTargetOwner(config.getSrcConnOwner().toUpperCase(Locale.US));
             } else {
                 config.changeSQLOwner(sstc, this.tarSchemaList[(int) obj[2]]);
                 sstc.setTargetOwner(this.tarSchemaList[(int) obj[2]]);

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -55,6 +55,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -614,9 +615,8 @@ public class SQLTableManageView extends AbstractMappingView {
     /** setup combo box value(target schema name list) */
     protected void setupCombobox() {
         if (config.isAddUserSchema()) {
-            Catalog catalog = (config.getTarCatalog() != null)
-                ? config.getTarCatalog()
-                : config.getSrcCatalog();
+            Catalog catalog = config.getTarCatalog()
+                .orElse(config.getSrcCatalog());
 
             if (catalog != null && catalog.getSchemas() != null) {
                 tarSchemaList = catalog.getSchemas().stream()

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -105,8 +105,6 @@ public class SQLTableManageView extends AbstractMappingView {
 
     private String[] tarSchemaList = {""};
     
-    private final String NO_USER_SCHEMA = "(unable to set user schema)"; 
-
     private final IAction actNew =
             new Action() {
 
@@ -617,9 +615,7 @@ public class SQLTableManageView extends AbstractMappingView {
     	String[] schemaNameArr = {""};
     	
     	if (config.getTarCatalog() != null) {
-    		if (config.isAddUserSchema() == false) {
-    			this.tarSchemaList = new String[] {NO_USER_SCHEMA};
-    		} else {
+    		if (config.isAddUserSchema() != false) {
         		schemaNameArr =
         				config.getTarCatalog().getSchemas().stream()
         				.map(Schema::getName)
@@ -627,18 +623,17 @@ public class SQLTableManageView extends AbstractMappingView {
         		this.tarSchemaList = schemaNameArr;
     		}
     	} else {
-    		if (config.isAddUserSchema() == false) {
-    			this.tarSchemaList = new String[] {NO_USER_SCHEMA};
+    		if (config.isAddUserSchema() != false) {
+        		schemaNameArr =
+        				config.getSrcCatalog().getSchemas().stream()
+        				.map(Schema::getName)
+        				.toArray(String[]::new);
+           		this.tarSchemaList = schemaNameArr;
     		}
-    		schemaNameArr =
-    				config.getSrcCatalog().getSchemas().stream()
-    				.map(Schema::getName)
-    				.toArray(String[]::new);
-       		this.tarSchemaList = schemaNameArr;
     	}
     	
    		CellEditor[] cellEditorArray = tvSQL.getCellEditors();
-		((ComboBoxCellEditor) cellEditorArray[2]).setItems(schemaNameArr);
+		((ComboBoxCellEditor) cellEditorArray[2]).setItems(tarSchemaList);
     }
 
     protected int getValueIndex(String targetOwner) {
@@ -678,11 +673,9 @@ public class SQLTableManageView extends AbstractMappingView {
             Object[] obj = (Object[]) ti.getData();
             SourceSQLTableConfig sstc = (SourceSQLTableConfig) obj[obj.length - 1];
             config.replaceSQL(sstc, (String) obj[0], sstc.getSql());
-            if (tarSchemaList[(int) obj[2]].equals(NO_USER_SCHEMA) || !config.isAddUserSchema()) {
-//            	config.changeSQLOwner(sstc, config.getSrcConnOwner().toUpperCase());
-            	config.changeSQLOwner(sstc, null);
-//            	sstc.setTargetOwner(config.getSrcConnOwner().toUpperCase());
-            	sstc.setTargetOwner(null);
+            if (tarSchemaList[(int) obj[2]].isEmpty() || !config.isAddUserSchema()) {
+            	config.changeSQLOwner(sstc, config.getSrcConnOwner().toUpperCase());
+            	sstc.setTargetOwner(config.getSrcConnOwner().toUpperCase());
             } else {
             	config.changeSQLOwner(sstc, this.tarSchemaList[(int) obj[2]]);
                 sstc.setTargetOwner(this.tarSchemaList[(int) obj[2]]);

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -619,9 +619,10 @@ public class SQLTableManageView extends AbstractMappingView {
                 .orElse(config.getSrcCatalog());
 
             if (catalog != null && catalog.getSchemas() != null) {
-                tarSchemaList = catalog.getSchemas().stream()
-                    .map(Schema::getName)
-                    .toArray(String[]::new);
+                tarSchemaList = 
+                	catalog.getSchemas().stream()
+                    	.map(Schema::getName)
+                    	.toArray(String[]::new);
             }
         }
 

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -104,6 +104,8 @@ public class SQLTableManageView extends AbstractMappingView {
     private Button btnRemoveSQL;
 
     private String[] tarSchemaList = {""};
+    
+    private final String NO_USER_SCHEMA = "(unable to set user schema)"; 
 
     private final IAction actNew =
             new Action() {
@@ -612,13 +614,31 @@ public class SQLTableManageView extends AbstractMappingView {
 
     /** setup real combo box value(target schema name list) */
     protected void setupCombobox() {
-        String[] schemaNameArr =
-                config.getTarCatalog().getSchemas().stream()
-                        .map(Schema::getName)
-                        .toArray(String[]::new);
-        this.tarSchemaList = schemaNameArr;
-        CellEditor[] cellEditorArray = tvSQL.getCellEditors();
-        ((ComboBoxCellEditor) cellEditorArray[2]).setItems(schemaNameArr);
+    	String[] schemaNameArr = {""};
+    	
+    	if (config.getTarCatalog() != null) {
+    		if (config.isAddUserSchema() == false) {
+    			this.tarSchemaList = new String[] {NO_USER_SCHEMA};
+    		} else {
+        		schemaNameArr =
+        				config.getTarCatalog().getSchemas().stream()
+        				.map(Schema::getName)
+        				.toArray(String[]::new);
+        		this.tarSchemaList = schemaNameArr;
+    		}
+    	} else {
+    		if (config.isAddUserSchema() == false) {
+    			this.tarSchemaList = new String[] {NO_USER_SCHEMA};
+    		}
+    		schemaNameArr =
+    				config.getSrcCatalog().getSchemas().stream()
+    				.map(Schema::getName)
+    				.toArray(String[]::new);
+       		this.tarSchemaList = schemaNameArr;
+    	}
+    	
+   		CellEditor[] cellEditorArray = tvSQL.getCellEditors();
+		((ComboBoxCellEditor) cellEditorArray[2]).setItems(schemaNameArr);
     }
 
     protected int getValueIndex(String targetOwner) {
@@ -658,8 +678,15 @@ public class SQLTableManageView extends AbstractMappingView {
             Object[] obj = (Object[]) ti.getData();
             SourceSQLTableConfig sstc = (SourceSQLTableConfig) obj[obj.length - 1];
             config.replaceSQL(sstc, (String) obj[0], sstc.getSql());
-            config.changeSQLOwner(sstc, this.tarSchemaList[(int) obj[2]]);
-            sstc.setTargetOwner(this.tarSchemaList[(int) obj[2]]);
+            if (tarSchemaList[(int) obj[2]].equals(NO_USER_SCHEMA) || !config.isAddUserSchema()) {
+//            	config.changeSQLOwner(sstc, config.getSrcConnOwner().toUpperCase());
+            	config.changeSQLOwner(sstc, null);
+//            	sstc.setTargetOwner(config.getSrcConnOwner().toUpperCase());
+            	sstc.setTargetOwner(null);
+            } else {
+            	config.changeSQLOwner(sstc, this.tarSchemaList[(int) obj[2]]);
+                sstc.setTargetOwner(this.tarSchemaList[(int) obj[2]]);
+            }
             config.changeTarget(sstc, (String) obj[3]);
             sstc.setMigrateData((Boolean) obj[4]);
             sstc.setCreateNewTable((Boolean) obj[5]);

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -39,6 +39,7 @@ import com.cubrid.common.ui.swt.table.celleditor.ComboBoxCellEditorFactory;
 import com.cubrid.common.ui.swt.table.celleditor.TextCellEditorFactory;
 import com.cubrid.common.ui.swt.table.listener.CheckBoxColumnSelectionListener;
 import com.cubrid.cubridmigration.core.common.CUBRIDIOUtils;
+import com.cubrid.cubridmigration.core.dbobject.Catalog;
 import com.cubrid.cubridmigration.core.dbobject.Schema;
 import com.cubrid.cubridmigration.core.engine.config.SourceSQLTableConfig;
 import com.cubrid.cubridmigration.core.engine.listener.ISQLTableChangedListener;
@@ -317,7 +318,7 @@ public class SQLTableManageView extends AbstractMappingView {
                 new String[] {
                     Messages.tabTitleName,
                     Messages.tabTitleSQL,
-                    Messages.tabTitleSchema,
+                    Messages.targetSchema,
                     Messages.tabTitleTargetTable,
                     Messages.tabTitleData,
                     Messages.lblCreate,
@@ -612,19 +613,15 @@ public class SQLTableManageView extends AbstractMappingView {
 
     /** setup combo box value(target schema name list) */
     protected void setupCombobox() {
-        if (config.getTarCatalog() != null) {
-            if (config.isAddUserSchema() != false) {
-            	this.tarSchemaList =
-                        config.getTarCatalog().getSchemas().stream()
-                                .map(Schema::getName)
-                                .toArray(String[]::new);
-            }
-        } else {
-            if (config.isAddUserSchema() != false) {
-                this.tarSchemaList =
-                        config.getSrcCatalog().getSchemas().stream()
-                                .map(Schema::getName)
-                                .toArray(String[]::new);
+        if (config.isAddUserSchema()) {
+            Catalog catalog = (config.getTarCatalog() != null)
+                ? config.getTarCatalog()
+                : config.getSrcCatalog();
+
+            if (catalog != null && catalog.getSchemas() != null) {
+                tarSchemaList = catalog.getSchemas().stream()
+                    .map(Schema::getName)
+                    .toArray(String[]::new);
             }
         }
 

--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -55,7 +55,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.stream.IntStream;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -615,14 +614,11 @@ public class SQLTableManageView extends AbstractMappingView {
     /** setup combo box value(target schema name list) */
     protected void setupCombobox() {
         if (config.isAddUserSchema()) {
-            Catalog catalog = config.getTarCatalog()
-                .orElse(config.getSrcCatalog());
+            Catalog catalog = config.getTarCatalog().orElse(config.getSrcCatalog());
 
             if (catalog != null && catalog.getSchemas() != null) {
-                tarSchemaList = 
-                	catalog.getSchemas().stream()
-                    	.map(Schema::getName)
-                    	.toArray(String[]::new);
+                tarSchemaList =
+                        catalog.getSchemas().stream().map(Schema::getName).toArray(String[]::new);
             }
         }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4704

- Purpose
SQL을 이용한 이관 기능 사용 시 schema 정보가 누락되어 쿼리가 정확하게 수행이 안되는 문제를 수정합니다

- Implementation
target이 cubrid dump가 되는 경우 combo box가 제대로 적용되도록 수정했습니다

- Remarks
아래 이슈의 후속 수정입니다
https://github.com/CUBRID/cubrid-migration/pull/268