### PR TITLE
[TOOLS-4764] Support JSON data type in CUBRID to CUBRID migration

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/Data2StrTranslator.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/Data2StrTranslator.java
@@ -152,6 +152,9 @@ public class Data2StrTranslator implements IData2StrTranslator {
                     DataTypeConstant.CUBRID_DT_DATETIME,
                     new CSVCharToCUBRIDString(new DatetimeToCUBRIDString(config), config));
             formaters.put(DataTypeConstant.CUBRID_DT_NUMERIC, new NumericToCUBRIDString());
+            formaters.put(
+                    DataTypeConstant.CUBRID_DT_JSON,
+                    new CSVCharToCUBRIDString(new CharToCUBRIDString(), config));
         } else {
             formaters.put(
                     DataTypeConstant.CUBRID_DT_BIT,
@@ -189,6 +192,9 @@ public class Data2StrTranslator implements IData2StrTranslator {
             formaters.put(
                     DataTypeConstant.CUBRID_DT_NUMERIC,
                     new UnloadNumericToCUBRIDString(new NumericToCUBRIDString()));
+            formaters.put(
+                    DataTypeConstant.CUBRID_DT_JSON,
+                    new UnloadCharToCUBRIDString(new CharToCUBRIDString()));
         }
     }
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/trans/CUBRID2CUBRID.xml
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/trans/CUBRID2CUBRID.xml
@@ -385,5 +385,17 @@
 			<scale></scale>
 		</TargetDataType>
 	</DataTypeMapping>
-	
+
+	<DataTypeMapping>
+	    <SourceDataType>
+	        <type>json</type>
+	        <precision></precision>
+	        <scale></scale>
+	    </SourceDataType>
+	    <TargetDataType>
+	        <type>json</type>
+	        <precision></precision>
+	        <scale></scale>
+	    </TargetDataType>
+	</DataTypeMapping>
 </CUBRID2CUBRID>


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4764>

### Purpose
CUBRID to CUBRID 마이그레이션 시 JSON 데이터 타입을 지원하도록 기능을 확장합니다.

### Implementation

- CUBRID 데이터 타입 매핑 XML에 JSON 타입 매핑 규칙 추가
- Data2StrTranslator에 JSON 매핑 추가

### Remarks
N/A
