### PR TITLE
[TOOLS-4783] Simplify and clarify console help messages

### DIFF
--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help.txt
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help.txt
@@ -1,11 +1,10 @@
 
-Usage in windows: migration.bat <utility-name> [options]
-Usage in linux: migration.sh <utility-name> [options]
+Available <command> (Default is "start"):
+  start [options] [script_file]  Start a migration task.
+  script [options][output_dir]   Build a migration script.
+  log [options] [mh_file]        Review a migration work's log.
+  report [options] [mh_file]     Review a migration work's result.
 
-Available <utility-name> (Default is "start"):
-    start: Start a migration task.
-    log: Review a migration work's log.
-    report: Review a migration work's result.
-    script: Build a migration script with online source and default options.
-	
-Please visit http://www.cubrid.org for more information.
+For more information on a command, run:
+  migration.sh <command> --help (Linux)
+  migration.bat <command> --help (Windows)

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help.txt
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help.txt
@@ -1,9 +1,9 @@
 
 Available <command> (Default is "start"):
-  start [options] [script_file]  Start a migration task.
-  script [options][output_dir]   Build a migration script.
-  log [options] [mh_file]        Review a migration work's log.
-  report [options] [mh_file]     Review a migration work's result.
+    start [options] [script_file]   Start a migration task.
+    script [options] [output_dir]   Build a migration script.
+    log [options] [mh_file]         Review a migration work's log.
+    report [options] [mh_file]      Review a migration work's result.
 
 For more information on a command, run:
   migration.sh <command> --help (Linux)

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_log.txt
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_log.txt
@@ -2,7 +2,8 @@
 Usage in Windows: migration.bat log [options] [migration history file(*.mh)]
 Usage in Linux: migration.sh log [options] [migration history file(*.mh)]
 
-Available [options]:
-    -l,    To show the latest migration log automatically.
-    -ps,   An integer value. Lines of text to be shown in a page.    
+Available options:
+    -l,    Show latest log automatically.
+    -ps,   Lines of text per page (integer).
+
 Please visit http://www.cubrid.org for more information.

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_report.txt
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_report.txt
@@ -2,8 +2,8 @@
 Usage in Windows: migration.bat report [options] [migration history file(*.mh)]
 Usage in Linux: migration.sh report [options] [migration history file(*.mh)]
 
-Available [options]:
-    -l,    To show the latest migration report automatically.
-    -ao,   To show the migration report at once without pressing the ENTER key.
+Available options:
+    -l,    Show latest report automatically.
+    -ao,   Show report at once (no ENTER key press).
 
 Please visit http://www.cubrid.org for more information.

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_script.txt
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_script.txt
@@ -1,6 +1,6 @@
 
-Usage in Windows: migration.bat script [options]
-Usage in Linux: migration.sh script [options]
+Usage in Windows: migration.bat script [options] [output directory path]
+Usage in Linux: migration.sh script [options] [output directory path]
 
 Available options:
     -s,           Source config name in db.conf (Required).

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_script.txt
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_script.txt
@@ -3,9 +3,9 @@ Usage in Windows: migration.bat script [options]
 Usage in Linux: migration.sh script [options]
 
 Available options:
-    -s,           Configuration Name of source in db.conf(Required).
-    -t,           Configuration Name of target in db.conf(Required).
-    -o,           The output migration script file name(Required).
-    -schema,      If 'yes', the source schema will be packeted into output file, default is 'no'.
+    -s,           Source config name in db.conf (Required).
+    -t,           Target config name in db.conf (Required).
+    -o,           Output migration script file name (Required).
+    -schema,      Include source schema [yes|no] (Default: no).
 
 Please visit http://www.cubrid.org for more information.

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_start.txt
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_start.txt
@@ -3,14 +3,14 @@ Usage in Windows: migration.bat start [options] [migration script file]
 Usage in Linux: migration.sh start [options] [migration script file]
 
 Available options:
-    -s,      Configuration Name of source in db.conf.
-    -t,      Configuration Name of target in db.conf.
-    -sd,     Full name of source database's JDBC driver file.
-    -td,     Full name of target database's JDBC driver file.
-    -tp,     Path to save exported files if the configuration is setting to export source DB to files.
+    -s,      Source config name in db.conf.
+    -t,      Target config name in db.conf.
+    -sd,     Source JDBC driver file path.
+    -td,     Target JDBC driver file path.
+    -tp,     Export path (when exporting to files).
     -xml,    MySQL XML dump file.
-    -mm,     Monitor mode. The value should be one of [error,info,debug]
-    -rm,     Report mode. The value should be one of [error,info,debug]
-    -do,     CMT only migrates data. The value should be one of [yes,no]
+    -mm,     Monitor mode [error|info|debug]
+    -rm,     Report mode [error|info|debug]
+    -do,     Data-only migration [yes|no]
 
 Please visit http://www.cubrid.org for more information.

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_start.txt
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/help_start.txt
@@ -9,8 +9,8 @@ Available options:
     -td,     Target JDBC driver file path.
     -tp,     Export path (when exporting to files).
     -xml,    MySQL XML dump file.
-    -mm,     Monitor mode [error|info|debug]
-    -rm,     Report mode [error|info|debug]
-    -do,     Data-only migration [yes|no]
+    -mm,     Monitor mode [error|info|debug] (Default: brief-shows progress only).
+    -rm,     Report mode [error|info|debug] (Optional).
+    -do,     Data-only migration [yes|no] (Default: no).
 
 Please visit http://www.cubrid.org for more information.


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4783>

### Purpose
Console Help 메시지 간소화, 명확하게 작성하여 사용자가 쉽게 이해할 수 있도록 합니다.

### Implementation
메인 도움말
```
Available <command> (Default is "start"):
    start [options] [script_file]  Start a migration task.
    script [options] [output_dir]  Build a migration script.
    log [options] [mh_file]        Review a migration work's log.
    report [options] [mh_file]     Review a migration work's result.

For more information on a command, run:
  migration.sh <command> --help (Linux)
  migration.bat <command> --help (Windows)
```

Start 명령어 도움말
```
Usage in Windows: migration.bat start [options] [migration script file]
Usage in Linux: migration.sh start [options] [migration script file]

Available options:
    -s,      Source config name in db.conf.
    -t,      Target config name in db.conf.
    -sd,     Source JDBC driver file path.
    -td,     Target JDBC driver file path.
    -tp,     Export path (when exporting to files).
    -xml,    MySQL XML dump file.
    -mm,     Monitor mode [error|info|debug] (Default: brief-shows progress only).
    -rm,     Report mode [error|info|debug] (Optional).
    -do,     Data-only migration [yes|no] (Default: no).

Please visit http://www.cubrid.org for more information.
```

Script 명령어 도움말
```
Usage in Windows: migration.bat script [options] [output directory path]
Usage in Linux: migration.sh script [options] [output directory path]

Available options:
    -s,           Source config name in db.conf (Required).
    -t,           Target config name in db.conf (Required).
    -o,           Output migration script file name (Required).
    -schema,      Include source schema [yes|no] (Default: no).

Please visit http://www.cubrid.org for more information.
```

Log 명령어 도움말
```
Usage in Windows: migration.bat log [options] [migration history file(*.mh)]
Usage in Linux: migration.sh log [options] [migration history file(*.mh)]

Available options:
    -l,    Show latest log automatically.
    -ps,   Lines of text per page (integer).

Please visit http://www.cubrid.org for more information.
```

Report 명령어 도움말
```
Usage in Windows: migration.bat report [options] [migration history file(*.mh)]
Usage in Linux: migration.sh report [options] [migration history file(*.mh)]

Available options:
    -l,    Show latest report automatically.
    -ao,   Show report at once (no ENTER key press).

Please visit http://www.cubrid.org for more information.
```

### Remarks
N/A
