### PR TITLE
[TOOLS-4767] Simplify TestSelectSQL generation to avoid invalid SQL

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
@@ -777,32 +777,7 @@ public class CUBRIDSQLHelper extends SQLHelper {
      * @return String
      */
     public String getTestSelectSQL(String sql) {
-        String cleanSql = sql.toUpperCase().trim();
-        String realSQL = sql;
-        Pattern groupbyPattern =
-                Pattern.compile("GROUP\\s+BY", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
-        Pattern orderbyPattern =
-                Pattern.compile("ORDER\\s+BY", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
-        realSQL = realSQL.replaceAll(LIMIT_PATTEN_1, "");
-        realSQL = realSQL.replaceAll(LIMIT_PATTEN_2, "");
-        Matcher groupbyMatcher = groupbyPattern.matcher(cleanSql);
-        Matcher orderbyMatcher = orderbyPattern.matcher(cleanSql);
-        StringBuilder buf = new StringBuilder(realSQL);
-        if (groupbyMatcher.find()) {
-            if (cleanSql.indexOf("HAVING") == -1) {
-                buf.append(" HAVING ");
-            } else {
-                buf.append(" AND ");
-            }
-            buf.append(" GROUPBY_NUM() = 1 ");
-        } else if (orderbyMatcher.find()) {
-            buf.append(" FOR ORDERBY_NUM() = 1 ");
-        } else if (cleanSql.indexOf("WHERE") != -1) {
-            buf.append(" AND ROWNUM = 1");
-        } else {
-            buf.append(" WHERE ROWNUM = 1");
-        }
-        return buf.toString();
+        return "SELECT * FROM ( " + sql + " ) WHERE 1<>1";
     }
 
     /**


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4767>

### Purpose
기존 TestSelectSQL 생성 로직은 사용자가 입력한 SQL을 복잡하게 파싱하고 수정하여, 문법 오류를 유발하는 문제가 있습니다.
TestSeletSQL의 본래 목적은 **(1) 사용자 입력 SQL의 문법 검사**와 **(2) 테이블 메타데이터 조회**에 있으므로, 결과 집합을 가져오거나 실제 데이터를 접근하는 것은 필요하지 않습니다.

이번 변경의 목적은 이러한 본래 목적을 유지하면서도 불필요한 SQL 변형을 제거하고, 에러 없이 안전하게 실행 가능한 SQL을 생성하도록 개선하는 것입니다.

### Implementation
- 기존에는 쿼리를 파싱하여 일부 조건이나 힌트를 삽입하는 방식을 사용하였으나, 이로 인해 SQL 문법 오류가 발생할 가능성이 있습니다. 또한 내부적으로 인덱스 스캔과 fetch가 실제 수행되어 불필요한 I/O가 발생합니다.
- 이를 개선하기 위해, 사용자가 입력한 SQL을 그래도 서브쿼리로 감싸고 최종적으로 `WHERE 1<>1`을 추가하여 결과를 비워주는 방식으로 변경합니다.
- 이 방식은 내부 쿼리를 문법 검사와 메타데이터 해석은 그래도 수행하면서도 결과 수집을 차단하여 실제 데이터 조회는 이뤄지지 않습니다.

### Remarks
N/A
