### PR TITLE
[TOOLS-4738] Enhance console script command

### DIFF
--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
@@ -480,11 +480,10 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
      * @return true if driver exists or added successfully
      */
     private boolean checkJDBCDriver(DatabaseType dt, String driverPath) {
-        if (dt.getJDBCData(driverPath) == null
-                && !JDBCDriverManager.getInstance().addDriver(driverPath, false)) {
-            return false;
-        }
-        return true;
+        boolean isDriverAlreadyRegistered =
+                JDBCDriverManager.getInstance().addDriver(driverPath, false);
+        boolean successfullyAddedNewDriver = (dt.getJDBCData(driverPath) != null);
+        return successfullyAddedNewDriver || isDriverAlreadyRegistered;
     }
 
     /**

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
@@ -453,11 +453,21 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
             }
             config.setTargetConParams(tcp);
         } else if (config.targetIsFile()) {
-            String ouputDir = dbProperties.getProperty(tvalue + ".output");
-            String prefix = dbProperties.getProperty(tvalue + ".prefix");
-            String charset = dbProperties.getProperty(tvalue + ".charset");
-            config.setExp2FileOuput(prefix, ouputDir, charset);
+            String prefix = dbProperties.getProperty(tvalue + ".file_prefix");
+            config.setTargetFilePrefix(
+                    prefix == null ? config.getSourceConParams().getDbName() : prefix);
+            config.setFileRepositroyPath(dbProperties.getProperty(tvalue + ".output"));
+            config.setTargetCharSet(dbProperties.getProperty(tvalue + ".charset"));
             config.setTargetFileTimeZone("Default");
+
+            String splitSchema = dbProperties.getProperty(tvalue + ".split_schema");
+            config.setSplitSchema(isDefaultYes(splitSchema));
+
+            String addSchema = dbProperties.getProperty(tvalue + ".add_schema");
+            config.setAddUserSchema(isDefaultYes(addSchema));
+
+            String oneTableOneFile = dbProperties.getProperty(tvalue + ".one_table_one_file");
+            config.setOneTableOneFile(isDefaultNo(oneTableOneFile));
         }
         return true;
     }
@@ -475,6 +485,32 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Return true if the value is null or not "no".
+     *
+     * @param value the text to check
+     * @return true if default is "yes"
+     */
+    private boolean isDefaultYes(String value) {
+        if (value == null) {
+            return true;
+        }
+        return !value.equalsIgnoreCase("no");
+    }
+
+    /**
+     * Return true if the value is "yes". Return false is null or anything else.
+     *
+     * @param value the text to check
+     * @return true if default is "no"
+     */
+    private boolean isDefaultNo(String value) {
+        if (value == null) {
+            return false;
+        }
+        return value.equalsIgnoreCase("yes");
     }
 
     //	public static void main(String[] args) {

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
@@ -35,6 +35,8 @@ import com.cubrid.cubridmigration.command.ConsoleCommandHandler;
 import com.cubrid.cubridmigration.command.ConsoleUtils;
 import com.cubrid.cubridmigration.core.common.PathUtils;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.connection.JDBCDriverManager;
+import com.cubrid.cubridmigration.core.connection.JDBCUtil;
 import com.cubrid.cubridmigration.core.dbmetadata.DBSchemaInfoFetcherFactory;
 import com.cubrid.cubridmigration.core.dbmetadata.IDBSchemaInfoFetcher;
 import com.cubrid.cubridmigration.core.dbmetadata.IDBSource;
@@ -197,6 +199,15 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
                 return;
             }
             loadDBProperties();
+            try {
+                JDBCUtil.initialJdbcByPath(PathUtils.getJDBCLibDir());
+            } catch (Exception ex) {
+                LOG.warn(
+                        "Skip default JDBC init ({}): {}",
+                        PathUtils.getJDBCLibDir(),
+                        ex.getMessage());
+                LOG.debug("Default JDBC init failed", ex);
+            }
             boolean isNeedReset = false;
             MigrationConfiguration config = getInitConfig(tmpArgs);
             if (config == null) {
@@ -338,6 +349,10 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
                 outPrinter.println("Read JDBC configuration error:" + svalue);
                 return false;
             }
+            if (!checkJDBCDriver(scp.getDatabaseType(), scp.getDriverFileName())) {
+                outPrinter.println("Invalid driver : " + scp.getDriverFileName());
+                return false;
+            }
             try {
                 Connection con = scp.createConnection();
                 con.close();
@@ -400,6 +415,10 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
                 outPrinter.println("Read JDBC configuration error:" + tvalue);
                 return false;
             }
+            if (!checkJDBCDriver(tcp.getDatabaseType(), tcp.getDriverFileName())) {
+                outPrinter.println("Invalid driver : " + tcp.getDriverFileName());
+                return false;
+            }
             try {
                 Connection con = tcp.createConnection();
                 con.close();
@@ -415,6 +434,21 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
             String charset = dbProperties.getProperty(tvalue + ".charset");
             config.setExp2FileOuput(prefix, ouputDir, charset);
             config.setTargetFileTimeZone("Default");
+        }
+        return true;
+    }
+
+    /**
+     * Check and add JDBC driver if necessary.
+     *
+     * @param dt DatabaseType
+     * @param driverPath driverPath
+     * @return true if driver exists or added successfully
+     */
+    private boolean checkJDBCDriver(DatabaseType dt, String driverPath) {
+        if (dt.getJDBCData(driverPath) == null
+                && !JDBCDriverManager.getInstance().addDriver(driverPath, false)) {
+            return false;
         }
         return true;
     }

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
@@ -47,11 +47,13 @@ import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import com.cubrid.cubridmigration.core.engine.config.SourceEntryTableConfig;
 import com.cubrid.cubridmigration.core.engine.template.MigrationTemplateParser;
+import com.cubrid.cubridmigration.cubrid.CUBRIDTimeUtil;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.PrintStream;
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
@@ -193,9 +195,24 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
                 printHelp();
                 return;
             }
-            String outputFileName = getParameter(tmpArgs, "-o");
-            if (StringUtils.isBlank(outputFileName)) {
-                outPrinter.println("Output file should be specified with '-o'.");
+            String outputDirPath = getParameter(tmpArgs, "-o");
+            if (StringUtils.isBlank(outputDirPath)) {
+                outPrinter.println("Output directory should be specified with '-o'.");
+                return;
+            }
+            File outputDir = new File(outputDirPath);
+            if (outputDir.exists() && !outputDir.isDirectory()) {
+                outPrinter.println("'-o' must be a directory path: " + outputDirPath);
+                return;
+            }
+            if (!outputDir.exists() && !outputDir.mkdirs()) {
+                outPrinter.println(
+                        "Failed to create output directory: " + outputDir.getAbsolutePath());
+                return;
+            }
+            if (!outputDir.canWrite()) {
+                outPrinter.println(
+                        "Output directory is not writable: " + outputDir.getAbsolutePath());
                 return;
             }
             loadDBProperties();
@@ -213,8 +230,9 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
             if (config == null) {
                 isNeedReset = true;
                 config = new MigrationConfiguration();
-                File outputFile = new File(outputFileName);
-                config.setName(PathUtils.getFileNameWithoutExtendName(outputFile.getName()));
+                config.setWizardStartDateTime(
+                        CUBRIDTimeUtil.wizardStarDateTimeFormat(
+                                new Date(System.currentTimeMillis())));
             }
             if (!setSource(config, tmpArgs)) {
                 return;
@@ -223,6 +241,10 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
                 return;
             }
             setOtherOptions(config, tmpArgs);
+            config.setName(
+                    config.getSourceDBType().getName(),
+                    config.getSourceConParams().getDbName(),
+                    config.getWizardStartDateTime());
             Catalog srcCat = config.buildSourceSchema();
             if (srcCat == null) {
                 outPrinter.println("Build source schema error.");
@@ -233,11 +255,13 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
                 config.setAll(true);
             }
             configObjectMapping(config);
+            String outputFileName = config.getName() + ".xml";
+            File outputFile = new File(outputDir, outputFileName);
             MigrationTemplateParser.save(
                     config,
-                    outputFileName,
+                    outputFile.getAbsolutePath(),
                     "yes".equalsIgnoreCase(getParameter(tmpArgs, "-schema")));
-            outPrinter.println(outputFileName + " was created successfully.");
+            outPrinter.println(outputFile.getAbsolutePath() + " was created successfully.");
         } catch (Exception ex) {
             outPrinter.println("Unexpected error. Please check the log for more information.");
             LOG.error("Unexpected error while processing CLI arguments: {}.", args, ex);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4738>

### Purpose
콘솔의 `script` 명령어는 여러 작동 문제와 기능 부족으로 인해 정상적인 사용이 어렵습니다.
- JDBC 초기화 문제로 인해 데이터베이스 연결을 안정적으로 생성하지 못했습니다.
- 새롭게 추가되거나 변경된 규칙이 적용되지 않아, RCP 애플리케이션 버전과 동일한 형식의 스크립트를 생성할 수 없었습니다.

해당 PR을 통해 기존에 동작하지 않던 기능을 수정하고 새로운 옵션을 추가하여, `script` 명령어가 정상적으로 동작하고, 사용성을 높이는 것을 목표로 합니다.

### Implementation
- **출력 방식 및 유효성 검사 개선**
  - `-o` 옵션이 '파일'이 아닌 '디렉터리' 경로를 받도록 수정
  - 지정된 출력 디렉터리의 존재 여부 및 쓰기 권한을 사전에 확인하는 방어 코드 추가
  - 스크립트 파일명은 `소스DB타입_DB이름_yyyyMMddHHmmss.xml` 규칙에 따라 자동 생성
- **JDBC 드라이버 등록 안정성 강화**
  - 기본 JDBC 디렉터리를 확인하고 초기화 하는 로직 추가
  - DB 연결 시도 전에 필요한 드라이버의 유효성을 먼저 검사하는 `checkJDBCDriver` 메서드를 구현해 적용
- **파일 출력 옵션 기능 확장**
  - 마이그레이션 대상이 파일일 경우, `db.conf` 파일을 통해 아래의 상세 옵션을 설정할 수 있도록 기능 추가
    - split_schema
    - add_schema
    - one_table_one_file
  - 'yes/no' 형태의 문자열 설정을 쉽게 처리하기 위해 헬퍼 메서드 추가

### Remarks
N/A
