### PR TITLE
[TOOLS-4727] Upgrade bundled JRE and minimum Java version in .ini config

### DIFF
--- a/plugins/com.cubrid.common.configuration/pom.xml
+++ b/plugins/com.cubrid.common.configuration/pom.xml
@@ -20,32 +20,32 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.17.0</version>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.5.0</version>
+            <version>${commons-collections4.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.13.1</version>
+            <version>${commons-text.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.3.5</version>
+            <version>${commons-logging.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
-            <version>2.27.2</version>
+            <version>${jsch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client-runtime</artifactId>
-            <version>3.4.1</version>
+            <version>${hadoop-client-runtime.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/plugins/com.cubrid.common.configuration/pom.xml
+++ b/plugins/com.cubrid.common.configuration/pom.xml
@@ -12,34 +12,8 @@
     <artifactId>com.cubrid.common.configuration</artifactId>
     <packaging>eclipse-plugin</packaging>
 
-    <properties>
-        <jre.download.url>https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05</jre.download.url>
-    </properties>
-
     <build>
         <sourceDirectory>src/</sourceDirectory>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>${maven-antrun-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <get src="${jre.download.url}/OpenJDK8U-jre_x64_windows_hotspot_8u422b05.zip" dest="${project.build.directory}/win-jre.zip" />
-                                <get src="${jre.download.url}/OpenJDK8U-jre_x64_linux_hotspot_8u422b05.tar.gz" dest="${project.build.directory}/linux-jre.tar.gz" />
-                                <get src="${jre.download.url}/OpenJDK8U-jre_x64_mac_hotspot_8u422b05.tar.gz" dest="${project.build.directory}/mac-jre.tar.gz" />
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
     </build>
 
     <dependencies>

--- a/plugins/com.cubrid.common.log/pom.xml
+++ b/plugins/com.cubrid.common.log/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.18</version>
+            <version>${logback-classic.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/com.cubrid.cubridmigration.core/pom.xml
+++ b/plugins/com.cubrid.cubridmigration.core/pom.xml
@@ -43,17 +43,17 @@
         <dependency>
             <groupId>net.sourceforge.jexcelapi</groupId>
             <artifactId>jxl</artifactId>
-            <version>2.6.12</version>
+            <version>${jxl.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
-            <version>7.1.1</version>
+            <version>${woodstox-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.11.1</version>
+            <version>${opencsv.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
@@ -76,12 +76,12 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4</artifactId>
-            <version>4.13.2</version>
+            <version>${antlr4.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.4.1</version>
+            <version>${poi-ooxml.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <eclipse-repo-url>https://download.eclipse.org/releases</eclipse-repo-url>
         <eclipse-p2-repo.url>${eclipse-repo-url}/${eclipse-version}/</eclipse-p2-repo.url>
         <cmt-p2-site>https://ftp.cubrid.org/CUBRID_Tools/Dev/p2-site</cmt-p2-site>
+        <jre.download.url>https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6</jre.download.url>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,19 @@
         <com.cubrid.bundle.apache.poi-ooxmlversion>5.4.1</com.cubrid.bundle.apache.poi-ooxmlversion>
         <com.cubrid.bundle.antlr4.version>4.13.2</com.cubrid.bundle.antlr4.version>
 
+        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <commons-collections4.version>4.5.0</commons-collections4.version>
+        <commons-text.version>1.13.1</commons-text.version>
+        <commons-logging.version>1.3.5</commons-logging.version>
+        <jsch.version>2.27.2</jsch.version>
+        <hadoop-client-runtime.version>3.4.1</hadoop-client-runtime.version>
+        <logback-classic.version>1.5.18</logback-classic.version>
+        <jxl.version>2.6.12</jxl.version>
+        <woodstox-core.version>7.1.1</woodstox-core.version>
+        <opencsv.version>5.11.1</opencsv.version>
+        <antlr4.version>4.13.2</antlr4.version>
+        <poi-ooxml.version>5.4.1</poi-ooxml.version>
+
         <eclipse-repo-url>https://download.eclipse.org/releases</eclipse-repo-url>
         <eclipse-p2-repo.url>${eclipse-repo-url}/${eclipse-version}/</eclipse-p2-repo.url>
         <cmt-p2-site>https://ftp.cubrid.org/CUBRID_Tools/Dev/p2-site</cmt-p2-site>

--- a/product/com.cubrid.cubridmigration.console/console-tar.xml
+++ b/product/com.cubrid.cubridmigration.console/console-tar.xml
@@ -28,7 +28,7 @@
             </includes>
         </fileSet>
         <fileSet>
-            <directory>${basedir}/target/jre/linux/jdk8u422-b05-jre</directory>
+            <directory>${basedir}/target/jre/linux/linux-jre</directory>
             <outputDirectory>jre</outputDirectory>
         </fileSet>
         <fileSet>

--- a/product/com.cubrid.cubridmigration.console/console-zip.xml
+++ b/product/com.cubrid.cubridmigration.console/console-zip.xml
@@ -26,7 +26,7 @@
             </includes>
         </fileSet>
         <fileSet>
-            <directory>${basedir}/target/jre/win/jdk8u422-b05-jre</directory>
+            <directory>${basedir}/target/jre/win/win-jre</directory>
             <outputDirectory>jre</outputDirectory>
         </fileSet>
         <fileSet>

--- a/product/com.cubrid.cubridmigration.console/pom.xml
+++ b/product/com.cubrid.cubridmigration.console/pom.xml
@@ -20,21 +20,36 @@
                 <version>${maven-antrun-plugin.version}</version>
                 <executions>
                     <execution>
+                        <id>download-jre</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <get src="${jre.download.url}/OpenJDK21U-jre_x64_windows_hotspot_21.0.7_6.zip" dest="${project.build.directory}/win-jre.zip" />
+                                <get src="${jre.download.url}/OpenJDK21U-jre_x64_linux_hotspot_21.0.7_6.tar.gz" dest="${project.build.directory}/linux-jre.tar.gz" />
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-jre</id>
                         <phase>package</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <configuration>
                             <target>
-                                <property name="output.dir" value="${project.build.directory}/jre"/>
-                                <unzip src="../../plugins/com.cubrid.common.configuration/target/win-jre.zip" dest="${project.build.directory}/jre/win"/>
-                                <mkdir dir="${output.dir}/linux" />
-                                <exec executable="tar">
-                                  <arg value="xzf"/>
-                                  <arg value="../../plugins/com.cubrid.common.configuration/target/linux-jre.tar.gz"/>
-                                  <arg value="-C"/>
-                                  <arg value="${output.dir}/linux"/>
-                                </exec>
+                                <property name="jre.dir" value="${project.build.directory}/jre"/>
+                                <unzip src="${project.build.directory}/win-jre.zip" dest="${jre.dir}/win">
+                                    <mapper type="regexp" from="^[^/]+/(.*)$" to="win-jre/\1"/>
+                                </unzip>
+                                <untar src="${project.build.directory}/linux-jre.tar.gz" dest="${jre.dir}/linux" compression="gzip">
+                                    <mapper type="regexp" from="^[^/]+/(.*)$" to="linux-jre/\1"/>
+                                </untar>
+                                <chmod perm="755">
+                                    <fileset dir="${jre.dir}/linux/linux-jre/bin" includes="**/*"/>
+                                </chmod>
                             </target>
                         </configuration>
                     </execution>

--- a/product/com.cubrid.cubridmigration.desktop/cubridmigration.product
+++ b/product/com.cubrid.cubridmigration.desktop/cubridmigration.product
@@ -7,7 +7,7 @@
 
    <launcherArgs>
       <programArgsMac>-vm ../Eclipse/jre/Contents/Home/bin/java</programArgsMac>
-      <vmArgs>-Xms1024M -Xmx4096M -Dosgi.requiredJavaVersion=1.8</vmArgs>
+      <vmArgs>-Xms1024M -Xmx4096M -Dosgi.requiredJavaVersion=21</vmArgs>
       <vmArgsMac>-XstartOnFirstThread </vmArgsMac>
    </launcherArgs>
 

--- a/product/com.cubrid.cubridmigration.desktop/linux.xml
+++ b/product/com.cubrid.cubridmigration.desktop/linux.xml
@@ -38,7 +38,7 @@
             </includes>
         </fileSet>
         <fileSet>
-            <directory>${basedir}/target/jre/linux/jdk8u422-b05-jre</directory>
+            <directory>${basedir}/target/jre/linux/linux-jre</directory>
             <outputDirectory>jre</outputDirectory>
         </fileSet>
         <fileSet>

--- a/product/com.cubrid.cubridmigration.desktop/mac.xml
+++ b/product/com.cubrid.cubridmigration.desktop/mac.xml
@@ -51,7 +51,7 @@
             </includes>
         </fileSet>
         <fileSet>
-            <directory>${basedir}/target/jre/linux/jdk8u422-b05-jre</directory>
+            <directory>${basedir}/target/jre/mac/mac-jre</directory>
             <outputDirectory>jre</outputDirectory>
         </fileSet>
         <fileSet>

--- a/product/com.cubrid.cubridmigration.desktop/pom.xml
+++ b/product/com.cubrid.cubridmigration.desktop/pom.xml
@@ -68,28 +68,43 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>download-jre</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <get src="${jre.download.url}/OpenJDK21U-jre_x64_windows_hotspot_21.0.7_6.zip" dest="${project.build.directory}/win-jre.zip" />
+                                <get src="${jre.download.url}/OpenJDK21U-jre_x64_linux_hotspot_21.0.7_6.tar.gz" dest="${project.build.directory}/linux-jre.tar.gz" />
+                                <get src="${jre.download.url}/OpenJDK21U-jre_x64_mac_hotspot_21.0.7_6.tar.gz" dest="${project.build.directory}/mac-jre.tar.gz" />
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-jre</id>
                         <phase>package</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <configuration>
                             <target>
-                                <property name="output.dir" value="${project.build.directory}/jre"/>
-                                <unzip src="../../plugins/com.cubrid.common.configuration/target/win-jre.zip" dest="${output.dir}/win"/>
-                                <mkdir dir="${output.dir}/linux"/>
-                                <exec executable="tar">
-                                    <arg value="xzf"/>
-                                    <arg value="../../plugins/com.cubrid.common.configuration/target/linux-jre.tar.gz"/>
-                                    <arg value="-C"/>
-                                    <arg value="${output.dir}/linux"/>
-                                </exec>
-                                <mkdir dir="${output.dir}/mac"/>
-                                <exec executable="tar">
-                                    <arg value="xzf"/>
-                                    <arg value="../../plugins/com.cubrid.common.configuration/target/mac-jre.tar.gz"/>
-                                    <arg value="-C"/>
-                                    <arg value="${output.dir}/mac"/>
-                                </exec>
+                                <property name="jre.dir" value="${project.build.directory}/jre"/>
+                                <unzip src="${project.build.directory}/win-jre.zip" dest="${jre.dir}/win">
+                                    <mapper type="regexp" from="^[^/]+/(.*)$" to="win-jre/\1"/>
+                                </unzip>
+                                <untar src="${project.build.directory}/linux-jre.tar.gz" dest="${jre.dir}/linux" compression="gzip">
+                                    <mapper type="regexp" from="^[^/]+/(.*)$" to="linux-jre/\1"/>
+                                </untar>
+                                <chmod perm="755">
+                                    <fileset dir="${jre.dir}/linux/linux-jre/bin" includes="**/*"/>
+                                </chmod>
+                                <untar src="${project.build.directory}/mac-jre.tar.gz" dest="${jre.dir}/mac" compression="gzip">
+                                    <mapper type="regexp" from="^[^/]+/(.*)$" to="mac-jre/\1"/>
+                                </untar>
+                                <chmod perm="755">
+                                    <fileset dir="${jre.dir}/mac/mac-jre/Contents/Home/bin" includes="**/*"/>
+                                </chmod>
                             </target>
                         </configuration>
                     </execution>

--- a/product/com.cubrid.cubridmigration.desktop/windows.xml
+++ b/product/com.cubrid.cubridmigration.desktop/windows.xml
@@ -38,7 +38,7 @@
             </includes>
         </fileSet>
         <fileSet>
-            <directory>${basedir}/target/jre/win/jdk8u422-b05-jre</directory>
+            <directory>${basedir}/target/jre/win/win-jre</directory>
             <outputDirectory>jre</outputDirectory>
         </fileSet>
         <fileSet>


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4727

### Purpose
- CMT 패키징 시 포함되는 JRE 버전과 및 .ini 파일에 최소 Java 버전을 업그레이드합니다.
- pom.xml dependency에 하드코딩된 라이브러리 버전을 root pom.xml에서 통합적으로 관리할 수 있도록 수정합니다.

### Implementation
- 기존에는 configuration 모듈에서 JRE를 공통으로 다운로드했으나, 이번 변경에서는 desktop 및 console 모듈에서 각각 JRE를 개별적으로 다운로드하도록 수정했습니다.

### Remarks
N/A