### PR TITLE
[TOOLS-4773] Modified scheme name not applied to SQL migration

### DIFF
--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -617,8 +617,7 @@ public class SQLTableManageView extends AbstractMappingView {
             Catalog catalog = config.getTarCatalog().orElse(config.getSrcCatalog());
 
             if (catalog != null && catalog.getSchemas() != null) {
-                tarSchemaList =
-                        catalog.getSchemas().stream().map(Schema::getName).toArray(String[]::new);
+            	tarSchemaList = catalog.getSchemas().stream().map(Schema::getTargetSchemaName).toArray(String[]::new);
             }
         }
 

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -617,7 +617,10 @@ public class SQLTableManageView extends AbstractMappingView {
             Catalog catalog = config.getTarCatalog().orElse(config.getSrcCatalog());
 
             if (catalog != null && catalog.getSchemas() != null) {
-            	tarSchemaList = catalog.getSchemas().stream().map(Schema::getTargetSchemaName).toArray(String[]::new);
+                tarSchemaList =
+                        catalog.getSchemas().stream()
+                                .map(Schema::getTargetSchemaName)
+                                .toArray(String[]::new);
             }
         }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4773>

### Purpose
- target이 dump파일일 때 스키마 매핑 페이지에서  target schema 이름을 변경할 경우 SQL 이관의 target schema에 적용되지 않는 문제 수정

### Implementation
- schema의 name을 가져오는 것이 아니라 target schema name을 가져오도록 수정

### Remarks
N/A
