### PR TITLE
[TOOLS-4733] Improve the display of migration progress by table in the console

### DIFF
--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -58,9 +58,9 @@ import java.util.Map;
  * @version 1.0 - 2012-2-2 created by Kevin Cao
  */
 public class CmdMigrationMonitor implements IMigrationMonitor {
-    private long totalProgress = 0;
-    private long currentProgress = 0;
-    private long progress = 0;
+    private long totalWorkUnits = 0;
+    private long completedWorkUnits = 0;
+    private long lastPrintedProgressPercent = 0;
     private MigrationFinishedEvent finalEvent = null;
     private boolean hasError;
     private final int monitorMode;
@@ -69,6 +69,8 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
     private final Map<String, Long> tableCurrentRows = new LinkedHashMap<>();
     private final List<String> tableOrder = new ArrayList<>();
     private boolean tablesInitialized = false;
+    private static final String CONSOLE_CURSOR_UP_FORMAT = "\033[%dA";
+    private static final String CLEAR_LINE = "\r\033[K";
 
     public CmdMigrationMonitor(MigrationConfiguration config, int monitorMode) {
         this.monitorMode = monitorMode;
@@ -78,10 +80,10 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
             for (SourceEntryTableConfig tbl : config.getExpEntryTableCfg()) {
                 Table table = config.getSrcTableSchema(tbl.getOwner(), tbl.getName());
                 if (tbl.isCreatePK() && table.getPk() != null) {
-                    totalProgress++;
+                    totalWorkUnits++;
                 }
                 long rowCount = table.getTableRowCount();
-                totalProgress += rowCount;
+                totalWorkUnits += rowCount;
 
                 String name = tbl.getName();
                 tableOrder.add(name);
@@ -92,7 +94,7 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
             for (SourceSQLTableConfig tbl : config.getExpSQLCfg()) {
                 Table table = config.getSrcTableSchema(tbl.getOwner(), tbl.getName());
                 long rowCount = table == null ? 0 : table.getTableRowCount();
-                totalProgress += rowCount;
+                totalWorkUnits += rowCount;
 
                 String name = tbl.getName();
                 tableOrder.add(name);
@@ -100,14 +102,14 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
                 tableCurrentRows.put(name, 0L);
             }
 
-            totalProgress += config.getExpObjCount();
+            totalWorkUnits += config.getExpObjCount();
         } else if (config.sourceIsSQL()) {
             for (String ss : config.getSqlFiles()) {
-                totalProgress += new File(ss).length();
+                totalWorkUnits += new File(ss).length();
             }
         } else if (config.sourceIsCSV()) {
             for (SourceCSVConfig scc : config.getCSVConfigs()) {
-                totalProgress += new File(scc.getName()).length();
+                totalWorkUnits += new File(scc.getName()).length();
             }
         }
     }
@@ -143,35 +145,27 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
         long percent = (totalRecords > 0) ? (currentRecords * 100 / totalRecords) : 100;
         percent = Math.max(percent, 1);
 
-        outPrinter.print("\033[" + (tableOrder.size() + 1) + "A");
+        outPrinter.print(String.format(CONSOLE_CURSOR_UP_FORMAT, tableOrder.size() + 1));
         outPrinter.print(
-                "\r\033[KProgress: "
-                        + percent
-                        + "% ["
-                        + currentRecords
-                        + " / "
-                        + totalRecords
-                        + "]\n");
+                String.format(
+                        "%sProgress: %d%% [%d / %d]%n",
+                        CLEAR_LINE, percent, currentRecords, totalRecords));
 
         for (int i = 0; i < tableOrder.size(); i++) {
             String tableName = tableOrder.get(i);
             Long totalRows = tableTotalRows.get(tableName);
             Long currentRows = tableCurrentRows.get(tableName);
             long tableProgress = (totalRows > 0) ? (currentRows * 100 / totalRows) : 0;
-            outPrinter.print("\r\033[K");
+            outPrinter.print(CLEAR_LINE);
             outPrinter.println(
-                    tableName
-                            + " ("
-                            + (i + 1)
-                            + "/"
-                            + tableOrder.size()
-                            + "): "
-                            + tableProgress
-                            + "% ["
-                            + currentRows
-                            + " / "
-                            + totalRows
-                            + "]");
+                    String.format(
+                            "%s (%d/%d): %d%% [%d / %d]",
+                            tableName,
+                            i + 1,
+                            tableOrder.size(),
+                            tableProgress,
+                            currentRows,
+                            totalRows));
         }
     }
 
@@ -209,14 +203,14 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
         if (event instanceof CreateObjectEvent) {
             CreateObjectEvent ev = (CreateObjectEvent) event;
             if (ev.isSuccess()) {
-                currentProgress++;
+                completedWorkUnits++;
             } else {
                 isError = true;
             }
         } else if (event instanceof ImportRecordsEvent) {
             final ImportRecordsEvent importRecordsEvent = (ImportRecordsEvent) event;
             if (importRecordsEvent.isSuccess()) {
-                currentProgress = currentProgress + importRecordsEvent.getRecordCount();
+                completedWorkUnits = completedWorkUnits + importRecordsEvent.getRecordCount();
                 String tblName = importRecordsEvent.getSourceTable().getName();
                 if (tableCurrentRows.containsKey(tblName)) {
                     long current = tableCurrentRows.get(tblName);
@@ -228,32 +222,29 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
             }
         } else if (event instanceof ImportSQLsEvent) {
             ImportSQLsEvent ev = (ImportSQLsEvent) event;
-            currentProgress = currentProgress + ev.getSize();
+            completedWorkUnits = completedWorkUnits + ev.getSize();
             if (!ev.isSuccess()) {
                 isError = true;
             }
         } else if (event instanceof ImportCSVEvent) {
             ImportCSVEvent ev = (ImportCSVEvent) event;
-            currentProgress = currentProgress + ev.getSize();
+            completedWorkUnits = completedWorkUnits + ev.getSize();
             if (!ev.isSuccess()) {
                 isError = true;
             }
         }
         hasError = isError;
-        boolean isNewLine = false;
         if (event.getLevel() <= monitorMode) {
             outPrinter.println(
                     CUBRIDTimeUtil.defaultFormatMilin(event.getEventTime())
                             + " "
                             + event.toString());
-            isNewLine = true;
         }
-        if (monitorMode <= MigrationConfiguration.RPT_LEVEL_ERROR && (totalProgress > 0)) {
-            // print progress
-            long tmpPro = currentProgress * 100 / totalProgress;
+        if (monitorMode <= MigrationConfiguration.RPT_LEVEL_ERROR && (totalWorkUnits > 0)) {
+            long tmpPro = completedWorkUnits * 100 / totalWorkUnits;
             tmpPro = tmpPro == 0 ? 1 : tmpPro;
-            if (tmpPro != progress) {
-                progress = tmpPro;
+            if (tmpPro != lastPrintedProgressPercent) {
+                lastPrintedProgressPercent = tmpPro;
                 progressUpdated = true;
             }
         }

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -47,7 +47,7 @@ import com.cubrid.cubridmigration.cubrid.CUBRIDTimeUtil;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -66,10 +66,9 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
     private boolean hasError;
     private final int monitorMode;
     private PrintStream outPrinter = System.out;
-    private Map<String, Long> tableTotalRows = new HashMap<>();
-    private Map<String, Long> tableCurrentRows = new HashMap<>();
-    private List<String> tableOrder = new ArrayList<>();
-    private int currentTableIndex = 0;
+    private final Map<String, Long> tableTotalRows = new LinkedHashMap<>();
+    private final Map<String, Long> tableCurrentRows = new LinkedHashMap<>();
+    private final List<String> tableOrder = new ArrayList<>();
     private boolean tablesInitialized = false;
 
     public CmdMigrationMonitor(MigrationConfiguration config, int monitorMode) {
@@ -195,5 +194,4 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
             outPrinter.print(ch);
         }
     }
-    
 }

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -46,7 +46,10 @@ import com.cubrid.cubridmigration.core.engine.event.MigrationStartEvent;
 import com.cubrid.cubridmigration.cubrid.CUBRIDTimeUtil;
 import java.io.File;
 import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * CommandMigrationMonitor Description
@@ -63,6 +66,9 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
     private boolean hasError;
     private final int monitorMode;
     private PrintStream outPrinter = System.out;
+    private Map<String, Long> tableTotalRows = new HashMap<>();
+    private Map<String, Long> tableCurrentRows = new HashMap<>();
+    private List<String> tableOrder = new ArrayList<>();
 
     public CmdMigrationMonitor(MigrationConfiguration config, int monitorMode) {
         if (config.sourceIsOnline() || config.sourceIsXMLDump()) {
@@ -187,4 +193,6 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
             outPrinter.print(ch);
         }
     }
+    
+    
 }

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -169,24 +169,19 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
             Long totalRows = tableTotalRows.get(tableName);
             Long currentRows = tableCurrentRows.get(tableName);
             long tableProgress = (totalRows > 0) ? (currentRows * 100 / totalRows) : 0;
-
-            if (tableProgress != lastPrintedTableProgress[i]) {
-                outPrinter.print("\r\033[K");
-                outPrinter.println(
-                        tableName
-                                + " ("
-                                + (i + 1)
-                                + "/"
-                                + tableOrder.size()
-                                + "): "
-                                + tableProgress
-                                + "% ["
-                                + currentRows
-                                + " / "
-                                + totalRows
-                                + "]");
-                lastPrintedTableProgress[i] = tableProgress;
-            }
+            outPrinter.println(
+                    tableName
+                            + " ("
+                            + (i + 1)
+                            + "/"
+                            + tableOrder.size()
+                            + "): "
+                            + tableProgress
+                            + "% ["
+                            + currentRows
+                            + " / "
+                            + totalRows
+                            + "]");
         }
     }
 

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -121,6 +121,10 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
     /** Print started message. */
     public void start() {
 
+        if (tablesInitialized || tableOrder.isEmpty()) {
+            return;
+        }
+
         for (int i = 0; i < tableOrder.size() + 1; i++) {
             outPrinter.println();
         }
@@ -151,24 +155,12 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
                         + totalRecords
                         + "]\n");
 
-        if (percent != lastPrintedPercent) {
-            outPrinter.print("\033[" + (tableOrder.size() + 1) + "A");
-            outPrinter.print(
-                    "\r\033[KProgress: "
-                            + percent
-                            + "% ["
-                            + currentRecords
-                            + " / "
-                            + totalRecords
-                            + "]\n");
-            lastPrintedPercent = percent;
-        }
-
         for (int i = 0; i < tableOrder.size(); i++) {
             String tableName = tableOrder.get(i);
             Long totalRows = tableTotalRows.get(tableName);
             Long currentRows = tableCurrentRows.get(tableName);
             long tableProgress = (totalRows > 0) ? (currentRows * 100 / totalRows) : 0;
+            outPrinter.print("\r\033[K");
             outPrinter.println(
                     tableName
                             + " ("

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -104,7 +104,14 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
     public void finished() {}
 
     /** Print started message. */
-    public void start() {}
+    public void start() {
+
+        for (int i = 0; i < tableOrder.size() + 1; i++) {
+            outPrinter.println();
+        }
+
+        tablesInitialized = true;
+    }
 
     /**
      * Print event message.

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -70,6 +70,8 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
     private final Map<String, Long> tableCurrentRows = new LinkedHashMap<>();
     private final List<String> tableOrder = new ArrayList<>();
     private boolean tablesInitialized = false;
+    private long lastPrintedPercent = -1;
+    private long[] lastPrintedTableProgress;
 
     public CmdMigrationMonitor(MigrationConfiguration config, int monitorMode) {
         if (config.sourceIsOnline() || config.sourceIsXMLDump()) {
@@ -111,6 +113,68 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
         }
 
         tablesInitialized = true;
+    }
+
+    private void printLiveProgressBlock() {
+        if (tableOrder.isEmpty()) return;
+
+        long totalRecords = 0;
+        long currentRecords = 0;
+        for (String tableName : tableOrder) {
+            totalRecords += tableTotalRows.getOrDefault(tableName, 0L);
+            currentRecords += tableCurrentRows.getOrDefault(tableName, 0L);
+        }
+
+        long percent = (totalRecords > 0) ? (currentRecords * 100 / totalRecords) : 100;
+        percent = Math.max(percent, 1);
+
+        outPrinter.print("\033[" + (tableOrder.size() + 1) + "A");
+        outPrinter.print(
+                "\r\033[KProgress: "
+                        + percent
+                        + "% ["
+                        + currentRecords
+                        + " / "
+                        + totalRecords
+                        + "]\n");
+
+        if (percent != lastPrintedPercent) {
+            outPrinter.print("\033[" + (tableOrder.size() + 1) + "A");
+            outPrinter.print(
+                    "\r\033[KProgress: "
+                            + percent
+                            + "% ["
+                            + currentRecords
+                            + " / "
+                            + totalRecords
+                            + "]\n");
+            lastPrintedPercent = percent; 
+        }
+
+        for (int i = 0; i < tableOrder.size(); i++) {
+            String tableName = tableOrder.get(i);
+            Long totalRows = tableTotalRows.get(tableName);
+            Long currentRows = tableCurrentRows.get(tableName);
+            long tableProgress = (totalRows > 0) ? (currentRows * 100 / totalRows) : 0;
+
+            if (tableProgress != lastPrintedTableProgress[i]) {
+                outPrinter.print("\r\033[K");
+                outPrinter.println(
+                        tableName
+                                + " ("
+                                + (i + 1)
+                                + "/"
+                                + tableOrder.size()
+                                + "): "
+                                + tableProgress
+                                + "% ["
+                                + currentRows
+                                + " / "
+                                + totalRows
+                                + "]");
+                lastPrintedTableProgress[i] = tableProgress; 
+            }
+        }
     }
 
     /**

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -62,7 +62,6 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
     private long currentProgress = 0;
     private long progress = 0;
     private MigrationFinishedEvent finalEvent = null;
-    // private int circle = 0;
     private boolean hasError;
     private final int monitorMode;
     private PrintStream outPrinter = System.out;
@@ -70,8 +69,6 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
     private final Map<String, Long> tableCurrentRows = new LinkedHashMap<>();
     private final List<String> tableOrder = new ArrayList<>();
     private boolean tablesInitialized = false;
-    private long lastPrintedPercent = -1;
-    private long[] lastPrintedTableProgress;
 
     public CmdMigrationMonitor(MigrationConfiguration config, int monitorMode) {
         this.monitorMode = monitorMode;
@@ -119,8 +116,9 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
     public void finished() {}
 
     /** Print started message. */
-    public void start() {
+    public void start() {}
 
+    public void prepareTableProgressOutput() {
         if (tablesInitialized || tableOrder.isEmpty()) {
             return;
         }
@@ -189,7 +187,7 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
 
         if (event instanceof MigrationStartEvent) {
             outPrinter.println(event.toString());
-            start();
+            prepareTableProgressOutput();
             return;
         }
 

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -254,23 +254,13 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
             // print progress
             long tmpPro = currentProgress * 100 / totalProgress;
             tmpPro = tmpPro == 0 ? 1 : tmpPro;
-            progress = tmpPro;
-            if (!isNewLine) {
-                print('\b', String.valueOf(tmpPro).length() + 2);
+            if (tmpPro != progress) {
+                progress = tmpPro;
+                progressUpdated = true;
             }
-            outPrinter.print(progress + "%");
         }
-    }
-
-    /**
-     * Print chars on screen.
-     *
-     * @param ch char to be printed
-     * @param count repeat count
-     */
-    private void print(char ch, int count) {
-        for (int i = 0; i < count; i++) {
-            outPrinter.print(ch);
+        if (progressUpdated) {
+            printLiveProgressBlock();
         }
     }
 }

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -148,7 +148,7 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
                             + " / "
                             + totalRecords
                             + "]\n");
-            lastPrintedPercent = percent; 
+            lastPrintedPercent = percent;
         }
 
         for (int i = 0; i < tableOrder.size(); i++) {
@@ -172,7 +172,7 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
                                 + " / "
                                 + totalRows
                                 + "]");
-                lastPrintedTableProgress[i] = tableProgress; 
+                lastPrintedTableProgress[i] = tableProgress;
             }
         }
     }
@@ -189,13 +189,14 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
 
         if (event instanceof MigrationStartEvent) {
             outPrinter.println(event.toString());
+            start();
             return;
         }
 
         if (event instanceof MigrationFinishedEvent) {
             finalEvent = (MigrationFinishedEvent) event;
-            print('\b', String.valueOf(progress).length() + 2);
-            outPrinter.print("100%");
+            printLiveProgressBlock();
+            outPrinter.print("\rProgress:100%");
             outPrinter.println();
             if (hasError) {
                 outPrinter.println("Some errors occurred during migration.");
@@ -206,6 +207,7 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
         }
 
         boolean isError = false;
+        boolean progressUpdated = false;
         if (event instanceof CreateObjectEvent) {
             CreateObjectEvent ev = (CreateObjectEvent) event;
             if (ev.isSuccess()) {
@@ -217,6 +219,12 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
             final ImportRecordsEvent importRecordsEvent = (ImportRecordsEvent) event;
             if (importRecordsEvent.isSuccess()) {
                 currentProgress = currentProgress + importRecordsEvent.getRecordCount();
+                String tblName = importRecordsEvent.getSourceTable().getName();
+                if (tableCurrentRows.containsKey(tblName)) {
+                    long current = tableCurrentRows.get(tblName);
+                    tableCurrentRows.put(tblName, current + importRecordsEvent.getRecordCount());
+                    progressUpdated = true;
+                }
             } else {
                 isError = true;
             }

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -74,32 +74,45 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
     private long[] lastPrintedTableProgress;
 
     public CmdMigrationMonitor(MigrationConfiguration config, int monitorMode) {
+        this.monitorMode = monitorMode;
+        hasError = false;
+
         if (config.sourceIsOnline() || config.sourceIsXMLDump()) {
-            List<SourceEntryTableConfig> tables = config.getExpEntryTableCfg();
-            for (SourceEntryTableConfig tbl : tables) {
+            for (SourceEntryTableConfig tbl : config.getExpEntryTableCfg()) {
                 Table table = config.getSrcTableSchema(tbl.getOwner(), tbl.getName());
                 if (tbl.isCreatePK() && table.getPk() != null) {
                     totalProgress++;
                 }
-                totalProgress = totalProgress + table.getTableRowCount();
+                long rowCount = table.getTableRowCount();
+                totalProgress += rowCount;
+
+                String name = tbl.getName();
+                tableOrder.add(name);
+                tableTotalRows.put(name, rowCount);
+                tableCurrentRows.put(name, 0L);
             }
-            List<SourceSQLTableConfig> sqlTables = config.getExpSQLCfg();
-            for (SourceSQLTableConfig tbl : sqlTables) {
+
+            for (SourceSQLTableConfig tbl : config.getExpSQLCfg()) {
                 Table table = config.getSrcTableSchema(tbl.getOwner(), tbl.getName());
-                totalProgress = totalProgress + (table == null ? 0 : table.getTableRowCount());
+                long rowCount = table == null ? 0 : table.getTableRowCount();
+                totalProgress += rowCount;
+
+                String name = tbl.getName();
+                tableOrder.add(name);
+                tableTotalRows.put(name, rowCount);
+                tableCurrentRows.put(name, 0L);
             }
-            totalProgress = totalProgress + config.getExpObjCount();
+
+            totalProgress += config.getExpObjCount();
         } else if (config.sourceIsSQL()) {
             for (String ss : config.getSqlFiles()) {
-                totalProgress = totalProgress + new File(ss).length();
+                totalProgress += new File(ss).length();
             }
         } else if (config.sourceIsCSV()) {
             for (SourceCSVConfig scc : config.getCSVConfigs()) {
-                totalProgress = totalProgress + new File(scc.getName()).length();
+                totalProgress += new File(scc.getName()).length();
             }
         }
-        this.monitorMode = monitorMode;
-        hasError = false;
     }
 
     /** Print finished message. */

--- a/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -69,6 +69,8 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
     private Map<String, Long> tableTotalRows = new HashMap<>();
     private Map<String, Long> tableCurrentRows = new HashMap<>();
     private List<String> tableOrder = new ArrayList<>();
+    private int currentTableIndex = 0;
+    private boolean tablesInitialized = false;
 
     public CmdMigrationMonitor(MigrationConfiguration config, int monitorMode) {
         if (config.sourceIsOnline() || config.sourceIsXMLDump()) {
@@ -193,6 +195,5 @@ public class CmdMigrationMonitor implements IMigrationMonitor {
             outPrinter.print(ch);
         }
     }
-    
     
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4733

**Purpose**

- 마이그레이션 진행 상황을 보다 명확히 확인할 수 있도록, 전체 진행률과 테이블별 진행률을 실시간으로 출력하도록 개선하였습니다.

**Format**

Progress: 1%  [13100 / 2011100]
s1h (1/5) : 100%  [100  / 100]
s1k (2/5) : 100% [1000 / 1000]
s1w (3/5) : 100% [10000 / 10000]
t1  (4/5) : 0%  [2000 / 1000000]
t2  (5/5) : 0%  [0  / 1000000]

**Implementation**

- CmdMigrationMonitor에 테이블별 진행률 출력 로직 추가

- ANSI 이스케이프 코드를 활용해 콘솔 상에서 실시간 갱신 처리

- printLiveProgressBlock() 및 prepareTableProgressOutput() 메서드로 관련 로직 정리

**Remarks**

- 콘솔 실행 시에만 적용