### PR TITLE
[TOOLS-4744] DB object의 comment에 single quotation(') 가 제대로 처리되지 않는 문제

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
@@ -1287,16 +1287,17 @@ public abstract class AbstractJDBCSchemaFetcher implements IDependOnDatabaseType
         return "YES".equalsIgnoreCase(value);
     }
 
+    /**
+     * Replace one small quotation mark inside the comment with two small quotation marks
+     *
+     * @param comment the comment to be processed
+     * @return processed comment or null if input is null
+     */
     protected String commentEditor(String comment) {
         if (comment == null) {
-            return comment;
+            return null;
         }
-
-        String editedComment;
-
-        editedComment = comment.replaceAll("[\\']", "\\'\\'");
-
-        return editedComment;
+        return comment.replaceAll("[\\']", "\\'\\'");
     }
     /**
      * Get table comment abstract method

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
@@ -1288,10 +1288,10 @@ public abstract class AbstractJDBCSchemaFetcher implements IDependOnDatabaseType
     }
 
     protected String commentEditor(String comment) {
-    	if (comment == null) {
-    		return comment;
-    	}
-    	
+        if (comment == null) {
+            return comment;
+        }
+
         String editedComment;
 
         editedComment = comment.replaceAll("[\\']", "\\'\\'");

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
@@ -1290,7 +1290,7 @@ public abstract class AbstractJDBCSchemaFetcher implements IDependOnDatabaseType
     /**
      * Replace one small quotation mark inside the comment with two small quotation marks
      *
-     * @param comment the comment to be processed
+     * @param comment to be processed
      * @return processed comment or null if input is null
      */
     protected String commentEditor(String comment) {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
@@ -1288,6 +1288,10 @@ public abstract class AbstractJDBCSchemaFetcher implements IDependOnDatabaseType
     }
 
     protected String commentEditor(String comment) {
+    	if (comment == null) {
+    		return comment;
+    	}
+    	
         String editedComment;
 
         editedComment = comment.replaceAll("[\\']", "\\'\\'");

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -644,6 +644,9 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
 
                 String columnComment = rs.getString("attr_comment");
 
+                comment = commentEditor(comment);
+                columnComment = commentEditor(columnComment);
+
                 if (tableName == null) {
                     continue;
                 }
@@ -655,7 +658,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 if (table == null) {
                     table = factory.createTable();
                     table.setName(tableName);
-                    table.setComment(commentEditor(comment));
+                    table.setComment(comment);
                     table.setOwner(owner);
                     table.setReuseOID(isYes(rs.getString("is_reuse_oid_class")));
                     schema.addTable(table);
@@ -682,7 +685,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 }
                 column.setPrecision(prec);
                 column.setScale(scale);
-                column.setComment(commentEditor(columnComment));
+                column.setComment(columnComment);
 
                 String isNull = rs.getString("is_nullable");
                 column.setNullable(isYes(isNull));
@@ -1309,7 +1312,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 int cachedNum = rs.getInt("cached_num");
                 if (dbVersion >= COMMENT_SUPPORT_VERSION) {
                     comment = rs.getString("comment");
-                    comment = comment != null ? commentEditor(comment) : null;
+                    comment = commentEditor(comment);
                 }
 
                 String owner = null;
@@ -1519,7 +1522,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 String comment = null;
                 if (dbVersion >= COMMENT_SUPPORT_VERSION) {
                     comment = rs.getString("comment");
-                    comment = comment != null ? commentEditor(comment) : null;
+                    comment = commentEditor(comment);
                 }
 
                 Column column = factory.createColumn();
@@ -1798,7 +1801,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                         String comment = null;
                         if (dbVersion >= COMMENT_SUPPORT_VERSION) {
                             comment = rs.getString("comment");
-                            comment = comment != null ? commentEditor(comment) : null;
+                            comment = commentEditor(comment);
                         }
 
                         view.setQuerySpec(querySpec);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -655,7 +655,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 if (table == null) {
                     table = factory.createTable();
                     table.setName(tableName);
-                    table.setComment(comment);
+                    table.setComment(commentEditor(comment));
                     table.setOwner(owner);
                     table.setReuseOID(isYes(rs.getString("is_reuse_oid_class")));
                     schema.addTable(table);
@@ -682,7 +682,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 }
                 column.setPrecision(prec);
                 column.setScale(scale);
-                column.setComment(columnComment);
+                column.setComment(commentEditor(columnComment));
 
                 String isNull = rs.getString("is_nullable");
                 column.setNullable(isYes(isNull));

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -322,7 +322,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 String comment = null;
                 if (dbVersion >= COMMENT_SUPPORT_VERSION) {
                     comment = rs.getString("comment");
-                    comment = comment != null ? commentEditor(comment) : null;
+                    comment = commentEditor(comment);
                 }
 
                 String indexFindKey = tableName + "-" + indexName;
@@ -471,7 +471,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 String tableComment = null;
                 if (dbVersion >= COMMENT_SUPPORT_VERSION) {
                     tableComment = rs.getString("table_comment");
-                    tableComment = tableComment != null ? commentEditor(tableComment) : null;
+                    tableComment = commentEditor(tableComment);
                 }
 
                 if (tableComment != null) {
@@ -502,7 +502,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 String columnComment = null;
                 if (dbVersion >= COMMENT_SUPPORT_VERSION) {
                     columnComment = rs.getString("column_comment");
-                    columnComment = columnComment != null ? commentEditor(columnComment) : null;
+                    columnComment = commentEditor(columnComment);
                 }
 
                 Column column = factory.createColumn();

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mariadb/meta/MariaDBSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mariadb/meta/MariaDBSchemaFetcher.java
@@ -514,7 +514,7 @@ public final class MariaDBSchemaFetcher extends AbstractJDBCSchemaFetcher {
 
                     if (column != null) {
                         if (charset != null) column.setCharset(charset);
-                        if (comment != null) column.setComment(comment);
+                        if (comment != null) column.setComment(commentEditor(comment));
                     }
                 }
             } finally {
@@ -1028,7 +1028,7 @@ public final class MariaDBSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 }
             }
 
-            return comment;
+            return commentEditor(comment);
         }
     }
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mssql/meta/MSSQLSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mssql/meta/MSSQLSchemaFetcher.java
@@ -554,7 +554,7 @@ public final class MSSQLSchemaFetcher extends AbstractJDBCSchemaFetcher {
 
                 // Set column comment from the pre-fetched map
                 String comment = columnComments.get(column.getName());
-                column.setComment(comment);
+                column.setComment(commentEditor(comment));
 
                 table.addColumn(column);
             }
@@ -606,7 +606,7 @@ public final class MSSQLSchemaFetcher extends AbstractJDBCSchemaFetcher {
 
             // Set column comment from the pre-fetched map
             String comment = columnComments.get(column.getName());
-            column.setComment(comment);
+            column.setComment(commentEditor(comment));
         }
     }
 
@@ -1040,7 +1040,7 @@ public final class MSSQLSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 comment = rs.getString(1);
             }
 
-            return comment;
+            return commentEditor(comment);
         } finally {
             Closer.close(rs);
             Closer.close(stmt);
@@ -1120,7 +1120,7 @@ public final class MSSQLSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 comment = rs.getString(1);
             }
 
-            return comment;
+            return commentEditor(comment);
         } finally {
             Closer.close(rs);
             Closer.close(stmt);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mysql/meta/MySQLSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/mysql/meta/MySQLSchemaFetcher.java
@@ -493,7 +493,7 @@ public final class MySQLSchemaFetcher extends AbstractJDBCSchemaFetcher {
 
                     if (column != null) {
                         if (charset != null) column.setCharset(charset);
-                        if (comment != null) column.setComment(comment);
+                        if (comment != null) column.setComment(commentEditor(comment));
                     }
                 }
             } finally {
@@ -1007,7 +1007,7 @@ public final class MySQLSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 }
             }
 
-            return comment;
+            return commentEditor(comment);
         }
     }
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -604,7 +604,7 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
 
                     String shownDataType = dtHelper.getShownDataType(column);
                     column.setShownDataType(shownDataType);
-                    column.setComment(rs.getString("COMMENTS"));
+                    column.setComment(commentEditor(rs.getString("COMMENTS")));
 
                     table.addColumn(column);
                 } catch (Exception ex) {
@@ -1245,10 +1245,6 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 comment = rs.getString("COMMENTS");
             }
 
-            if (comment != null) {
-                comment = commentEditor(comment);
-            }
-
             return comment;
         } catch (Exception e) {
             e.printStackTrace();
@@ -1272,10 +1268,6 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
             String comment = "";
             while (rs.next()) {
                 comment = rs.getString("COMMENTS");
-            }
-
-            if (comment != null) {
-                comment = commentEditor(comment);
             }
 
             return comment;

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -604,7 +604,8 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
 
                     String shownDataType = dtHelper.getShownDataType(column);
                     column.setShownDataType(shownDataType);
-                    column.setComment(commentEditor(rs.getString("COMMENTS")));
+                    String comment = rs.getString("COMMENTS");
+                    column.setComment(commentEditor(comment));
 
                     table.addColumn(column);
                 } catch (Exception ex) {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -242,11 +242,6 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
             }
             for (Table table : tableList) {
                 String comment = getTableComment(conn, schema.getName(), table.getName());
-
-                if (comment != null) {
-                    comment = commentEditor(comment);
-                }
-
                 table.setComment(comment);
             }
             // get views
@@ -261,11 +256,6 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 view.setQuerySpec(getQueryText(conn, schema.getName(), view.getName(), view));
 
                 String comment = getViewComment(conn, schema.getName(), view.getName());
-
-                if (comment != null) {
-                    comment = commentEditor(comment);
-                }
-
                 view.setComment(comment);
             }
             buildPartitions(conn, catalog, schema);
@@ -1228,8 +1218,9 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
      * get TABLE comment
      *
      * @param conn Connection
+     * @param schemaName String
      * @param objectName String
-     * @return comment
+     * @return processed comment
      */
     protected String getTableComment(Connection conn, String schemaName, String objectName) {
         PreparedStatement pstmt = null;
@@ -1246,7 +1237,7 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 comment = rs.getString("COMMENTS");
             }
 
-            return comment;
+            return commentEditor(comment);
         } catch (Exception e) {
             e.printStackTrace();
             return null;
@@ -1271,7 +1262,7 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
                 comment = rs.getString("COMMENTS");
             }
 
-            return comment;
+            return commentEditor(comment);
         } catch (Exception e) {
             e.printStackTrace();
             return null;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4744>

### Purpose
- source DB에서 추출한 comment에 작은 따옴표(')가 존재할 경우 제대로 이관되지 않는 문제를 수정합니다

### Implementation
- 모든 source DB의 table, view, table column, view column의 작은 따옴표를 포함한 comment를 이관할 때 작은 따옴표 2개('')를 적용합니다

### Remarks
- commentEditor에 null check를 추가해서 기존에 commentEditor를 호출하기 전에 null check를 하던 코드를 수정합니다 (ex. cubrid의 sequence)
