### PR TITLE
[TOOLS-4784] Update code-style workflow to Google Java Format v1.32.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,11 +83,11 @@ jobs:
           distribution: temurin
           java-version: '21'
       - id: changed
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62
         with:
           files: "**/*.java"
           write_output_files: true
-      - uses: axel-op/googlejavaformat-action@v4
+      - uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd
         if: ${{ steps.changed.outputs.any_changed == 'true' }}
         with:
           release-name: v1.32.0
@@ -96,6 +96,6 @@ jobs:
           skip-commit: true
       - name: Suggest code changes
         if: ${{ failure() }}
-        uses: reviewdog/action-suggester@v1
+        uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff
         with:
           tool_name: code-style (indent, googlejavaformat)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,19 +75,25 @@ jobs:
     name: code-style
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
-      - id: files
-        uses: jitterbit/get-changed-files@v1
-        continue-on-error: true
-      - uses: axel-op/googlejavaformat-action@v3
+      - uses: actions/checkout@v4
         with:
-          skipCommit: true
-          version: 1.7
-          args: "--aosp --replace --set-exit-if-changed"
-          run: |
-            for f in ${{ steps.files.outputs.added_modified }}; do
-              files: $f
-            done
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - id: changed
+        uses: tj-actions/changed-files@v47
+        with:
+          files: "**/*.java"
+          write_output_files: true
+      - uses: axel-op/googlejavaformat-action@v4
+        if: ${{ steps.changed.outputs.any_changed == 'true' }}
+        with:
+          release-name: v1.32.0
+          args: "--aosp --replace --set-exit-if-changed @.github/outputs/all_changed_files.txt"
+          files-excluded: "**/*"
+          skip-commit: true
       - name: Suggest code changes
         if: ${{ failure() }}
         uses: reviewdog/action-suggester@v1


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4784>

### Purpose
Google Java Format을 1.32.0 버전으로 변경합니다.

### Implementation
Codacy 정적 분석에서 서드파티 액션을 태그(`@v4` 등)로 사용할 경우 공급망 공격(supply chain attack)에 취약할 수 있다는 보안 경고가 발생했습니다.
(An action sourced from a third-party repository on GitHub is not pinned to a full length commit SHA. Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release.)
이에 따라, GitHub 공식 액션을 제외한 모든 서드파티 액션의 버전을 특정 커밋 SHA로 고정했습니다.

### Remarks
N/A
