### PR TITLE
[TOOLS-4728] '-p' option not working in build.sh on macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,7 @@ function get_options ()
 {
   while getopts ":p:X" opt; do
     case $opt in
-	  p ) PROFILE="${OPTARG,,}" ;;
+	  p ) PROFILE=$(printf %s "$OPTARG" | tr '[:upper:]' '[:lower:]') ;;
           X ) MVN_DEBUG="-Dtycho.debug.resolver=true -X" ;;
           * ) show_usage 
               exit ;;


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4728

### Purpose
Mac의 Bash 3.2.57 버전에서도 buid.sh의 -p 옵션이 정상적으로 작동할 수 있도록 수정합니다.

### Implementation
`tr` POSIX 표준에 포함된 기본적인 유틸리티로 변경합니다.

### Remarks
N/A