### PR TITLE
[TOOLS-4732] Exclude DISABLED PK and FK from Oracle migration

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -44,6 +44,7 @@ import com.cubrid.cubridmigration.core.dbobject.DBObjectFactory;
 import com.cubrid.cubridmigration.core.dbobject.FK;
 import com.cubrid.cubridmigration.core.dbobject.Grant;
 import com.cubrid.cubridmigration.core.dbobject.Index;
+import com.cubrid.cubridmigration.core.dbobject.PK;
 import com.cubrid.cubridmigration.core.dbobject.PartitionInfo;
 import com.cubrid.cubridmigration.core.dbobject.PartitionTable;
 import com.cubrid.cubridmigration.core.dbobject.PlcsqlFunction;
@@ -182,7 +183,12 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
                     + " AND P.OWNER=V.OWNER"
                     + " AND P.GRANTEE=?";
 
-    // private static final String SHOW_SEQUENCE_MAXVAL = "SELECT ?.CURRVAL  FROM DUAL";
+    private static final String SQL_GET_ENABLED_PK =
+            "SELECT acc.COLUMN_NAME, ac.CONSTRAINT_NAME AS PK_NAME "
+                    + "FROM ALL_CONSTRAINTS ac JOIN ALL_CONS_COLUMNS acc "
+                    + "ON ac.OWNER = acc.OWNER AND ac.CONSTRAINT_NAME = acc.CONSTRAINT_NAME "
+                    + "WHERE ac.CONSTRAINT_TYPE = 'P' AND ac.STATUS = 'ENABLED' AND ac.OWNER = ? AND ac.TABLE_NAME = ? "
+                    + "ORDER BY acc.POSITION";
 
     public OracleSchemaFetcher() {
         factory = new DBObjectFactory() {};
@@ -593,33 +599,54 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
         }
     }
 
-    //	/**
-    //	 * get time zone
-    //	 *
-    //	 * @param conn Connection
-    //	 * @return String time zone
-    //	 * @throws SQLException e
-    //	 */
-    //	public String getTimezone(final Connection conn) throws SQLException {
-    //
-    //		Statement stmt = null; // NOPMD
-    //		ResultSet rs = null; // NOPMD
-    //		try {
-    //			String timezone = "";
-    //			stmt = conn.createStatement();
-    //			rs = stmt.executeQuery("select dbtimezone from dual");
-    //
-    //			if (rs.next()) {
-    //				timezone = rs.getString(1);
-    //				timezone = "GMT" + timezone;
-    //			}
-    //
-    //			return timezone;
-    //		} finally {
-    //			Closer.close(rs);
-    //			Closer.close(stmt);
-    //		}
-    //	}
+    /**
+     * Build enabled primary key information for the given table.
+     *
+     * @param conn Connection
+     * @param catalog Catalog
+     * @param schema Schema
+     * @param table Table
+     * @throws SQLException e
+     */
+    @Override
+    protected void buildTablePK(
+            final Connection conn, final Catalog catalog, final Schema schema, final Table table)
+            throws SQLException {
+        LOG.debug("[IN] buildTablePK()");
+        try (PreparedStatement pstmt = conn.prepareStatement(SQL_GET_ENABLED_PK)) {
+            pstmt.setString(1, schema.getName());
+            pstmt.setString(2, table.getName());
+            LOG.debug(
+                    "[SQL]{} (1={}, 2={})", SQL_GET_ENABLED_PK, schema.getName(), table.getName());
+            try (ResultSet rs = pstmt.executeQuery()) {
+                PK primaryKey = null;
+
+                while (rs.next()) {
+                    if (primaryKey == null) {
+                        primaryKey = factory.createPK(table);
+                        primaryKey.setName(rs.getString("PK_NAME"));
+                        table.setPk(primaryKey);
+                    }
+
+                    // The SQL result is already ordered by POSITION, so we don't need to sort here.
+                    String columnName = rs.getString("COLUMN_NAME");
+                    Column col = table.getColumnWithNoCase(columnName);
+                    if (col != null) {
+                        primaryKey.addColumn(col.getName());
+                    }
+                }
+
+                if (primaryKey != null) {
+                    final String primaryKeyName = primaryKey.getName();
+                    if (primaryKeyName != null) {
+                        table.getIndexes()
+                                .removeIf(idx -> primaryKeyName.equalsIgnoreCase(idx.getName()));
+                    }
+                }
+            }
+        }
+        setUniquColumnByPK(table);
+    }
 
     /**
      * extract Table's FK

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -190,6 +190,22 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
                     + "WHERE ac.CONSTRAINT_TYPE = 'P' AND ac.STATUS = 'ENABLED' AND ac.OWNER = ? AND ac.TABLE_NAME = ? "
                     + "ORDER BY acc.POSITION";
 
+    private static final String SQL_GET_ENABLED_FKS =
+            "SELECT fk.constraint_name AS FK_NAME, "
+                    + "fk.delete_rule AS DELETE_RULE, "
+                    + "fk_col.column_name AS FK_COLUMN_NAME, "
+                    + "pk_col.table_name AS PK_TABLE_NAME, "
+                    + "pk_col.column_name AS PK_COLUMN_NAME "
+                    + "FROM all_constraints fk "
+                    + "JOIN all_cons_columns fk_col "
+                    + "ON fk.owner = fk_col.owner AND fk.constraint_name = fk_col.constraint_name "
+                    + "JOIN all_cons_columns pk_col "
+                    + "ON fk.r_owner = pk_col.owner AND fk.r_constraint_name = pk_col.constraint_name "
+                    + "AND fk_col.position = pk_col.position "
+                    + "WHERE fk.owner = ? AND fk.table_name = ? "
+                    + "AND fk.constraint_type = 'R' AND fk.status = 'ENABLED' "
+                    + "ORDER BY fk.constraint_name, fk_col.position";
+
     public OracleSchemaFetcher() {
         factory = new DBObjectFactory() {};
     }
@@ -660,83 +676,59 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
     protected void buildTableFKs(
             final Connection conn, final Catalog catalog, final Schema schema, final Table table)
             throws SQLException {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("[IN]buildTableFKs()");
-        }
-        ResultSet rs = null; // NOPMD
-        try {
-            final String schemaName = schema == null ? null : schema.getName();
-            rs =
-                    conn.getMetaData()
-                            .getImportedKeys(
-                                    catalog == null ? null : catalog.getName(),
-                                    schemaName,
-                                    table.getName());
-            String fkName = "";
-            FK foreignKey = null;
+        LOG.debug("[IN] buildTableFKs()");
+        try (PreparedStatement pstmt = conn.prepareStatement(SQL_GET_ENABLED_FKS)) {
+            pstmt.setString(1, schema.getName());
+            pstmt.setString(2, table.getName());
+            LOG.debug(
+                    "[SQL]{} (1={}, 2={})", SQL_GET_ENABLED_FKS, schema.getName(), table.getName());
 
-            while (rs.next()) {
-                final String newFkName = rs.getString("FK_NAME");
-                if (LOG.isDebugEnabled()) {
+            try (ResultSet rs = pstmt.executeQuery()) {
+                String fkName = "";
+                FK foreignKey = null;
+
+                while (rs.next()) {
+                    final String newFkName = rs.getString("FK_NAME");
                     LOG.debug("[VAR]newFkName=" + newFkName);
-                }
-                if (fkName.compareToIgnoreCase(newFkName) != 0) {
-                    if (foreignKey != null) {
-                        table.addFK(foreignKey);
-                    }
+                    if (fkName.compareToIgnoreCase(newFkName) != 0) {
+                        if (foreignKey != null) {
+                            table.addFK(foreignKey);
+                        }
 
-                    fkName = newFkName;
-                    foreignKey = factory.createFK(table);
-                    foreignKey.setName(fkName);
-                    foreignKey.setUpdateRule(
-                            FK.ON_UPDATE_NO_ACTION); // oracle doesn't have update rule
-                    // foreignKey.setDeferability(rs.getInt("DEFERRABILITY"));
+                        fkName = newFkName;
+                        foreignKey = factory.createFK(table);
+                        foreignKey.setName(fkName);
+                        foreignKey.setUpdateRule(
+                                FK.ON_UPDATE_NO_ACTION); // oracle doesn't have update rule
 
-                    switch (rs.getShort("delete_rule")) {
-                        case 0:
+                        String deleteRule = rs.getString("DELETE_RULE");
+                        if ("CASCADE".equalsIgnoreCase(deleteRule)) {
                             foreignKey.setDeleteRule(FK.ON_DELETE_CASCADE);
-                            break;
-                        case 1:
-                            foreignKey.setDeleteRule(FK.ON_DELETE_NO_ACTION);
-                            break;
-
-                        default:
+                        } else if ("SET NULL".equalsIgnoreCase(deleteRule)) {
                             foreignKey.setDeleteRule(FK.ON_DELETE_SET_NULL);
-                            break;
+                        } else {
+                            foreignKey.setDeleteRule(FK.ON_DELETE_RESTRICT);
+                        }
+
+                        foreignKey.setReferencedTableName(rs.getString("PK_TABLE_NAME"));
                     }
-
-                    // final String fkSchemaName = rs.getString("PKTABLE_SCHEM");
-                    //					if (rs.wasNull()) {
-                    //						foreignKey.setFkSchemaName(schemaName);
-                    //					} else {
-                    //						foreignKey.setFkSchemaName(fkSchemaName);
-                    //					}
-
-                    foreignKey.setReferencedTableName(rs.getString("PKTABLE_NAME"));
+                    if (foreignKey != null) {
+                        // find reference table column
+                        final String colName = rs.getString("FK_COLUMN_NAME");
+                        Column column = table.getColumnByName(colName);
+                        if (column != null) {
+                            foreignKey.addRefColumnName(colName, rs.getString("PK_COLUMN_NAME"));
+                        }
+                    }
                 }
+
                 if (foreignKey != null) {
-                    // find reference table column
-                    final String colName = rs.getString("FKCOLUMN_NAME");
-                    Column column = table.getColumnByName(colName);
-                    if (column != null) {
-                        foreignKey.addRefColumnName(colName, rs.getString("PKCOLUMN_NAME"));
-                    }
-                    //					for (int j = 0; j < table.getColumns().size(); j++) {
-                    //						final Column column = (Column) (table.getColumns().get(j));
-                    //
-                    //						if (column.getName().compareToIgnoreCase(colName) == 0) {
-                    //							foreignKey.addColumn(column);
-                    //							break;
-                    //						}
-                    //					}
+                    table.addFK(foreignKey);
                 }
             }
-
-            if (foreignKey != null) {
-                table.addFK(foreignKey);
-            }
-        } finally {
-            Closer.close(rs);
+        } catch (SQLException e) {
+            LOG.error("Error while building table FKs", e);
+            throw e;
         }
     }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4732>

### Purpose
Oracle의 DISABLE 상태의 PK, FK를 마이그레이션 대상에서 제외합니다.

### Implementation
- 딕셔너리 뷰 조회 SQL 추가
  - 기존 JDBC 메서드를 통해 조회하는 방식은 DISABLE 상태의 PK, FK를 구분해서 조회할 수 없음
  - DISABLE 조건을 추가해 직접 딕셔너리 뷰를 조회할 수 있도록 SQL로 조회하는 방식으로 변경

- FK `DELETE_RULE` 조건 수정
  - JDBC 메소드를 통해 조회 시 `DELETE_RULE`은 Short 타입으로 조회되지만, SQL을 실행해 조회 시 문자열로 반환됨
  - 문자열을 비교하는 것으로 조건문 수정

- FK `ON DELETE` 규칙 기본 설정을 `ON_DELETE_RESTRICT`로 변경
  - CUBRID 기본 설정은 `RESTRICT` [FOREIGN KEY 제약](https://www.cubrid.org/manual/ko/11.4/sql/schema/table_stmt.html#foreign-key)
  - 마이그레이션 결과에 영향 없음

- 사용하지 않는 주석 삭제

### Remarks
N/A