### PR TITLE
[TOOLS-4761] Avoid duplicate %class header in local dump file

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -40,6 +40,7 @@ import com.cubrid.cubridmigration.core.engine.MigrationDirAndFilesManager;
 import com.cubrid.cubridmigration.core.engine.MigrationStatusManager;
 import com.cubrid.cubridmigration.core.engine.config.SourceTableConfig;
 import com.cubrid.cubridmigration.core.engine.event.ImportRecordsEvent;
+import com.cubrid.cubridmigration.core.engine.exception.BreakMigrationException;
 import com.cubrid.cubridmigration.core.engine.exception.NormalMigrationException;
 import com.cubrid.cubridmigration.core.engine.task.FileMergeRunnable;
 import com.cubrid.cubridmigration.core.engine.task.RunnableResultHandler;
@@ -163,6 +164,26 @@ public class LoadFileImporter extends OfflineImporter {
                         isSchemaFile || !config.targetIsXLS()));
     }
 
+    /** Ensure header exists at the top of a target data file. */
+    private void ensureHeaderPresent(String fileFullName, SourceTableConfig stc) {
+        if (config.targetIsCSV() || config.targetIsXLS() || config.targetIsSQL()) {
+            return;
+        }
+        File target = new File(fileFullName);
+        try {
+            if (!target.exists()) {
+                PathUtils.createFile(target);
+            } else if (target.length() > 0L) {
+                return;
+            }
+            String header = getDataFileHeader(stc);
+            CUBRIDIOUtils.writeLines(
+                    target, new String[] {header}, config.getTargetCharSet(), false);
+        } catch (IOException ex) {
+            throw new BreakMigrationException(ex);
+        }
+    }
+
     /**
      * Send schema file and data file to server for loadDB command.
      *
@@ -202,6 +223,7 @@ public class LoadFileImporter extends OfflineImporter {
             }
             final String fileTableFullName = es.fileTableFullName;
             final String fileFullName = es.fileFullName;
+            ensureHeaderPresent(fileTableFullName, stc);
             mdfm.addDataFile(fileTableFullName, impCount);
             executeTask(
                     fileName,
@@ -212,18 +234,14 @@ public class LoadFileImporter extends OfflineImporter {
                             eventHandler.handleEvent(new ImportRecordsEvent(stc, impCount));
                             final MigrationStatusManager sm = mrManager.getStatusMgr();
                             sm.addImpCount(stc.getOwner(), stc.getName(), expCount);
-                            // CSV, XLS file will not be merged into one data file.
-                            if (config.targetIsCSV() || config.targetIsXLS()) {
-                                return;
-                            }
-                            if (config.isOneTableOneFile()) {
-                                return;
-                            }
                             final Table st =
                                     config.getSrcTableSchema(stc.getOwner(), stc.getName());
-                            if (null == st) {
-                                return;
-                            }
+                            boolean skipMerge =
+                                    (config.targetIsCSV()
+                                            || config.targetIsXLS()
+                                            || config.isOneTableOneFile()
+                                            || st == null);
+                            if (skipMerge) return;
                             final long totalEc = sm.getExpCount(stc.getOwner(), stc.getName());
                             final long totalIc = sm.getImpCount(stc.getOwner(), stc.getName());
                             final boolean expEnd = sm.getExpFlag(stc.getOwner(), stc.getName());

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -234,14 +234,16 @@ public class LoadFileImporter extends OfflineImporter {
                             eventHandler.handleEvent(new ImportRecordsEvent(stc, impCount));
                             final MigrationStatusManager sm = mrManager.getStatusMgr();
                             sm.addImpCount(stc.getOwner(), stc.getName(), expCount);
+                            if (config.targetIsCSV()
+                                    || config.targetIsXLS()
+                                    || config.isOneTableOneFile()) {
+                                return;
+                            }
                             final Table st =
                                     config.getSrcTableSchema(stc.getOwner(), stc.getName());
-                            boolean skipMerge =
-                                    (config.targetIsCSV()
-                                            || config.targetIsXLS()
-                                            || config.isOneTableOneFile()
-                                            || st == null);
-                            if (skipMerge) return;
+                            if (null == st) {
+                                return;
+                            }
                             final long totalEc = sm.getExpCount(stc.getOwner(), stc.getName());
                             final long totalIc = sm.getImpCount(stc.getOwner(), stc.getName());
                             final boolean expEnd = sm.getExpFlag(stc.getOwner(), stc.getName());

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -160,11 +160,6 @@ public abstract class OfflineImporter extends Importer {
                             new PrintWriter(file, config.getTargetCharSet()),
                             CUBRIDIOUtils.DEFAULT_MEMORY_CACHE_SIZE);
             try {
-                String header = getDataFileHeader(stc);
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("[VAR]header=" + header);
-                }
-                pw.write(header);
                 // The template LOB files path in local.
                 List<String> lobFiles = new ArrayList<String>();
                 int total = 0;
@@ -571,7 +566,7 @@ public abstract class OfflineImporter extends Importer {
             sb.append(spliter).append("[").append(col.getTarget()).append("]");
             spliter = " ";
         }
-        sb.append(")\n");
+        sb.append(")");
         return sb.toString();
     }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4761>

### Purpose
Local CUBRID dump 마이그레이션 시, 데이터 파일에 `%class` 헤더가 여러 번 출력되는 문제를 해결합니다.

### Implementation
**이전 동작**
- 임시 파일(temp) 생성 시 `%class` 헤더와 데이터를 함께 기록
- 테이블 파일 병합 시, 임시 파일들의 헤더가 반복적으로 포함되어 최종 파일에 `%class` 헤더가 여러 번 출력

**변경 후 동작**
- 임시 파일(temp)에는 데이터만 기록
- 테이블 파일 병합 시, 최초 한 번만 `%class` 헤더를 기록
- 이후 병합 과정에서는 데이터만 이어붙임

**추가 리팩토링**
- 중복된 조건문(CSV, XLS, OneTableOneFile, null check)을 하나의 skipMerge 플래그로통합하여 코드 가독성 개선

### Remarks
N/A
