### PR TITLE
[TOOLS-4759] Change Database Type to Multiple Schemas im migration wizard step 6

### DIFF
--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages.java
@@ -241,6 +241,7 @@ public class Messages extends NLS {
     public static String confirmMessage;
     public static String confirmMigrationPageDescription;
     public static String confirmMigrationPageTile;
+    public static String confirmMultipleSchemas;
     public static String confirmPath;
     public static String confirmPort;
     public static String confirmSettingsSourceDatabase;

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages.properties
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages.properties
@@ -200,6 +200,7 @@ confirmHostIP=Host IP \:
 confirmMessage=Do you want to continue?
 confirmMigrationPageDescription=Confirm Migration Settings
 confirmMigrationPageTile=Confirm Migration Settings
+confirmMultipleSchemas=Multiple Schemas \:
 confirmPath=Path \:
 confirmPort=Port \:
 confirmSettingsSourceDatabase=Source Database \:

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages_ko_KR.properties
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/message/Messages_ko_KR.properties
@@ -199,6 +199,7 @@ confirmHostIP=\uD638\uC2A4\uD2B8 \uC8FC\uC18C \:
 confirmMessage=\uACC4\uC18D\uD558\uC2DC\uACA0\uC2B5\uB2C8\uAE4C?
 confirmMigrationPageDescription=\uB9C8\uC774\uADF8\uB808\uC774\uC158 \uC124\uC815\uC744 \uD655\uC778\uD574 \uC8FC\uC2ED\uC2DC\uC624.
 confirmMigrationPageTile=\uB9C8\uC774\uADF8\uB808\uC774\uC158 \uD655\uC778
+confirmMultipleSchemas=\uBA40\uD2F0 \uC2A4\uD0A4\uB9C8 \:
 confirmPath=\uACBD\uB85C \:
 confirmPort=\uD3EC\uD2B8 \:
 confirmSettingsSourceDatabase=\uC6D0\uBCF8 \uB370\uC774\uD130\uBCA0\uC774\uC2A4 \:

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/ConfirmationPage.java
@@ -218,12 +218,9 @@ public class ConfirmationPage extends BaseConfirmationPage {
             text.append(migration.getTargetDataFileFormatLabel());
             text.append(")").append(lineSeparator).append(tabSeparator);
 
-            text.append(Messages.confirmDatabaseType)
+            text.append(Messages.confirmMultipleSchemas)
                     .append("  ")
-                    .append(
-                            migration.isAddUserSchema()
-                                    ? Messages.confirmCubrid112Higher
-                                    : Messages.confirmCubrid110Lower)
+                    .append(migration.isAddUserSchema() ? "Yes" : "No")
                     .append(lineSeparator)
                     .append(tabSeparator);
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4759>

### Purpose
오프라인 마이그레이션 시 마이그레이션 마법사 6페이지에 표시되는 `Database Type` 문구를 다음과 같이 수정합니다.
- Multiple Schemas: Yes / No
- 멀티 스키마: Yes / No

### Implementation
N/A

### Remarks
N/A
