### PR TITLE
[TOOLS-4769] Skip pagination for user SQL to prevent migration failure

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/exporter/impl/JDBCExporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/exporter/impl/JDBCExporter.java
@@ -264,7 +264,8 @@ public class JDBCExporter extends MigrationExporter {
                     realPageCount =
                             Math.min(sTable.getTableRowCount() - totalExported, intPageCount);
                 }
-                String pagesql = expHelper.getPagedSelectSQL(sql, realPageCount, totalExported, pk);
+                String pagesql =
+                        expHelper.getPagedSelectSQL(stc, sql, realPageCount, totalExported, pk);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("[SQL]PAGINATED=" + pagesql);
                 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/export/DBExportHelper.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/export/DBExportHelper.java
@@ -445,6 +445,27 @@ public abstract class DBExportHelper implements IDependOnDatabaseType {
             String sql, long pageSize, long exportedRecords, PK pk);
 
     /**
+     * Retrieves the SQL with page condition. Overload that is aware of SourceTableConfig type.
+     *
+     * <p>Policy: If it is a user-provided SQL (SourceSQLTableConfig), pagination MUST NOT be
+     * applied and the original SQL should be returned as-is.
+     *
+     * @param stc SourceTableConfig
+     * @param sql original SQL
+     * @param pageSize record count per-page
+     * @param exportedRecords record count to be skipped.
+     * @param pk table's primary key
+     * @return SQL (paginated or original)
+     */
+    public String getPagedSelectSQL(
+            SourceTableConfig stc, String sql, long pageSize, long exportedRecords, PK pk) {
+        if (stc instanceof SourceSQLTableConfig) {
+            return sql;
+        }
+        return getPagedSelectSQL(sql, pageSize, exportedRecords, pk);
+    }
+
+    /**
      * Is support fast search with PK.
      *
      * @param conn Connection


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4769>

### Purpose
사용자가 마법사 5단계(SQL 탭)에서 직접 입력한 SQL에 CMT가 페이징 로직을 적용하면서 SQL 파싱 오류가 발생하고 마이그레이션이 실패하는 문제가 있습니다.
사용자 정의 SQL은 수정하지 않고 원문 그대로 실행하도록 하여 이 문제를 해결합니다.

### Implementation
- `DBExportHelper#getPagedSelectSQL()` 메서드를 오버로드하여 SourceSQLTableConfig(사용자 입력 SQL)인 경우 페이징을 적용하지 않고 원본 SQL을 반환하도록 수정
- JDBCExporter에서 페이징 SQL 생성 시 SourceTableConfig를 인자로 전달하도록 변경
- CMT가 생성한 SQL에 대해서는 기존 페이징 로직을 유지

### Remarks
N/A
