### PR TITLE
[TOOLS-4751] Improve Record Count Display: '0' for Empty, '-' for Skipped

### DIFF
--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/ConsoleUtils.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/ConsoleUtils.java
@@ -46,6 +46,8 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class ConsoleUtils {
 
+    public static final String EMPTY_CELL_VALUE = "-";
+
     /**
      * Reading console input
      *

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ReportCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ReportCommandHandler.java
@@ -136,9 +136,15 @@ public class ReportCommandHandler extends HistoryCommandHandler {
         pageCount = 1;
         for (RecordMigrationResult rmr : recMigResults) {
             outPrinter.println("    [" + rmr.getSource() + "] >> [" + rmr.getTarget() + "]");
-            outPrinter.println("           Total:[" + rmr.getTotalCount() + "]");
-            outPrinter.println("        Exported:[" + rmr.getExpCount() + "]");
-            outPrinter.println("        Imported:[" + rmr.getImpCount() + "]");
+            if (!rmr.isDataMigrationSelected()) {
+                outPrinter.println("           Total:[" + ConsoleUtils.EMPTY_CELL_VALUE + "]");
+                outPrinter.println("        Exported:[" + ConsoleUtils.EMPTY_CELL_VALUE + "]");
+                outPrinter.println("        Imported:[" + ConsoleUtils.EMPTY_CELL_VALUE + "]");
+            } else {
+                outPrinter.println("           Total:[" + rmr.getTotalCount() + "]");
+                outPrinter.println("        Exported:[" + rmr.getExpCount() + "]");
+                outPrinter.println("        Imported:[" + rmr.getImpCount() + "]");
+            }
             if (pageCount >= pageSize) {
                 pageCount = 1;
                 if (!waitForEnter(atOnceMode)) {

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
@@ -566,11 +566,21 @@ public class StartCommandHandler implements ConsoleCommandHandler {
                     bw.append(rmr.getTarget());
                     bw.append("]");
                     bw.append(":");
-                    bw.append(" Exported:[");
-                    bw.append(Long.toString(rmr.getExpCount()));
-                    bw.append("] Imported:[");
-                    bw.append(Long.toString(rmr.getImpCount()));
-                    bw.append("]\r\n");
+                    if (!rmr.isDataMigrationSelected()) {
+                        bw.append(
+                                " Exported:["
+                                        + ConsoleUtils.EMPTY_CELL_VALUE
+                                        + "] Imported:["
+                                        + ConsoleUtils.EMPTY_CELL_VALUE
+                                        + "]");
+                    } else {
+                        bw.append(" Exported:[");
+                        bw.append(Long.toString(rmr.getExpCount()));
+                        bw.append("] Imported:[");
+                        bw.append(Long.toString(rmr.getImpCount()));
+                        bw.append("]");
+                    }
+                    bw.append("\r\n");
                 }
                 bw.flush();
             } finally {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/MigrationReport.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/MigrationReport.java
@@ -593,6 +593,7 @@ public class MigrationReport implements Serializable {
             result.setSrcSchema(stc.getOwner());
             result.setSource(stc.getName());
             result.setTarget(stc.getTarget());
+            result.setDataMigrationSelected(stc.isMigrateData());
             if (!restore) {
                 result.setTotalCount(0);
             } else if (stc.isMigrateData()) {
@@ -612,6 +613,7 @@ public class MigrationReport implements Serializable {
             RecordMigrationResult result = new RecordMigrationResult();
             result.setSource(sstc.getName());
             result.setTarget(sstc.getTarget());
+            result.setDataMigrationSelected(sstc.isMigrateData());
             if (!restore) {
                 result.setTotalCount(0);
             } else if (sstc.isMigrateData()) {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/RecordMigrationResult.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/RecordMigrationResult.java
@@ -54,6 +54,8 @@ public class RecordMigrationResult implements Serializable {
     private long expCount;
     private long impCount;
 
+    private boolean isDataMigrationSelected = false;
+
     public String getSource() {
         return source;
     }
@@ -137,5 +139,13 @@ public class RecordMigrationResult implements Serializable {
     /** @return true if the migration has error */
     public boolean isDataMigrationHasError() {
         return getTotalCount() != getExpCount() || getExpCount() != getImpCount();
+    }
+
+    public boolean isDataMigrationSelected() {
+        return isDataMigrationSelected;
+    }
+
+    public void setDataMigrationSelected(boolean isDataMigrationSelected) {
+        this.isDataMigrationSelected = isDataMigrationSelected;
     }
 }

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/history/tableviewer/RecordMigrationResultTableLabelProvider.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/history/tableviewer/RecordMigrationResultTableLabelProvider.java
@@ -72,19 +72,28 @@ public class RecordMigrationResultTableLabelProvider extends BaseTableLabelProvi
             case 0:
                 return rs.getSource();
             case 1:
+                if (!rs.isDataMigrationSelected()) {
+                    return MigrationReportEditorPart.EMPTY_CELL_VALUE;
+                }
                 return rs.getTotalCount() == 0
-                        ? MigrationReportEditorPart.EMPTY_CELL_VALUE
+                        ? "0"
                         : NumberFormat.getIntegerInstance().format(rs.getTotalCount());
             case 2:
+                if (!rs.isDataMigrationSelected()) {
+                    return MigrationReportEditorPart.EMPTY_CELL_VALUE;
+                }
                 return rs.getTotalCount() == 0
-                        ? MigrationReportEditorPart.EMPTY_CELL_VALUE
+                        ? "0"
                         : NumberFormat.getIntegerInstance().format(rs.getExpCount());
             case 3:
                 return getTimeUsed(
                         rs.getTotalCount(), rs.getStartExportTime(), rs.getEndExportTime());
             case 4:
+                if (!rs.isDataMigrationSelected()) {
+                    return MigrationReportEditorPart.EMPTY_CELL_VALUE;
+                }
                 return rs.getTotalCount() == 0
-                        ? MigrationReportEditorPart.EMPTY_CELL_VALUE
+                        ? "0"
                         : NumberFormat.getIntegerInstance().format(rs.getImpCount());
             case 5:
                 return getTimeUsed(

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/editor/controller/MigrationProgressUIController.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/editor/controller/MigrationProgressUIController.java
@@ -229,7 +229,7 @@ public class MigrationProgressUIController {
                             NA_STRING,
                             stc.getOwner()
                         };
-            } else if (tbl == null || tbl.getTableRowCount() == 0) {
+            } else if (tbl == null) {
                 tableItems[index] =
                         new String[] {
                             stc.getName(),
@@ -239,6 +239,19 @@ public class MigrationProgressUIController {
                             NA_STRING,
                             stc.getOwner()
                         };
+            } else if (!stc.isMigrateData()) {
+                tableItems[index] =
+                        new String[] {
+                            stc.getName(),
+                            NA_STRING,
+                            NA_STRING,
+                            NA_STRING,
+                            NA_STRING,
+                            stc.getOwner()
+                        };
+            } else if (tbl.getTableRowCount() == 0) {
+                tableItems[index] =
+                        new String[] {stc.getName(), "0", "0", "0", "100%", stc.getOwner()};
             } else {
                 tableItems[index] =
                         new String[] {


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4751

### Purpose
현재 마이그레이션 진행 화면과 보고서에서는, 데이터 이관을 선택하지 않은 테이블과 이관되었지만 레코드가 0건인 테이블이 모두 '-'로 표시되어 구분이 어렵습니다. 이에 따라 두 경우를 명확히 구분할 수 있도록, 화면과 보고서 모두에서 표시 방식을 수정합니다.

### Implementation
데이터 이관 여부 및 레코드 수에 따라 '0' 또는 '-'로 출력되도록 수정 

**변경 기준:**

- 이관 선택 안 된 테이블 → '-'
- 이관 선택되었으나 레코드가 0건인 테이블 → '0'

### Remarks
콘솔 버전에서도 동일한 표시 방식이 적용되도록 반영 완료
