### PR TITLE
[TOOLS-4766] Online Migration: Target Schema incorrectly shown as DB name in Step 4 of Migration Wizard

### DIFF
--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -630,7 +630,7 @@ public class SchemaMappingPage extends MigrationWizardPage {
                 }
 
                 if (tarSchemaName == null || tarSchemaName.isEmpty()) {
-                    srcTable.setTarSchema(tarCatalog.getName());
+                    srcTable.setTarSchema(srcTable.getSrcSchema());
                 }
 
                 logger.info("srcTable target schema : " + srcTable.getTarSchema());


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4766>

### Purpose
온라인 마이그레이션 수행 시 마이그레이션 마법사 4단계(Schema Mapping) 화면에서 Target Schema가 원래 기대와 다르게 DB 이름으로 표시되는 문제를 해결합니다.

### Implementation
대상 스키마에 값이 없으면 기본 값으로 DB 이름을 가져오는 부분을 원본 스키마 이름으로 초기화 할 수 있도록 수정합니다.

### Remarks
N/A
