### PR TITLE
[TOOLS-4712] Schema name not updated in Procedure/Function DDL at Step 5

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -1034,7 +1034,10 @@ public class MigrationConfiguration {
                             getTargetPlcsqlProcedureSchema(sc.getTargetOwner(), sc.getTarget());
                 }
 
-                if (tprocedure == null) {
+                if (tprocedure == null
+                        || !sourceDBSchema
+                                .getTargetSchemaName()
+                                .equals(tprocedure.getTargetOwner())) {
                     tprocedure = new PlcsqlProcedure();
                     tprocedure.setOwner(sc.getOwner());
                     tprocedure.setTargetOwner(sc.getTargetOwner());
@@ -1106,7 +1109,10 @@ public class MigrationConfiguration {
                     tfunction = getTargetPlcsqlFunctionSchema(sc.getTargetOwner(), sc.getTarget());
                 }
 
-                if (tfunction == null) {
+                if (tfunction == null
+                        || !sourceDBSchema
+                                .getTargetSchemaName()
+                                .equals(tfunction.getTargetOwner())) {
                     tfunction = new PlcsqlFunction();
                     tfunction.setOwner(sc.getOwner());
                     tfunction.setTargetOwner(sc.getTargetOwner());


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4712>

### Purpose
마이그레이션 마법사 Step 4에서 변경한 스키마명이 Step5 Procedure/Function에 적용되지 않는 문제를 해결합니다. 해당 케이스는 다음과 같은 특수한 상황에서 발생합니다.
1. Step5에서 **Back** 버튼을 클릭하여 Step4로 이동
2. Target Schema명을 변경 (예: `CUBRID` → `CUBRID_EDIT`) 
3. **Next** 버튼을 눌러 다시 Step5로 이동
4. Step5에서 **Back** 버튼을 클릭하여 다시 Step4로 이
5. Target Schema명을 원래대로 복원 (예: `CUBRID_EDIT` → `CUBRID`)
6. **Next** 버튼을 눌러 다시 Step5로 이동

### Implementation
- Procedure/Function DDL을 만들 때 사용하는 오브젝트도 변경되 스키마명이 적용될 수 있도록 조건 수정

### Remarks
N/A
