### PR TITLE
[TOOLS-4734] Migration exclusion for Oracle mlog$, rupd$, and bin$ tables related to Mview

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -145,13 +145,15 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
 
     private static final String SQL_SHOW_ALL_OBJECTS =
             "SELECT NAME FROM ALL_SOURCE S "
-                    + "WHERE S.TYPE=? AND S.OWNER=? AND NOT S.NAME LIKE 'BIN$%'";
+                    + "WHERE S.TYPE=? AND S.OWNER=? AND NOT S.NAME LIKE 'BIN$%' "
+                    + "AND NOT S.NAME LIKE 'MLOG$%' AND NOT S.NAME LIKE 'RUPD$%'";
 
     private static final String SQL_SHOW_DDL = "SELECT DBMS_METADATA.GET_DDL(?, ?, ?) FROM dual";
 
     private static final String SQL_SHOW_SEQUENCES =
             "SELECT S.* FROM ALL_SEQUENCES S "
-                    + "WHERE S.SEQUENCE_OWNER=? AND NOT S.SEQUENCE_NAME LIKE 'BIN$%' ";
+                    + "WHERE S.SEQUENCE_OWNER=? AND NOT S.SEQUENCE_NAME LIKE 'BIN$%' "
+                    + "AND NOT S.SEQUENCE_NAME LIKE 'MLOG$%' AND NOT S.SEQUENCE_NAME LIKE 'RUPD$%' ";
 
     private static final String SQL_SHOW_SYNONYM =
             "SELECT SYNONYM_NAME, TABLE_OWNER, TABLE_NAME, DB_LINK FROM ALL_SYNONYMS WHERE OWNER=?";
@@ -1071,7 +1073,9 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 tables.getString(1);
                 tables.getString(2);
                 String name = tables.getString(3);
-                if (name.startsWith("BIN$%")) {
+                if (name.startsWith("BIN$")
+                        || name.startsWith("MLOG$")
+                        || name.startsWith("RUPD$")) {
                     continue;
                 }
                 tableNameList.add(owner + "." + name);
@@ -1140,7 +1144,10 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
         try {
             while (rs.next()) {
                 String name = rs.getString(3);
-                if (name.startsWith("BIN$%") || "USER_SEQUENCES".equals(name)) {
+                if (name.startsWith("BIN$")
+                        || name.startsWith("MLOG$")
+                        || name.startsWith("RUPD$")
+                        || "USER_SEQUENCES".equals(name)) {
                     continue;
                 }
                 viewNameList.add(owner + "." + name);


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4734

### Purpose
Oracle 데이터베이스에서 CUBRID로 마이그레이션할 때, BIN$, MLOG$, RUPD$ 접두사가 붙은 Oracle 시스템 테이블들이 함께 포함되어 불필요한 객체들이 마이그레이션되는 문제를 수정합니다.

### Implementation

- SQL_SHOW_ALL_OBJECTS 쿼리에 시스템 테이블(BIN$%, MLOG$%, RUPD$%) 제외 조건 추가

- SQL_SHOW_SEQUENCES 쿼리에 시스템 시퀀스 제외 조건 추가

- getAllTableNames()와 getAllViewNames() 메소드에 시스템 테이블 및 뷰 필터링 로직 추가

### Remarks

- BIN$: Oracle 휴지통(Recycle Bin) 관련 삭제된 객체

- MLOG$:  Oracle Materialized View Log 테이블

- RUPD$: Oracle Refresh Update 테이블
