### PR TITLE
[TOOLS-4742] Isolate Script Export Settings from Migration Execution

### DIFF
--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/ExportScriptDialog.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/ExportScriptDialog.java
@@ -226,11 +226,34 @@ public class ExportScriptDialog extends TransFileBySSHDialog {
     /** create temporary script xml */
     private void createTempXml(String fName) {
         tmpFile = PathUtils.getBaseTempDir() + UUID.randomUUID() + ".xml";
-        changeMigrationName(fName);
-        changeSourceJDBCDriverDirectory();
-        changeTargetJDBCDriverDirectory();
-        changeOutputDirectory();
-        MigrationTemplateParser.save(config, tmpFile, isSaveSchema);
+        // Backup fields we are about to change
+        String originalName = config.getName();
+        String originalSrcDriver =
+                config.getSourceConParams() == null
+                        ? null
+                        : config.getSourceConParams().getDriverFileName();
+        String originalTarDriver =
+                config.getTargetConParams() == null
+                        ? null
+                        : config.getTargetConParams().getDriverFileName();
+        String originalOutputDir = config.getFileRepositroyPath();
+        try {
+            changeMigrationName(fName);
+            changeSourceJDBCDriverDirectory();
+            changeTargetJDBCDriverDirectory();
+            changeOutputDirectory();
+            MigrationTemplateParser.save(config, tmpFile, isSaveSchema);
+        } finally {
+            // Restore original values to avoid side effects
+            config.setName(originalName);
+            if (config.getSourceConParams() != null) {
+                config.getSourceConParams().setDriverFileName(originalSrcDriver);
+            }
+            if (config.getTargetConParams() != null) {
+                config.getTargetConParams().setDriverFileName(originalTarDriver);
+            }
+            config.setFileRepositroyPath(originalOutputDir);
+        }
     }
 
     /** OK pressed */

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/ExportScriptDialog.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/ExportScriptDialog.java
@@ -244,7 +244,7 @@ public class ExportScriptDialog extends TransFileBySSHDialog {
             changeOutputDirectory();
             MigrationTemplateParser.save(config, tmpFile, isSaveSchema);
         } finally {
-            // Restore original values to avoid side effects
+            // Restore config for the migration step that runs after export
             config.setName(originalName);
             if (config.getSourceConParams() != null) {
                 config.getSourceConParams().setDriverFileName(originalSrcDriver);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4742>

### Purpose
마이그레이션 마법사 5단계에서 `내보내기(Export)` 시 변경한 스크립트 이름, JDBC 디렉터리, 출력 파일 디렉터리 경로 설정이 다음 단계에서 진행하는 마이그레이션 작업에 영향이 없도록 수정합니다.

### Implementation

- try...finally 구문을 추가하여, MigrationConfiguration 객체의 원본 값을 백업
- finally 블록테서 백업해 둔 원 본 값으로 객체를 복원하여, 메서드 실행 후에도 마이그레이션 설정이 원본 상태를 유지하도록 보장

### Remarks
N/A
