### PR TITLE
[TOOLS-4609] Display "-" in TargetSchema column on page 5 of Migration Wizard

### DIFF
--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/GeneralObjMappingView.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/GeneralObjMappingView.java
@@ -265,7 +265,7 @@ public class GeneralObjMappingView extends AbstractMappingView {
                             data.add(
                                     new Object[] {
                                         setc.getName(),
-                                        setc.getTargetOwner(),
+                                        Objects.requireNonNullElse(setc.getTargetOwner(), "-"),
                                         setc.getTarget(),
                                         setc.isMigrateData(),
                                         setc.getCondition(),


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4609>

### Purpose
마이그레이션 대상 DB의 버전이 11.0 이하인 경우 멀티 스키마를 지원하지 않습니다.
이에 따라 마이그레이션 마법사 5페이지의 `TargetSchema` 컬럼이 빈칸으로 표시되지 않고 `-`로 출력되도록 수정합니다.
이를 통해 사용자가 해당 칸에 값이 없음을 명확히 인식할 수 있도록 합니다.

<img width="583" height="171" alt="스크린샷 2025-09-11 오전 9 42 33" src="https://github.com/user-attachments/assets/63da66da-ce90-412c-b725-0c8b67cdc258" />

### Implementation
N/A

### Remarks
N/A
