### PR TITLE
[TOOLS-4774] Fix Oracle FK ON DELETE rule to output NO ACTION instead of RESTRICT during migration

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/meta/OracleSchemaFetcher.java
@@ -700,7 +700,7 @@ public final class OracleSchemaFetcher extends AbstractJDBCSchemaFetcher {
                         } else if ("SET NULL".equalsIgnoreCase(deleteRule)) {
                             foreignKey.setDeleteRule(FK.ON_DELETE_SET_NULL);
                         } else {
-                            foreignKey.setDeleteRule(FK.ON_DELETE_RESTRICT);
+                            foreignKey.setDeleteRule(FK.ON_DELETE_NO_ACTION);
                         }
 
                         foreignKey.setReferencedTableName(rs.getString("PK_TABLE_NAME"));


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4774>

### Purpose
Oracle FK ON DELETE가 NO ACTION일 때 마이그레이션 결과에서 동일한 NO ACTION으로 출력되도록 수정합니다.

### Implementation
- ON DELETE 값이 NO ACTION, null, 빈 문자열인 경우 FK.ON_DELETE_NO_ACTION으로 매핑하도록 수정

### Remarks
N/A
