### PR TITLE
[TOOLS-4735] Convert Oracle default datetime functions to CUBRID

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -385,9 +385,6 @@ public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
             case "sysdate":
                 return "sys_datetime";
             case "current_date":
-            case "localtimestamp":
-            case "systimestamp":
-            case "current_timestamp":
                 return "current_datetime";
         }
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -386,6 +386,8 @@ public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
                 return "sys_datetime";
             case "current_date":
             case "localtimestamp":
+            case "systimestamp":
+            case "current_timestamp":
                 return "current_datetime";
         }
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/trans/Oracle2CUBRIDTranformHelper.java
@@ -324,6 +324,7 @@ public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
 
         if ((dataType.indexOf("TIMESTAMP") > -1 || "DATE".equalsIgnoreCase(dataType))
                 && isDefaultDateTimeFunction(defaultValue)) {
+            defaultValue = convertFunctionInDefaultValue(defaultValue, cubridColumn.getDataType());
             cubridColumn.setDefaultValue(defaultValue);
             return;
         }
@@ -379,6 +380,14 @@ public class Oracle2CUBRIDTranformHelper extends DBTransformHelper {
      */
     private String convertFunctionInDefaultValue(String defaultValue, String dataType) {
         String lowerCaseDefaultValue = defaultValue.toLowerCase(Locale.US);
+
+        switch (lowerCaseDefaultValue) {
+            case "sysdate":
+                return "sys_datetime";
+            case "current_date":
+            case "localtimestamp":
+                return "current_datetime";
+        }
 
         if ("datetime".equalsIgnoreCase(dataType) && lowerCaseDefaultValue.startsWith("to_date")) {
             return lowerCaseDefaultValue.replaceFirst("to_date", "to_datetime");


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4735>

### Purpose
Oracle의 날짜/시간 함수는 CUBRID에도 동일한 이름으로 존재하지만, 데이터 타입의 차이로 인해 동일한 방식으로 사용하는 것은 적절하지 않습니다.
Oracle의 DATE 타입은 CUBRID의 DATETIME으로 변환해 사용해야 함으로, 그에 맞는 기본값 함수로 변환 할 수 있도록 수정합니다.

| **Oracle 함수** | **CUBRID 함수** |
| --------------- | ---------------- |
| SYSDATE          | SYS_DATETIME  |
| CURRENT_DATE | CURRENT_DATETIME |

### Implementation
- 날짜/시간 데이터 타입인 경우에도 기본 값을 변환할 수 있도록 `convertFunctionInDefaultValue` 추가
- `convertFunctionInDefaultValue`메소드에 날짜/시간 함수 변환 조건 추가

### Remarks
N/A
