### PR TITLE
[TOOLS-4765] Use MongoDB BSON library for Informix BSON to JSON migration

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/pom.xml
+++ b/plugins/com.cubrid.cubridmigration.core/pom.xml
@@ -97,6 +97,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>bson</artifactId>
+            <version>${bson.version}</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/export/handler/InformixBSONTypeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/informix/export/handler/InformixBSONTypeHandler.java
@@ -30,11 +30,15 @@
 
 package com.cubrid.cubridmigration.informix.export.handler;
 
+import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.dbobject.Column;
 import com.cubrid.cubridmigration.core.export.IExportDataHandler;
-import java.lang.reflect.Method;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import org.bson.RawBsonDocument;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.slf4j.Logger;
 
 /**
  * InformixBSONTypeHandler Description
@@ -45,34 +49,28 @@ import java.sql.SQLException;
  */
 public class InformixBSONTypeHandler implements IExportDataHandler {
 
+    private static final Logger LOG = LogUtil.getLogger(InformixBSONTypeHandler.class);
+    private static final JsonWriterSettings JSON_SETTINGS =
+            JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).build();
+
     /**
-     * Retrieves the value object of year column.
+     * Retrieves the value object of BSON column.
      *
      * @param rs the result set
      * @param column column description
-     * @return value of column
+     * @return JSON string representation of BSON column
      * @throws SQLException e
      */
     public Object getJdbcObject(ResultSet rs, Column column) throws SQLException {
-
+        final String colName = column.getName();
+        final byte[] bytes = rs.getBytes(colName);
+        if (bytes == null) return null;
         try {
-
-            try {
-                Class<?> c = Class.forName("com.informix.jdbc.IfxBSONObject");
-                byte[] b = rs.getBytes(column.getName());
-                Object o = c.newInstance();
-                Method method = o.getClass().getMethod("setBytes", byte[].class);
-                method.invoke(o, b);
-                Method method1 = o.getClass().getMethod("toJson");
-                String value = (String) method1.invoke(o);
-                return value;
-            } catch (Exception e) {
-                e.printStackTrace();
-                return "";
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            return "";
+            RawBsonDocument doc = new RawBsonDocument(bytes);
+            return doc.toJson(JSON_SETTINGS);
+        } catch (RuntimeException ex) {
+            LOG.warn("Failed to convert Informix BSON to JSON. column={}", colName, ex);
+            return null;
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <opencsv.version>5.11.1</opencsv.version>
         <antlr4.version>4.13.2</antlr4.version>
         <poi-ooxml.version>5.4.1</poi-ooxml.version>
+        <bson.version>5.6.0</bson.version>
 
         <eclipse-repo-url>https://download.eclipse.org/releases</eclipse-repo-url>
         <eclipse-p2-repo.url>${eclipse-repo-url}/${eclipse-version}/</eclipse-p2-repo.url>


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4765>

### Purpose
Informix의 BSON 데이터 타입을 CUBRID의 JSON 타입으로 마이그레이션 시 사용하는 라이브러리를 변경합니다.

### Implementation
**기존**
- Informix JDBC 내부 클래스(IfxBSONObject)를 리플렉션으로 호출하여 BSON을 JSON 문자열로 변환
- 이 방식은 CMT 라이브러리에 Informix JDBC 드라이버를 직접 포함해야 하는 제약이 생김

**변경**
 - MongoDB BSON 라이브러리를 사용하여 BSON을 표준 JSON 문자열로 변환
 - 예외 처리 로직 개선: 변환 실패 시 빈 문자열("")을 반환하던 기존 방식을 null 반환으로 수정
   - CUBRID의 JSON 컬럼에 빈 문자열("")을 허용하지 않음
   - Informix의 BSON 값이 null인 경우, CUBRID에도 동일하게 null로 반영될 수 있도록 처리 방식 수정

### Remarks
N/A
