### PR TITLE
[TOOLS-4768] Fetch FK correctly in CUBRID migration with JDBC 11.3+

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -923,10 +923,15 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                         continue;
                     }
 
-                    String noSchemaFkTableName = fkTableName.split("\\.")[1];
-                    foreignKey.setReferencedTableName(noSchemaFkTableName);
-
-                    //					foreignKey.setReferencedTableName(fkTableName);
+                    String referencedTable = fkTableName;
+                    int dotIndex = fkTableName.indexOf('.');
+                    if (dotIndex >= 0) {
+                        String[] parts = fkTableName.split("\\.", 2);
+                        if (parts.length == 2) {
+                            referencedTable = parts[1];
+                        }
+                    }
+                    foreignKey.setReferencedTableName(referencedTable);
 
                     // foreignKey.setDeferability(rs.getInt("DEFERRABILITY"));
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -923,6 +923,7 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
                         continue;
                     }
 
+                    // CUBRID JDBC 11.2 returns "schema.table", 11.3 returns "table" only.
                     String referencedTable = fkTableName;
                     int dotIndex = fkTableName.indexOf('.');
                     if (dotIndex >= 0) {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4768>

### Purpose
CUBRID → CUBRID 마이그레이션 수행 시 JDBC 드라이버 버전이 11.3 이상인 경우, 원본 DB에서 FK 정보를 조회를 실패하여 FK 마이그레이션이 되지 않는 문제를 해결합니다.

### Implementation
- FK 참조 테이블명을 schema.table 여부에 따라 적절히 파싱하여 설정하도록 변경

### Remarks
N/A
