### PR TITLE
[TOOLS-4771] When executing SQL transfer, the record entry in the results window is incorrect

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/MigrationReport.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/MigrationReport.java
@@ -613,6 +613,7 @@ public class MigrationReport implements Serializable {
                 continue;
             }
             RecordMigrationResult result = new RecordMigrationResult();
+            result.setSrcSchema(sstc.getOwner());
             result.setSource(sstc.getName());
             result.setTarget(sstc.getTarget());
             result.setDataMigrationSelected(sstc.isMigrateData());


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4771>

### Purpose
- SQL을 통해 record를 이관한 경우 결과창에서 record 이관이 실패한 것으로 표시되는 에러 수정

### Implementation
- 다른 record는 source owner 값이 적용되어 올바른 result를 가져와서 표시하고 있으나, SQL 이관으로 생성된 record에 대한 result는 source owner가 적용되지 않아서 result 객체가 중복 생성되고 있었음. source owner를 추가하여 result 객체를 정확하게 찾아오게 함으로써 result가 중복 생성되는 현상을 방지

### Remarks
N/A
