### PR TITLE
[TOOLS-4770] Change default script output directory to CMT installation path

### DIFF
--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/ExportScriptDialog.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/script/dialog/ExportScriptDialog.java
@@ -127,7 +127,7 @@ public class ExportScriptDialog extends TransFileBySSHDialog {
         btnEnableLocal.setText(Messages.btnExportScript2Local);
         btnEnableLocal.setSelection(prefers.getBoolean(EXPORT_LOCAL, true));
         String rf = getDefaultScriptFileName();
-        txtLocal.setText(PathUtils.getUserHomeDir() + rf);
+        txtLocal.setText(PathUtils.getInstallPath() + rf);
         btnBrowseLocal.addSelectionListener(
                 new SelectionAdapter() {
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4770>

### Purpose
스크립트 내보내기 기능 사용 시 기본 디렉터리 경로를 기존 User 홈 디렉터리에서 CMT 설치 경로로 변경합니다.

### Implementation
- ExportScriptDialog.java 내 txtLocal 초기값 설정 로직 수정

### Remarks
N/A
