### PR TITLE
[TOOLS-4610] Refine console migration result output and add exit code

### DIFF
--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/CmdMigrationMonitor.java
@@ -101,7 +101,7 @@ public class CmdMigrationMonitor implements IMigrationMonitor, Runnable {
 
         if (event instanceof MigrationFinishedEvent) {
             finalEvent = (MigrationFinishedEvent) event;
-            displayManager.printFinalProgress(progressTracker, hasError.get(), finalEvent);
+            displayManager.printProgressIfChanged(progressTracker);
             requestStop();
             return;
         }

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/ProgressDisplayManager.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/ProgressDisplayManager.java
@@ -30,7 +30,6 @@
 package com.cubrid.cubridmigration.command;
 
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
-import com.cubrid.cubridmigration.core.engine.event.MigrationFinishedEvent;
 import java.io.PrintStream;
 import java.util.Set;
 
@@ -124,22 +123,5 @@ public class ProgressDisplayManager {
         }
 
         return outputCount;
-    }
-
-    public void printFinalProgress(
-            MigrationProgressTracker progressTracker,
-            boolean hasError,
-            MigrationFinishedEvent finalEvent) {
-        printProgressIfChanged(progressTracker);
-
-        synchronized (printLock) {
-            if (hasError) {
-                outPrinter.println("Some errors occurred during migration.");
-                outPrinter.println("Please see the report for more.");
-            }
-            if (finalEvent != null) {
-                outPrinter.println(finalEvent.toString());
-            }
-        }
     }
 }

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
@@ -468,17 +468,6 @@ public class StartCommandHandler implements ConsoleCommandHandler {
         }
     }
 
-    /** Print final result banner, quick failure summary and report location. */
-    private void printFinalResultBanner(
-            MigrationReport mr, ConsoleMigrationReporter migrationReporter) {
-        boolean hasError = mr.hasError();
-        outPrinter.println();
-        outPrinter.println(
-                hasError
-                        ? "==================== RESULT: FAILED ====================="
-                        : "==================== RESULT: SUCCESS ====================");
-    }
-
     /**
      * Print report information onto screen after migration.
      *
@@ -487,8 +476,8 @@ public class StartCommandHandler implements ConsoleCommandHandler {
     private void printReport(ConsoleMigrationReporter migrationReporter) {
         MigrationReport mr = migrationReporter.getReport();
 
-        printFinalResultBanner(mr, migrationReporter);
-
+        outPrinter.println();
+        outPrinter.println("-------------------------------------------------------------");
         outPrinter.println("Migration Report summary:");
         outPrinter.print("    Time used: ");
         outPrinter.print(TimeZoneUtils.format(mr.getTotalEndTime() - mr.getTotalStartTime()));
@@ -521,7 +510,8 @@ public class StartCommandHandler implements ConsoleCommandHandler {
                 outPrinter.println();
             }
         }
-        outPrinter.println("--------------------------------------------------------");
+        outPrinter.println("-------------------------------------------------------------");
+        outPrinter.println();
         // Write report to a local text file
         String txtFile =
                 PathUtils.getReportDir()

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
@@ -602,6 +602,11 @@ public class StartCommandHandler implements ConsoleCommandHandler {
         } catch (IOException ex) {
             LOG.error("", ex);
         }
+
+        String finalResult = mr.hasError() ? "FAILED" : "SUCCESS";
+        outPrinter.println("=============================================================");
+        outPrinter.println("MIGRATION RESULT: " + finalResult);
+        outPrinter.println("=============================================================");
     }
 
     /**

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
@@ -443,6 +443,14 @@ public class StartCommandHandler implements ConsoleCommandHandler {
 
         // print rename object report
         printRenameObjReport(migrationReporter);
+
+        // exit code
+        try {
+            MigrationReport mr = migrationReporter.getReport();
+            System.exit(mr != null && mr.hasError() ? 1 : 0);
+        } catch (Throwable t) {
+            System.exit(1);
+        }
     }
 
     /** Load db.conf configuration at the start up. */
@@ -460,6 +468,17 @@ public class StartCommandHandler implements ConsoleCommandHandler {
         }
     }
 
+    /** Print final result banner, quick failure summary and report location. */
+    private void printFinalResultBanner(
+            MigrationReport mr, ConsoleMigrationReporter migrationReporter) {
+        boolean hasError = mr.hasError();
+        outPrinter.println();
+        outPrinter.println(
+                hasError
+                        ? "==================== RESULT: FAILED ====================="
+                        : "==================== RESULT: SUCCESS ====================");
+    }
+
     /**
      * Print report information onto screen after migration.
      *
@@ -467,6 +486,9 @@ public class StartCommandHandler implements ConsoleCommandHandler {
      */
     private void printReport(ConsoleMigrationReporter migrationReporter) {
         MigrationReport mr = migrationReporter.getReport();
+
+        printFinalResultBanner(mr, migrationReporter);
+
         outPrinter.println("Migration Report summary:");
         outPrinter.print("    Time used: ");
         outPrinter.print(TimeZoneUtils.format(mr.getTotalEndTime() - mr.getTotalStartTime()));
@@ -499,6 +521,7 @@ public class StartCommandHandler implements ConsoleCommandHandler {
                 outPrinter.println();
             }
         }
+        outPrinter.println("--------------------------------------------------------");
         // Write report to a local text file
         String txtFile =
                 PathUtils.getReportDir()


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4610>

### Purpose
Console 마이그레이션 결과를 사용자가 더 직관적으로 알 수 있도록 출력 포맷을 수정합니다.

**실패**

```
Thank you for using CUBRID Migration Toolkit(CMT) Console.
Reading </home/cubrid/CUBRID_fail.xml>
Reading source database schema ...
Migration started at 2025-09-12 12:52:06

-------------------------------------------------------------
Migration Report summary:
    Time used: 00 00:00:24.508
    schema: Exported[0]; Imported[0]
    table: Exported[8]; Imported[0]
    view: Exported[0]; Imported[0]
    primary key: Exported[8]; Imported[0]
    foreign key: Exported[0]; Imported[0]
    index: Exported[0]; Imported[0]
    sequence: Exported[2]; Imported[0]
    synonym: Exported[0]; Imported[0]
    trigger: Exported[0]; Imported[0]
    plcsql_function: Exported[0]; Imported[0]
    plcsql_procedure: Exported[0]; Imported[0]
    grant: Exported[0]; Imported[0]
    record: Exported[9633]; Imported[0]
-------------------------------------------------------------

=============================================================
MIGRATION RESULT: FAILED
=============================================================
``` 

**성공**
```
Thank you for using CUBRID Migration Toolkit(CMT) Console.
Reading </home/cubrid/CUBRID_success.xml>
Reading source database schema ...
Migration started at 2025-09-12 12:53:39
Record Migration Progress: 100% [9633 / 9633 records]

-------------------------------------------------------------
Migration Report summary:
    Time used: 00 00:00:01.641
    schema: Exported[0]; Imported[0]
    table: Exported[8]; Imported[8]
    view: Exported[0]; Imported[0]
    primary key: Exported[8]; Imported[8]
    foreign key: Exported[0]; Imported[0]
    index: Exported[0]; Imported[0]
    sequence: Exported[2]; Imported[2]
    synonym: Exported[0]; Imported[0]
    trigger: Exported[0]; Imported[0]
    plcsql_function: Exported[0]; Imported[0]
    plcsql_procedure: Exported[0]; Imported[0]
    grant: Exported[0]; Imported[0]
    record: Exported[9633]; Imported[9633]
-------------------------------------------------------------

=============================================================
MIGRATION RESULT: SUCCESS
=============================================================
```

### Implementation
- `ProgressDisplayManager`는 마이그레이션 결과 출력을 제거하여 테이블 진행률 출력에 대한 역할과 책임만 가지도록 수정
- `StartCommandHandler`가 최종 결과 강조 배너 출력을 하는 것으로 수정
- 추후 자동화 스크립트나 쉘에서 쉽게 판별할 수 있도록 프로세스 종료 코드 추가

### Remarks
N/A
