### PR TITLE
[TOOLS-4669] Resolve migration failure when using -tp option in console

### DIFF
--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
@@ -180,6 +180,7 @@ public class StartCommandHandler implements ConsoleCommandHandler {
                 }
             }
             if (targetPath != null) {
+                config.setFileRepositroyPath(targetPath);
                 config.changeTargetFilePath(targetPath);
             }
             config.cleanNoUsedConfigForStart();

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
@@ -180,8 +180,8 @@ public class StartCommandHandler implements ConsoleCommandHandler {
                 }
             }
             if (targetPath != null) {
-                config.setFileRepositroyPath(targetPath);
                 config.changeTargetFilePath(targetPath);
+                config.setFileRepositroyPath(targetPath);
             }
             config.cleanNoUsedConfigForStart();
             if (config.hasOtherParam()) {

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
@@ -345,19 +345,21 @@ public class StartCommandHandler implements ConsoleCommandHandler {
                 return false;
             }
         } else {
-            boolean confirm;
-            String tempPath = config.getFileRepositroyPath();
-            if (SystemUtils.IS_OS_WINDOWS) {
-                confirm = !tempPath.matches("^[A-Za-z]:\\\\.*");
-            } else {
-                confirm = tempPath.matches("^[A-Za-z]:\\\\.*");
-            }
-            if (confirm) {
-                outPrinter.println("Invalid path : " + tempPath);
-                outPrinter.println(
-                        "Please specify the path where you want to save exported files by parameter [-tp]");
-                outPrinter.println();
-                return false;
+            if (targetPath == null) {
+                boolean confirm;
+                String tempPath = config.getFileRepositroyPath();
+                if (SystemUtils.IS_OS_WINDOWS) {
+                    confirm = !tempPath.matches("^[A-Za-z]:\\\\.*");
+                } else {
+                    confirm = tempPath.matches("^[A-Za-z]:\\\\.*");
+                }
+                if (confirm) {
+                    outPrinter.println("Invalid path : " + tempPath);
+                    outPrinter.println(
+                            "Please specify the path where you want to save exported files by parameter [-tp]");
+                    outPrinter.println();
+                    return false;
+                }
             }
         }
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -2008,19 +2008,15 @@ public class MigrationConfiguration {
                                         .substring(tempPath.length()));
             }
             if (targetGrantFileName.get(schemaName) != null) {
-                Map<String, String> grantFileFullName = targetGrantFileName.get(schemaName);
-                for (SourceGrantConfig sgc : expGrants) {
-                    if (!grantFileFullName.containsKey(schemaName)) {
-                        continue;
-                    }
-                    if (grantFileFullName.get(schemaName) != null) {
-                        addTargetGrantFileName(
-                                schemaName,
-                                sgc.getSourceObjectOwner(),
-                                path2
-                                        + grantFileFullName
-                                                .get(schemaName)
-                                                .substring(tempPath.length()));
+                Map<String, String> grantFilesForSchema = targetGrantFileName.get(schemaName);
+
+                for (Map.Entry<String, String> entry : grantFilesForSchema.entrySet()) {
+                    String sourceObjectOwner = entry.getKey();
+                    String oldFilePath = entry.getValue();
+
+                    if (oldFilePath != null) {
+                        String newFilePath = path2 + oldFilePath.substring(tempPath.length());
+                        addTargetGrantFileName(schemaName, sourceObjectOwner, newFilePath);
                     }
                 }
             }
@@ -2057,25 +2053,31 @@ public class MigrationConfiguration {
                                         .substring(tempPath.length()));
             }
             if (targetPlcsqlProcedureFileName.get(schemaName) != null) {
-                for (SourcePlcsqlProcedureConfig spc : expPlcsqlProcedures) {
-                    addTargetPlcsqlProcedureFileName(
-                            schemaName,
-                            spc.getName(),
-                            path2
-                                    + targetSchemaFileListName
-                                            .get(schemaName)
-                                            .substring(tempPath.length()));
+                Map<String, String> proceduresForSchema =
+                        targetPlcsqlProcedureFileName.get(schemaName);
+
+                for (Map.Entry<String, String> entry : proceduresForSchema.entrySet()) {
+                    String procedureName = entry.getKey();
+                    String oldFilePath = entry.getValue();
+
+                    if (oldFilePath != null) {
+                        String newFilePath = path2 + oldFilePath.substring(tempPath.length());
+                        addTargetPlcsqlProcedureFileName(schemaName, procedureName, newFilePath);
+                    }
                 }
             }
             if (targetPlcsqlFunctionFileName.get(schemaName) != null) {
-                for (SourcePlcsqlFunctionConfig fpc : expPlcsqlFunctions) {
-                    addTargetPlcsqlFunctionFileName(
-                            schemaName,
-                            fpc.getName(),
-                            path2
-                                    + targetSchemaFileListName
-                                            .get(schemaName)
-                                            .substring(tempPath.length()));
+                Map<String, String> functionsForSchema =
+                        targetPlcsqlFunctionFileName.get(schemaName);
+
+                for (Map.Entry<String, String> entry : functionsForSchema.entrySet()) {
+                    String functionName = entry.getKey();
+                    String oldFilePath = entry.getValue();
+
+                    if (oldFilePath != null) {
+                        String newFilePath = path2 + oldFilePath.substring(tempPath.length());
+                        addTargetPlcsqlFunctionFileName(schemaName, functionName, newFilePath);
+                    }
                 }
             }
         } else {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -2089,7 +2089,7 @@ public class MigrationConfiguration {
         }
         if (this.isOneTableOneFile()) {
             if (targetTableDataFileName.get(schemaName) != null) {
-                List<String> filePaths = targetTableDataFileName.get(schemaName);
+                List<String> filePaths = new ArrayList<>(targetTableDataFileName.get(schemaName));
                 for (String filePath : filePaths) {
                     addTargetTableDataFileName(
                             schemaName, path2 + filePath.substring(tempPath.length()));


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4669>

### Purpose
콘솔 모드에서 `-tp` 옵션이 동작하지 않는 문제를 해결해 사용자가 지정한 경로에 결과 파일이 정상적으로 생성되도록 수정합니다.

### Implementation
 - Grant, PL/CSQL Procedure, Function의 파일 경로를 변경할 때, 중첩된 Map 자료구조를 올바르게 탐색하지 못하고 잘못된 변수를 참조 버그 수정
- `-tp` 옵션으로 새로운 경로가 입력되었을 때, `setFileRepositoryPath()`가 호출되지 않아 설정이 누락되는 문제 수정
- `-tp`옵션을 사용해 `targetPath`가 초기화된 경우, 기존 파일 출력 경로에 대한 유효성 검사를 건너뛰도록 수정
- one table one file 옵션 사용 시 테이블의 복사본 리스트를 순회하도록 수정

### Remarks
N/A
