### PR TITLE
[TOOLS-4787] Split specific migration configurations into dedicated XML tags

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
@@ -131,10 +131,10 @@ public final class TemplateTags {
     public static final String ATTR_REUSE_OID = "reuse_oid";
     public static final String ATTR_REVERSE = "reverse";
     public static final String ATTR_SCHEMA = "schema";
-    public static final String ATTR_SCHEMA_NAME = "schema_name";
     public static final String ATTR_SHARED = "shared";
     public static final String ATTR_SHARED_VALUE = "shared_value";
     public static final String ATTR_SIZE = "size";
+    public static final String ATTR_SOURCE = "source";
     public static final String ATTR_SOURCE_DDL = "source_ddl";
     public static final String ATTR_SOURCE_GRANTOR_NAME = "source_grantor_name";
     public static final String ATTR_SOURCE_OBJECT_OWNER = "source_object_owner";
@@ -202,7 +202,6 @@ public final class TemplateTags {
     public static final String TAG_PROCEDURES = "procedures";
     public static final String TAG_RANGE = "range";
     public static final String TAG_SCHEMA = "schema";
-    public static final String TAG_SCHEMA_INFO = "schema_info";
     public static final String TAG_SCHEMAS = "schemas";
     public static final String TAG_SEQUENCE = "sequence";
     public static final String TAG_SEQUENCES = "sequences";

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
@@ -96,6 +96,7 @@ public final class TemplateTags {
     public static final String ATTR_MAX = "max";
     public static final String ATTR_MIGRATE_DATA = "migrate_data";
     public static final String ATTR_MIN = "min";
+    public static final String ATTR_ID = "id";
     public static final String ATTR_NAME = "name";
     public static final String ATTR_NO_LOGGING = "no_logging";
     public static final String ATTR_NO_MAX = "no_max";
@@ -166,6 +167,8 @@ public final class TemplateTags {
     public static final String TAG_CMSERVER = "cmServer";
     public static final String TAG_COLUMN = "column";
     public static final String TAG_COLUMNS = "columns";
+    public static final String TAG_CONNECTION = "connection";
+    public static final String TAG_CONNECTIONS = "connections";
     public static final String TAG_CONSTRAINTS = "constraints";
     public static final String TAG_CREATEDB = "createDB";
     public static final String TAG_CREATEVIEWSQL = "createViewSQL";

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/MigrationTemplateHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/MigrationTemplateHandler.java
@@ -35,6 +35,7 @@ import static com.cubrid.cubridmigration.core.engine.template.TemplateTags.*;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.ConnectionsNodeHandler;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.ParametersNodeHandler;
+import com.cubrid.cubridmigration.core.engine.template.reader.node.SchemasNodeHandler;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.SourceNodeHandler;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.TargetFileRepositoryNodeHandler;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.TargetNodeHandler;
@@ -73,6 +74,9 @@ public final class MigrationTemplateHandler extends DefaultHandler {
             case TAG_CONNECTIONS:
                 handleConnections(attributes);
                 break;
+            case TAG_SCHEMAS:
+                handleSchemas(attributes);
+                break;
             case TAG_FILE_REPOSITORY:
                 handleTargetFileRepository(attributes);
                 break;
@@ -98,6 +102,7 @@ public final class MigrationTemplateHandler extends DefaultHandler {
         if (delegatingHandler != null) {
             delegatingHandler.endElement(uri, localName, qName);
             if (TAG_CONNECTIONS.equals(qName)
+                    || TAG_SCHEMAS.equals(qName)
                     || TAG_SOURCE.equals(qName)
                     || TAG_TARGET.equals(qName)) {
                 delegatingHandler = null;
@@ -116,6 +121,10 @@ public final class MigrationTemplateHandler extends DefaultHandler {
 
     public MigrationConfiguration getResult() {
         return config;
+    }
+
+    private void handleSchemas(Attributes attributes) {
+        delegatingHandler = new SchemasNodeHandler(config);
     }
 
     private void handleTargetFileRepository(Attributes attributes) {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/MigrationTemplateHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/MigrationTemplateHandler.java
@@ -33,6 +33,7 @@ import static com.cubrid.cubridmigration.core.engine.template.MigrationTemplateU
 import static com.cubrid.cubridmigration.core.engine.template.TemplateTags.*;
 
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+import com.cubrid.cubridmigration.core.engine.template.reader.node.ConnectionsNodeHandler;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.ParametersNodeHandler;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.SourceNodeHandler;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.TargetNodeHandler;
@@ -68,6 +69,9 @@ public final class MigrationTemplateHandler extends DefaultHandler {
         }
 
         switch (qName) {
+            case TAG_CONNECTIONS:
+                handleConnections(attributes);
+                break;
             case TAG_SOURCE:
                 handleSource(attributes);
                 break;
@@ -89,7 +93,9 @@ public final class MigrationTemplateHandler extends DefaultHandler {
     public void endElement(String uri, String localName, String qName) throws SAXException {
         if (delegatingHandler != null) {
             delegatingHandler.endElement(uri, localName, qName);
-            if (TAG_SOURCE.equals(qName) || TAG_TARGET.equals(qName)) {
+            if (TAG_CONNECTIONS.equals(qName)
+                    || TAG_SOURCE.equals(qName)
+                    || TAG_TARGET.equals(qName)) {
                 delegatingHandler = null;
             }
             return;
@@ -106,6 +112,10 @@ public final class MigrationTemplateHandler extends DefaultHandler {
 
     public MigrationConfiguration getResult() {
         return config;
+    }
+
+    private void handleConnections(Attributes attributes) {
+        delegatingHandler = new ConnectionsNodeHandler(config);
     }
 
     private void handleSource(Attributes attributes) {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/MigrationTemplateHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/MigrationTemplateHandler.java
@@ -36,6 +36,7 @@ import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.ConnectionsNodeHandler;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.ParametersNodeHandler;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.SourceNodeHandler;
+import com.cubrid.cubridmigration.core.engine.template.reader.node.TargetFileRepositoryNodeHandler;
 import com.cubrid.cubridmigration.core.engine.template.reader.node.TargetNodeHandler;
 
 import org.xml.sax.Attributes;
@@ -71,6 +72,9 @@ public final class MigrationTemplateHandler extends DefaultHandler {
         switch (qName) {
             case TAG_CONNECTIONS:
                 handleConnections(attributes);
+                break;
+            case TAG_FILE_REPOSITORY:
+                handleTargetFileRepository(attributes);
                 break;
             case TAG_SOURCE:
                 handleSource(attributes);
@@ -112,6 +116,11 @@ public final class MigrationTemplateHandler extends DefaultHandler {
 
     public MigrationConfiguration getResult() {
         return config;
+    }
+
+    private void handleTargetFileRepository(Attributes attributes) {
+        TargetFileRepositoryNodeHandler handler = new TargetFileRepositoryNodeHandler(config);
+        handler.processAttributes(attributes);
     }
 
     private void handleConnections(Attributes attributes) {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/ConnectionsNodeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/ConnectionsNodeHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.core.engine.template.reader.node;
+
+import static com.cubrid.cubridmigration.core.engine.template.MigrationTemplateUtils.getBoolean;
+import static com.cubrid.cubridmigration.core.engine.template.TemplateTags.*;
+
+import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
+import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class ConnectionsNodeHandler extends DefaultHandler {
+
+    private final MigrationConfiguration config;
+
+    public ConnectionsNodeHandler(MigrationConfiguration config) {
+        this.config = config;
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) {
+        if (!TAG_CONNECTION.equals(qName)) {
+            return;
+        }
+
+        String id = attributes.getValue(ATTR_ID);
+        if ("source".equals(id)) {
+            ConnParameters scp =
+                    ConnParameters.getConParam(
+                            null,
+                            attributes.getValue(ATTR_HOST),
+                            Integer.parseInt(attributes.getValue(ATTR_PORT)),
+                            attributes.getValue(ATTR_NAME),
+                            DatabaseType.getDatabaseTypeIDByDBName(
+                                    attributes.getValue(ATTR_DB_TYPE)),
+                            attributes.getValue(ATTR_CHARSET),
+                            attributes.getValue(ATTR_USER),
+                            attributes.getValue(ATTR_PASSWORD),
+                            attributes.getValue(ATTR_DRIVER),
+                            attributes.getValue(ATTR_SCHEMA));
+            scp.setUserJDBCURL(attributes.getValue(ATTR_USER_JDBC_URL));
+            scp.setTimeZone(attributes.getValue(ATTR_TIMEZONE));
+            config.setSourceConParams(scp);
+        } else if ("target".equals(id)) {
+            ConnParameters cp =
+                    ConnParameters.getConParam(
+                            null,
+                            attributes.getValue(ATTR_HOST),
+                            Integer.parseInt(attributes.getValue(ATTR_PORT)),
+                            attributes.getValue(ATTR_NAME),
+                            DatabaseType.CUBRID,
+                            attributes.getValue(ATTR_CHARSET),
+                            attributes.getValue(ATTR_USER),
+                            attributes.getValue(ATTR_PASSWORD),
+                            attributes.getValue(ATTR_DRIVER),
+                            attributes.getValue(ATTR_SCHEMA));
+            cp.setUserJDBCURL(attributes.getValue(ATTR_USER_JDBC_URL));
+            cp.setTimeZone(attributes.getValue(ATTR_TIMEZONE));
+
+            config.setTargetConParams(cp);
+            config.setCreateConstrainsBeforeData(
+                    getBoolean(attributes.getValue(ATTR_CREATE_CONSTRAINT_NOW), false));
+            config.setWriteErrorRecords(
+                    getBoolean(attributes.getValue(ATTR_WRITE_ERROR_RECORDS), false));
+            config.setAddUserSchema(getBoolean(attributes.getValue(ATTR_ADD_SCHEMA), false));
+        }
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/SchemasNodeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/SchemasNodeHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.core.engine.template.reader.node;
+
+import static com.cubrid.cubridmigration.core.engine.template.TemplateTags.*;
+
+import com.cubrid.cubridmigration.core.dbobject.Schema;
+import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class SchemasNodeHandler extends DefaultHandler {
+
+    private final MigrationConfiguration config;
+
+    public SchemasNodeHandler(MigrationConfiguration config) {
+        this.config = config;
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) {
+        if (TAG_SCHEMA.equals(qName)) {
+            String src = attributes.getValue(ATTR_SOURCE);
+            String trg = attributes.getValue(ATTR_TARGET);
+
+            if (src != null && trg != null) {
+                Schema schema = new Schema();
+                schema.setName(src);
+                schema.setTargetSchemaName(trg);
+                schema.setMigration(true);
+
+                config.addScriptSchemaMapping(src, schema);
+                config.addTargetSchemaList(schema);
+            }
+        }
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/SourceNodeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/SourceNodeHandler.java
@@ -85,7 +85,6 @@ public class SourceNodeHandler extends DefaultHandler {
     }
 
     private void initializeStartTagHandlers() {
-        startTagHandlers.put(TAG_JDBC, this::parseSourceJDBC);
         startTagHandlers.put(TAG_SCHEMA, attr -> schemaCache = new StringBuffer());
         startTagHandlers.put(TAG_SQL_SCHEMA, attr -> schemaCache = new StringBuffer());
         startTagHandlers.put(TAG_SCHEMA_INFO, this::parseSourceSchemaInfo);
@@ -164,24 +163,6 @@ public class SourceNodeHandler extends DefaultHandler {
     }
 
     // startElement
-
-    private void parseSourceJDBC(Attributes attributes) {
-        ConnParameters scp =
-                ConnParameters.getConParam(
-                        null,
-                        attributes.getValue(ATTR_HOST),
-                        Integer.parseInt(attributes.getValue(ATTR_PORT)),
-                        attributes.getValue(ATTR_NAME),
-                        config.getSourceDBType(),
-                        attributes.getValue(ATTR_CHARSET),
-                        attributes.getValue(ATTR_USER),
-                        attributes.getValue(ATTR_PASSWORD),
-                        attributes.getValue(ATTR_DRIVER),
-                        attributes.getValue(ATTR_SCHEMA));
-        scp.setUserJDBCURL(attributes.getValue(ATTR_USER_JDBC_URL));
-        scp.setTimeZone(attributes.getValue(ATTR_TIMEZONE));
-        config.setSourceConParams(scp);
-    }
 
     private void parseSourceSchemaInfo(Attributes attributes) {
         Schema schema = new Schema();

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/SourceNodeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/SourceNodeHandler.java
@@ -87,7 +87,6 @@ public class SourceNodeHandler extends DefaultHandler {
     private void initializeStartTagHandlers() {
         startTagHandlers.put(TAG_SCHEMA, attr -> schemaCache = new StringBuffer());
         startTagHandlers.put(TAG_SQL_SCHEMA, attr -> schemaCache = new StringBuffer());
-        startTagHandlers.put(TAG_SCHEMA_INFO, this::parseSourceSchemaInfo);
         startTagHandlers.put(TAG_FILE, this::parseSourceFile);
         startTagHandlers.put(TAG_TABLE, this::parseSourceTable);
         startTagHandlers.put(TAG_COLUMN, this::parseSourceColumn);
@@ -163,14 +162,6 @@ public class SourceNodeHandler extends DefaultHandler {
     }
 
     // startElement
-
-    private void parseSourceSchemaInfo(Attributes attributes) {
-        Schema schema = new Schema();
-        schema.setName(attributes.getValue(ATTR_SCHEMA_NAME));
-        schema.setTargetSchemaName(attributes.getValue(ATTR_TARGET_SCHEMA));
-        schema.setMigration(true);
-        config.addScriptSchemaMapping(attributes.getValue(ATTR_SCHEMA_NAME), schema);
-    }
 
     private void parseSourceFile(Attributes attributes) {
         config.setSourceFileName(attributes.getValue(ATTR_LOCATION));

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/TargetFileRepositoryNodeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/TargetFileRepositoryNodeHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.core.engine.template.reader.node;
+
+import static com.cubrid.cubridmigration.core.engine.template.MigrationTemplateUtils.getBoolean;
+import static com.cubrid.cubridmigration.core.engine.template.TemplateTags.*;
+
+import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xml.sax.Attributes;
+
+public class TargetFileRepositoryNodeHandler {
+
+    private final MigrationConfiguration config;
+
+    public TargetFileRepositoryNodeHandler(MigrationConfiguration config) {
+        this.config = config;
+    }
+
+    public void processAttributes(Attributes attributes) {
+        config.setFileRepositroyPath(attributes.getValue(ATTR_DIR));
+        config.setTargetFileTimeZone(attributes.getValue(ATTR_TIMEZONE));
+        config.setOneTableOneFile(getBoolean(attributes.getValue(ATTR_ONETABLEONEFILE), false));
+        final String fileMaxSize = attributes.getValue(ATTR_FILE_MAX_SIZE);
+        config.setMaxCountPerFile(fileMaxSize == null ? 0 : Integer.parseInt(fileMaxSize));
+        config.setTargetFilePrefix(attributes.getValue(ATTR_OUTPUT_FILE_PREFIX));
+        try {
+            config.setDestType(Integer.parseInt(attributes.getValue(ATTR_DATA_FILE_FORMAT)));
+        } catch (Exception ex) {
+            config.setDestType(MigrationConfiguration.DEST_DB_UNLOAD);
+        }
+        config.setTargetCharSet(attributes.getValue(ATTR_CHARSET));
+        if (config.targetIsCSV()) {
+            String value = attributes.getValue(ATTR_CSV_SEPARATE);
+            config.getCsvSettings()
+                    .setSeparateChar(StringUtils.isEmpty(value) ? ',' : value.charAt(0));
+            value = attributes.getValue(ATTR_CSV_QUOTE);
+            config.getCsvSettings()
+                    .setQuoteChar(
+                            StringUtils.isEmpty(value)
+                                    ? MigrationConfiguration.CSV_NO_CHAR
+                                    : value.charAt(0));
+            value = attributes.getValue(ATTR_CSV_ESCAPE);
+            config.getCsvSettings()
+                    .setEscapeChar(
+                            StringUtils.isEmpty(value)
+                                    ? MigrationConfiguration.CSV_NO_CHAR
+                                    : value.charAt(0));
+        }
+        config.setTargetLOBRootPath(attributes.getValue(ATTR_LOB_ROOT_DIR));
+        config.setAddUserSchema(getBoolean(attributes.getValue(ATTR_ADD_SCHEMA), false));
+        config.setSplitSchema(getBoolean(attributes.getValue(ATTR_SPLIT_SCHEMA), false));
+        config.setCreateUserSQL(getBoolean(attributes.getValue(ATTR_CREATE_USER_SQL), false));
+        config.createDumpfile(config.isSplitSchema(), config.isOneTableOneFile());
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/TargetNodeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/TargetNodeHandler.java
@@ -42,7 +42,6 @@ import com.cubrid.cubridmigration.core.dbobject.PartitionInfo;
 import com.cubrid.cubridmigration.core.dbobject.PartitionTable;
 import com.cubrid.cubridmigration.core.dbobject.PlcsqlFunction;
 import com.cubrid.cubridmigration.core.dbobject.PlcsqlProcedure;
-import com.cubrid.cubridmigration.core.dbobject.Schema;
 import com.cubrid.cubridmigration.core.dbobject.Sequence;
 import com.cubrid.cubridmigration.core.dbobject.Synonym;
 import com.cubrid.cubridmigration.core.dbobject.Table;
@@ -91,7 +90,6 @@ public class TargetNodeHandler extends DefaultHandler {
 
     private void initializeStartTagHandlers() {
         startTagHandlers.put(TAG_SCHEMA, attr -> schemaCache = new StringBuffer());
-        startTagHandlers.put(TAG_SCHEMA_INFO, this::parseTargetSchemaInfo);
         startTagHandlers.put(TAG_TABLE, this::parseTargetTable);
         startTagHandlers.put(TAG_COLUMN, this::parseTargetColumn);
         startTagHandlers.put(TAG_PK, this::parseTargetPK);
@@ -161,14 +159,6 @@ public class TargetNodeHandler extends DefaultHandler {
     }
 
     // startElement
-
-    private void parseTargetSchemaInfo(Attributes attributes) {
-        Schema schema = new Schema();
-        schema.setName(attributes.getValue(ATTR_SCHEMA_NAME));
-        schema.setTargetSchemaName(attributes.getValue(ATTR_TARGET_SCHEMA));
-        schema.setMigration(true);
-        config.addTargetSchemaList(schema);
-    }
 
     private void parseTargetTable(Attributes attributes) {
         targetTable = new Table();

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/TargetNodeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/TargetNodeHandler.java
@@ -90,7 +90,6 @@ public class TargetNodeHandler extends DefaultHandler {
     }
 
     private void initializeStartTagHandlers() {
-        startTagHandlers.put(TAG_FILE_REPOSITORY, this::parseTargetFileRepository);
         startTagHandlers.put(TAG_SCHEMA, attr -> schemaCache = new StringBuffer());
         startTagHandlers.put(TAG_SCHEMA_INFO, this::parseTargetSchemaInfo);
         startTagHandlers.put(TAG_TABLE, this::parseTargetTable);
@@ -162,43 +161,6 @@ public class TargetNodeHandler extends DefaultHandler {
     }
 
     // startElement
-
-    private void parseTargetFileRepository(Attributes attributes) {
-        config.setFileRepositroyPath(attributes.getValue(ATTR_DIR));
-        config.setTargetFileTimeZone(attributes.getValue(ATTR_TIMEZONE));
-        config.setOneTableOneFile(getBoolean(attributes.getValue(ATTR_ONETABLEONEFILE), false));
-        final String fileMaxSize = attributes.getValue(ATTR_FILE_MAX_SIZE);
-        config.setMaxCountPerFile(fileMaxSize == null ? 0 : Integer.parseInt(fileMaxSize));
-        config.setTargetFilePrefix(attributes.getValue(ATTR_OUTPUT_FILE_PREFIX));
-        try {
-            config.setDestType(Integer.parseInt(attributes.getValue(ATTR_DATA_FILE_FORMAT)));
-        } catch (Exception ex) {
-            config.setDestType(MigrationConfiguration.DEST_DB_UNLOAD);
-        }
-        config.setTargetCharSet(attributes.getValue(ATTR_CHARSET));
-        if (config.targetIsCSV()) {
-            String value = attributes.getValue(ATTR_CSV_SEPARATE);
-            config.getCsvSettings()
-                    .setSeparateChar(StringUtils.isEmpty(value) ? ',' : value.charAt(0));
-            value = attributes.getValue(ATTR_CSV_QUOTE);
-            config.getCsvSettings()
-                    .setQuoteChar(
-                            StringUtils.isEmpty(value)
-                                    ? MigrationConfiguration.CSV_NO_CHAR
-                                    : value.charAt(0));
-            value = attributes.getValue(ATTR_CSV_ESCAPE);
-            config.getCsvSettings()
-                    .setEscapeChar(
-                            StringUtils.isEmpty(value)
-                                    ? MigrationConfiguration.CSV_NO_CHAR
-                                    : value.charAt(0));
-        }
-        config.setTargetLOBRootPath(attributes.getValue(ATTR_LOB_ROOT_DIR));
-        config.setAddUserSchema(getBoolean(attributes.getValue(ATTR_ADD_SCHEMA), false));
-        config.setSplitSchema(getBoolean(attributes.getValue(ATTR_SPLIT_SCHEMA), false));
-        config.setCreateUserSQL(getBoolean(attributes.getValue(ATTR_CREATE_USER_SQL), false));
-        config.createDumpfile(config.isSplitSchema(), config.isOneTableOneFile());
-    }
 
     private void parseTargetSchemaInfo(Attributes attributes) {
         Schema schema = new Schema();

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/TargetNodeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/TargetNodeHandler.java
@@ -33,7 +33,6 @@ import static com.cubrid.cubridmigration.core.engine.template.MigrationTemplateU
 import static com.cubrid.cubridmigration.core.engine.template.TemplateTags.*;
 
 import com.cubrid.common.log.LogUtil;
-import com.cubrid.cubridmigration.core.connection.ConnParameters;
 import com.cubrid.cubridmigration.core.dbobject.Column;
 import com.cubrid.cubridmigration.core.dbobject.FK;
 import com.cubrid.cubridmigration.core.dbobject.Grant;
@@ -48,7 +47,6 @@ import com.cubrid.cubridmigration.core.dbobject.Sequence;
 import com.cubrid.cubridmigration.core.dbobject.Synonym;
 import com.cubrid.cubridmigration.core.dbobject.Table;
 import com.cubrid.cubridmigration.core.dbobject.View;
-import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import com.cubrid.cubridmigration.cubrid.CUBRIDDataTypeHelper;
 
@@ -92,7 +90,6 @@ public class TargetNodeHandler extends DefaultHandler {
     }
 
     private void initializeStartTagHandlers() {
-        startTagHandlers.put(TAG_JDBC, this::parseTargetJDBC);
         startTagHandlers.put(TAG_FILE_REPOSITORY, this::parseTargetFileRepository);
         startTagHandlers.put(TAG_SCHEMA, attr -> schemaCache = new StringBuffer());
         startTagHandlers.put(TAG_SCHEMA_INFO, this::parseTargetSchemaInfo);
@@ -165,33 +162,6 @@ public class TargetNodeHandler extends DefaultHandler {
     }
 
     // startElement
-
-    /**
-     * @param attributes of node
-     */
-    private void parseTargetJDBC(Attributes attributes) {
-        ConnParameters cp =
-                ConnParameters.getConParam(
-                        null,
-                        attributes.getValue(ATTR_HOST),
-                        Integer.parseInt(attributes.getValue(ATTR_PORT)),
-                        attributes.getValue(ATTR_NAME),
-                        DatabaseType.CUBRID,
-                        attributes.getValue(ATTR_CHARSET),
-                        attributes.getValue(ATTR_USER),
-                        attributes.getValue(ATTR_PASSWORD),
-                        attributes.getValue(ATTR_DRIVER),
-                        attributes.getValue(ATTR_SCHEMA));
-        cp.setUserJDBCURL(attributes.getValue(ATTR_USER_JDBC_URL));
-        cp.setTimeZone(attributes.getValue(ATTR_TIMEZONE));
-
-        config.setTargetConParams(cp);
-        config.setCreateConstrainsBeforeData(
-                getBoolean(attributes.getValue(ATTR_CREATE_CONSTRAINT_NOW), false));
-        config.setWriteErrorRecords(
-                getBoolean(attributes.getValue(ATTR_WRITE_ERROR_RECORDS), false));
-        config.setAddUserSchema(getBoolean(attributes.getValue(ATTR_ADD_SCHEMA), false));
-    }
 
     private void parseTargetFileRepository(Attributes attributes) {
         config.setFileRepositroyPath(attributes.getValue(ATTR_DIR));

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/MigrationTemplateWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/MigrationTemplateWriter.java
@@ -39,6 +39,7 @@ import com.cubrid.cubridmigration.core.engine.exception.ErrorMigrationTemplateEx
 import com.cubrid.cubridmigration.core.engine.template.writer.node.ConnectionsNodeWriter;
 import com.cubrid.cubridmigration.core.engine.template.writer.node.ParametersNodeWriter;
 import com.cubrid.cubridmigration.core.engine.template.writer.node.SourceNodeWriter;
+import com.cubrid.cubridmigration.core.engine.template.writer.node.TargetFileRepositoryNodeWriter;
 import com.cubrid.cubridmigration.core.engine.template.writer.node.TargetNodeWriter;
 
 import org.slf4j.Logger;
@@ -78,6 +79,7 @@ public final class MigrationTemplateWriter {
             writer.writeAttribute(ATTR_WIZARD_START_DATE_TIME, config.getWizardStartDateTime());
 
             new ConnectionsNodeWriter().write(writer, config);
+            new TargetFileRepositoryNodeWriter().write(writer, config);
             new SourceNodeWriter().write(writer, config, saveSchema);
             new TargetNodeWriter().write(writer, config);
             new ParametersNodeWriter().write(writer, config);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/MigrationTemplateWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/MigrationTemplateWriter.java
@@ -38,6 +38,7 @@ import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import com.cubrid.cubridmigration.core.engine.exception.ErrorMigrationTemplateException;
 import com.cubrid.cubridmigration.core.engine.template.writer.node.ConnectionsNodeWriter;
 import com.cubrid.cubridmigration.core.engine.template.writer.node.ParametersNodeWriter;
+import com.cubrid.cubridmigration.core.engine.template.writer.node.SchemasNodeWriter;
 import com.cubrid.cubridmigration.core.engine.template.writer.node.SourceNodeWriter;
 import com.cubrid.cubridmigration.core.engine.template.writer.node.TargetFileRepositoryNodeWriter;
 import com.cubrid.cubridmigration.core.engine.template.writer.node.TargetNodeWriter;
@@ -79,6 +80,7 @@ public final class MigrationTemplateWriter {
             writer.writeAttribute(ATTR_WIZARD_START_DATE_TIME, config.getWizardStartDateTime());
 
             new ConnectionsNodeWriter().write(writer, config);
+            new SchemasNodeWriter().write(writer, config);
             new TargetFileRepositoryNodeWriter().write(writer, config);
             new SourceNodeWriter().write(writer, config, saveSchema);
             new TargetNodeWriter().write(writer, config);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/MigrationTemplateWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/MigrationTemplateWriter.java
@@ -36,6 +36,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
 import com.cubrid.cubridmigration.core.engine.exception.ErrorMigrationTemplateException;
+import com.cubrid.cubridmigration.core.engine.template.writer.node.ConnectionsNodeWriter;
 import com.cubrid.cubridmigration.core.engine.template.writer.node.ParametersNodeWriter;
 import com.cubrid.cubridmigration.core.engine.template.writer.node.SourceNodeWriter;
 import com.cubrid.cubridmigration.core.engine.template.writer.node.TargetNodeWriter;
@@ -76,6 +77,7 @@ public final class MigrationTemplateWriter {
             writer.writeAttribute(ATTR_VERSION, "11.1.0");
             writer.writeAttribute(ATTR_WIZARD_START_DATE_TIME, config.getWizardStartDateTime());
 
+            new ConnectionsNodeWriter().write(writer, config);
             new SourceNodeWriter().write(writer, config, saveSchema);
             new TargetNodeWriter().write(writer, config);
             new ParametersNodeWriter().write(writer, config);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/ConnectionsNodeWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/ConnectionsNodeWriter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.core.engine.template.writer.node;
+
+import static com.cubrid.cubridmigration.core.engine.template.MigrationTemplateUtils.getBooleanString;
+import static com.cubrid.cubridmigration.core.engine.template.TemplateTags.*;
+
+import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+public class ConnectionsNodeWriter {
+
+    public void write(XMLStreamWriter writer, MigrationConfiguration config)
+            throws XMLStreamException {
+        ConnParameters scp = config.getSourceConParams();
+        ConnParameters tcp = config.getTargetConParams();
+
+        if (scp == null && tcp == null) {
+            return;
+        }
+
+        writer.writeStartElement(TAG_CONNECTIONS);
+        if (scp != null) {
+            writer.writeEmptyElement(TAG_CONNECTION);
+            writer.writeAttribute(ATTR_ID, "source");
+            sourceConnectionAttributes(writer, scp, config);
+        }
+
+        if (tcp != null) {
+            writer.writeEmptyElement(TAG_CONNECTION);
+            writer.writeAttribute(ATTR_ID, "target");
+            targetConnectionAttributes(writer, tcp, config);
+        }
+        writer.writeEndElement(); // </connections>
+    }
+
+    private void sourceConnectionAttributes(
+            XMLStreamWriter writer, ConnParameters scp, MigrationConfiguration config)
+            throws XMLStreamException {
+        writeCommonAttributes(writer, scp);
+        writer.writeAttribute(ATTR_DB_TYPE, config.getSourceTypeName());
+    }
+
+    private void targetConnectionAttributes(
+            XMLStreamWriter writer, ConnParameters tcp, MigrationConfiguration config)
+            throws XMLStreamException {
+        writeCommonAttributes(writer, tcp);
+        writer.writeAttribute(
+                ATTR_CREATE_CONSTRAINT_NOW,
+                getBooleanString(config.isCreateConstrainsBeforeData()));
+        writer.writeAttribute(
+                ATTR_WRITE_ERROR_RECORDS, getBooleanString(config.isWriteErrorRecords()));
+        writer.writeAttribute(ATTR_ADD_SCHEMA, getBooleanString(config.isAddUserSchema()));
+    }
+
+    private void writeCommonAttributes(XMLStreamWriter writer, ConnParameters cp)
+            throws XMLStreamException {
+        writer.writeAttribute(ATTR_HOST, cp.getHost());
+        writer.writeAttribute(ATTR_PORT, String.valueOf(cp.getPort()));
+        writer.writeAttribute(ATTR_DRIVER, cp.getDriverFileName());
+        writer.writeAttribute(ATTR_NAME, cp.getDbName());
+        writer.writeAttribute(ATTR_USER, cp.getConUser());
+        writer.writeAttribute(ATTR_PASSWORD, cp.getConPassword());
+        writer.writeAttribute(ATTR_CHARSET, cp.getCharset());
+        writer.writeAttribute(ATTR_TIMEZONE, cp.getTimeZone());
+        writer.writeAttribute(ATTR_USER_JDBC_URL, cp.getUserJDBCURL());
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/SchemasNodeWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/SchemasNodeWriter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.core.engine.template.writer.node;
+
+import static com.cubrid.cubridmigration.core.engine.template.TemplateTags.*;
+
+import com.cubrid.cubridmigration.core.dbobject.Schema;
+import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+
+import java.util.List;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+public class SchemasNodeWriter {
+
+    public void write(XMLStreamWriter writer, MigrationConfiguration config)
+            throws XMLStreamException {
+        List<Schema> schemas = config.getTargetSchemaList();
+
+        if (schemas.isEmpty()) {
+            return;
+        }
+
+        writer.writeStartElement(TAG_SCHEMAS);
+        for (Schema schema : schemas) {
+            writer.writeEmptyElement(TAG_SCHEMA);
+            writer.writeAttribute(ATTR_SOURCE, schema.getName());
+            writer.writeAttribute(ATTR_TARGET, schema.getTargetSchemaName());
+        }
+        writer.writeEndElement(); // </schemas>
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/SourceNodeWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/SourceNodeWriter.java
@@ -37,7 +37,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.common.PathUtils;
 import com.cubrid.cubridmigration.core.common.TextFileUtils;
-import com.cubrid.cubridmigration.core.connection.ConnParameters;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
 import com.cubrid.cubridmigration.core.dbobject.Schema;
 import com.cubrid.cubridmigration.core.dbobject.Table;
@@ -99,8 +98,6 @@ public class SourceNodeWriter {
     private void writeOnlineSource(
             XMLStreamWriter writer, MigrationConfiguration config, boolean saveSchema)
             throws XMLStreamException, IOException {
-        writeSourceJDBCNode(writer, config);
-
         if (saveSchema) {
             writeSourceSchemaNode(writer, config);
         }
@@ -200,24 +197,6 @@ public class SourceNodeWriter {
         }
         writer.writeEndElement(); // </csv_columns>
         writer.writeEndElement(); // </csv>
-    }
-
-    private void writeSourceJDBCNode(XMLStreamWriter writer, MigrationConfiguration config)
-            throws XMLStreamException {
-        ConnParameters scp = config.getSourceConParams();
-        if (scp == null) {
-            return;
-        }
-        writer.writeEmptyElement(TAG_JDBC);
-        writer.writeAttribute(ATTR_HOST, scp.getHost());
-        writer.writeAttribute(ATTR_PORT, String.valueOf(scp.getPort()));
-        writer.writeAttribute(ATTR_DRIVER, scp.getDriverFileName());
-        writer.writeAttribute(ATTR_NAME, scp.getDbName());
-        writer.writeAttribute(ATTR_USER, scp.getConUser());
-        writer.writeAttribute(ATTR_PASSWORD, scp.getConPassword());
-        writer.writeAttribute(ATTR_CHARSET, scp.getCharset());
-        writer.writeAttribute(ATTR_TIMEZONE, scp.getTimeZone());
-        writer.writeAttribute(ATTR_USER_JDBC_URL, scp.getUserJDBCURL());
     }
 
     private void writeSourceSchemaNode(XMLStreamWriter writer, MigrationConfiguration config)

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/SourceNodeWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/SourceNodeWriter.java
@@ -102,7 +102,6 @@ public class SourceNodeWriter {
             writeSourceSchemaNode(writer, config);
         }
 
-        writeSourceSchemaMapping(writer, config);
         writeSourceTables(writer, config);
         writeSourceSQLTables(writer, config);
         writeSourceSequences(writer, config);
@@ -241,26 +240,6 @@ public class SourceNodeWriter {
             }
             writer.writeEndElement(); // </sql_schema>
         }
-    }
-
-    private void writeSourceSchemaMapping(XMLStreamWriter writer, MigrationConfiguration config)
-            throws XMLStreamException {
-        writer.writeStartElement(TAG_SCHEMAS);
-        Catalog srcCatalog = config.getSrcCatalog();
-        if (srcCatalog != null) {
-            for (Schema schema : srcCatalog.getSchemas()) {
-                writer.writeEmptyElement(TAG_SCHEMA_INFO);
-                writer.writeAttribute(ATTR_SCHEMA_NAME, schema.getName());
-                writer.writeAttribute(ATTR_TARGET_SCHEMA, schema.getTargetSchemaName());
-            }
-        } else {
-            for (Schema schema : config.getScriptSchemaMapping().values()) {
-                writer.writeEmptyElement(TAG_SCHEMA_INFO);
-                writer.writeAttribute(ATTR_SCHEMA_NAME, schema.getName());
-                writer.writeAttribute(ATTR_TARGET_SCHEMA, schema.getTargetSchemaName());
-            }
-        }
-        writer.writeEndElement(); // </schemas>
     }
 
     private void writeSourceTables(XMLStreamWriter writer, MigrationConfiguration config)

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/TargetFileRepositoryNodeWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/TargetFileRepositoryNodeWriter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.core.engine.template.writer.node;
+
+import static com.cubrid.cubridmigration.core.engine.template.MigrationTemplateUtils.getBooleanString;
+import static com.cubrid.cubridmigration.core.engine.template.TemplateTags.*;
+
+import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+public class TargetFileRepositoryNodeWriter {
+
+    public void write(XMLStreamWriter writer, MigrationConfiguration config)
+            throws XMLStreamException {
+        if (!config.targetIsFile()) {
+            return;
+        }
+
+        writer.writeEmptyElement(TAG_FILE_REPOSITORY);
+        writer.writeAttribute(ATTR_DIR, config.getFileRepositroyPath());
+        writer.writeAttribute(ATTR_TIMEZONE, config.getTargetFileTimeZone());
+        writer.writeAttribute(ATTR_CHARSET, config.getTargetCharSet());
+        writer.writeAttribute(ATTR_ADD_SCHEMA, getBooleanString(config.isAddUserSchema()));
+        writer.writeAttribute(ATTR_SPLIT_SCHEMA, getBooleanString(config.isSplitSchema()));
+        writer.writeAttribute(ATTR_CREATE_USER_SQL, getBooleanString(config.isCreateUserSQL()));
+        writer.writeAttribute(ATTR_ONETABLEONEFILE, getBooleanString(config.isOneTableOneFile()));
+        writer.writeAttribute(ATTR_DATA_FILE_FORMAT, String.valueOf(config.getDestType()));
+        writer.writeAttribute(ATTR_OUTPUT_FILE_PREFIX, config.getTargetFilePrefix());
+        writer.writeAttribute(ATTR_FILE_MAX_SIZE, String.valueOf(config.getMaxCountPerFile()));
+        if (config.targetIsCSV()) {
+            writer.writeAttribute(
+                    ATTR_CSV_SEPARATE,
+                    config.getCsvSettings().getSeparateChar() == MigrationConfiguration.CSV_NO_CHAR
+                            ? ""
+                            : String.valueOf(config.getCsvSettings().getSeparateChar()));
+            writer.writeAttribute(
+                    ATTR_CSV_QUOTE,
+                    config.getCsvSettings().getQuoteChar() == MigrationConfiguration.CSV_NO_CHAR
+                            ? ""
+                            : String.valueOf(config.getCsvSettings().getQuoteChar()));
+            writer.writeAttribute(
+                    ATTR_CSV_ESCAPE,
+                    config.getCsvSettings().getEscapeChar() == MigrationConfiguration.CSV_NO_CHAR
+                            ? ""
+                            : String.valueOf(config.getCsvSettings().getEscapeChar()));
+        }
+        if (config.targetIsDBDump()) {
+            writer.writeAttribute(ATTR_LOB_ROOT_DIR, config.getTargetLOBRootPath());
+        }
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/TargetNodeWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/TargetNodeWriter.java
@@ -70,8 +70,6 @@ public class TargetNodeWriter {
         }
         writer.writeAttribute(ATTR_DB_TYPE, "cubrid");
 
-        writeFileRepositoryNode(writer, config);
-
         writeTargetSchemaNodes(writer, config);
         writeTargetTableNodes(writer, config);
         writeTargetSequenceNodes(writer, config);
@@ -80,45 +78,6 @@ public class TargetNodeWriter {
         writeTargetPlcsqlProcedureNodes(writer, config);
         writeTargetPlcsqlFunctionNodes(writer, config);
         writer.writeEndElement(); // </target>
-    }
-
-    private void writeFileRepositoryNode(XMLStreamWriter writer, MigrationConfiguration config)
-            throws XMLStreamException {
-        if (!config.targetIsFile()) {
-            return;
-        }
-
-        writer.writeEmptyElement(TAG_FILE_REPOSITORY);
-        writer.writeAttribute(ATTR_DIR, config.getFileRepositroyPath());
-        writer.writeAttribute(ATTR_TIMEZONE, config.getTargetFileTimeZone());
-        writer.writeAttribute(ATTR_CHARSET, config.getTargetCharSet());
-        writer.writeAttribute(ATTR_ADD_SCHEMA, getBooleanString(config.isAddUserSchema()));
-        writer.writeAttribute(ATTR_SPLIT_SCHEMA, getBooleanString(config.isSplitSchema()));
-        writer.writeAttribute(ATTR_CREATE_USER_SQL, getBooleanString(config.isCreateUserSQL()));
-        writer.writeAttribute(ATTR_ONETABLEONEFILE, getBooleanString(config.isOneTableOneFile()));
-        writer.writeAttribute(ATTR_DATA_FILE_FORMAT, String.valueOf(config.getDestType()));
-        writer.writeAttribute(ATTR_OUTPUT_FILE_PREFIX, config.getTargetFilePrefix());
-        writer.writeAttribute(ATTR_FILE_MAX_SIZE, String.valueOf(config.getMaxCountPerFile()));
-        if (config.targetIsCSV()) {
-            writer.writeAttribute(
-                    ATTR_CSV_SEPARATE,
-                    config.getCsvSettings().getSeparateChar() == MigrationConfiguration.CSV_NO_CHAR
-                            ? ""
-                            : String.valueOf(config.getCsvSettings().getSeparateChar()));
-            writer.writeAttribute(
-                    ATTR_CSV_QUOTE,
-                    config.getCsvSettings().getQuoteChar() == MigrationConfiguration.CSV_NO_CHAR
-                            ? ""
-                            : String.valueOf(config.getCsvSettings().getQuoteChar()));
-            writer.writeAttribute(
-                    ATTR_CSV_ESCAPE,
-                    config.getCsvSettings().getEscapeChar() == MigrationConfiguration.CSV_NO_CHAR
-                            ? ""
-                            : String.valueOf(config.getCsvSettings().getEscapeChar()));
-        }
-        if (config.targetIsDBDump()) {
-            writer.writeAttribute(ATTR_LOB_ROOT_DIR, config.getTargetLOBRootPath());
-        }
     }
 
     private void writeTargetSchemaNodes(XMLStreamWriter writer, MigrationConfiguration config)

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/TargetNodeWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/TargetNodeWriter.java
@@ -40,7 +40,6 @@ import com.cubrid.cubridmigration.core.dbobject.PartitionInfo;
 import com.cubrid.cubridmigration.core.dbobject.PartitionTable;
 import com.cubrid.cubridmigration.core.dbobject.PlcsqlFunction;
 import com.cubrid.cubridmigration.core.dbobject.PlcsqlProcedure;
-import com.cubrid.cubridmigration.core.dbobject.Schema;
 import com.cubrid.cubridmigration.core.dbobject.Sequence;
 import com.cubrid.cubridmigration.core.dbobject.Synonym;
 import com.cubrid.cubridmigration.core.dbobject.Table;
@@ -70,7 +69,6 @@ public class TargetNodeWriter {
         }
         writer.writeAttribute(ATTR_DB_TYPE, "cubrid");
 
-        writeTargetSchemaNodes(writer, config);
         writeTargetTableNodes(writer, config);
         writeTargetSequenceNodes(writer, config);
         writeTargetViewNodes(writer, config);
@@ -78,21 +76,6 @@ public class TargetNodeWriter {
         writeTargetPlcsqlProcedureNodes(writer, config);
         writeTargetPlcsqlFunctionNodes(writer, config);
         writer.writeEndElement(); // </target>
-    }
-
-    private void writeTargetSchemaNodes(XMLStreamWriter writer, MigrationConfiguration config)
-            throws XMLStreamException {
-        List<Schema> schemaList = config.getTargetSchemaList();
-        if (schemaList.isEmpty()) {
-            return;
-        }
-        writer.writeStartElement(TAG_SCHEMAS);
-        for (Schema schema : schemaList) {
-            writer.writeEmptyElement(TAG_SCHEMA_INFO);
-            writer.writeAttribute(ATTR_SCHEMA_NAME, schema.getName());
-            writer.writeAttribute(ATTR_TARGET_SCHEMA, schema.getTargetSchemaName());
-        }
-        writer.writeEndElement(); // </schemas>
     }
 
     private void writeTargetTableNodes(XMLStreamWriter writer, MigrationConfiguration config)

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/TargetNodeWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/TargetNodeWriter.java
@@ -32,7 +32,6 @@ package com.cubrid.cubridmigration.core.engine.template.writer.node;
 import static com.cubrid.cubridmigration.core.engine.template.MigrationTemplateUtils.*;
 import static com.cubrid.cubridmigration.core.engine.template.TemplateTags.*;
 
-import com.cubrid.cubridmigration.core.connection.ConnParameters;
 import com.cubrid.cubridmigration.core.dbobject.Column;
 import com.cubrid.cubridmigration.core.dbobject.FK;
 import com.cubrid.cubridmigration.core.dbobject.Index;
@@ -71,7 +70,7 @@ public class TargetNodeWriter {
         }
         writer.writeAttribute(ATTR_DB_TYPE, "cubrid");
 
-        writeTargetConInfoNode(writer, config);
+        writeFileRepositoryNode(writer, config);
 
         writeTargetSchemaNodes(writer, config);
         writeTargetTableNodes(writer, config);
@@ -83,38 +82,12 @@ public class TargetNodeWriter {
         writer.writeEndElement(); // </target>
     }
 
-    private void writeTargetConInfoNode(XMLStreamWriter writer, MigrationConfiguration config)
-            throws XMLStreamException {
-        if (config.targetIsOnline()) {
-            writeJdbcNode(writer, config);
-        } else if (config.targetIsFile()) {
-            writeFileRepositoryNode(writer, config);
-        }
-    }
-
-    private void writeJdbcNode(XMLStreamWriter writer, MigrationConfiguration config)
-            throws XMLStreamException {
-        writer.writeEmptyElement(TAG_JDBC);
-        ConnParameters tcp = config.getTargetConParams();
-        writer.writeAttribute(ATTR_HOST, tcp.getHost());
-        writer.writeAttribute(ATTR_PORT, String.valueOf(tcp.getPort()));
-        writer.writeAttribute(ATTR_DRIVER, tcp.getDriverFileName());
-        writer.writeAttribute(ATTR_NAME, tcp.getDbName());
-        writer.writeAttribute(ATTR_USER, tcp.getConUser());
-        writer.writeAttribute(ATTR_PASSWORD, tcp.getConPassword());
-        writer.writeAttribute(ATTR_CHARSET, tcp.getCharset());
-        writer.writeAttribute(ATTR_TIMEZONE, tcp.getTimeZone());
-        writer.writeAttribute(ATTR_USER_JDBC_URL, tcp.getUserJDBCURL());
-        writer.writeAttribute(
-                ATTR_CREATE_CONSTRAINT_NOW,
-                getBooleanString(config.isCreateConstrainsBeforeData()));
-        writer.writeAttribute(
-                ATTR_WRITE_ERROR_RECORDS, getBooleanString(config.isWriteErrorRecords()));
-        writer.writeAttribute(ATTR_ADD_SCHEMA, getBooleanString(config.isAddUserSchema()));
-    }
-
     private void writeFileRepositoryNode(XMLStreamWriter writer, MigrationConfiguration config)
             throws XMLStreamException {
+        if (!config.targetIsFile()) {
+            return;
+        }
+
         writer.writeEmptyElement(TAG_FILE_REPOSITORY);
         writer.writeAttribute(ATTR_DIR, config.getFileRepositroyPath());
         writer.writeAttribute(ATTR_TIMEZONE, config.getTargetFileTimeZone());


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4787>

### Purpose
마이그레이션 스크립트 XML 파일의 <source>, <target> 태그 내에 있던 연결 정보, 스키마 매핑, 파일 설정을 별도의 태그로 분리합니다.

### Implementation
**Connections (<connections>)**
 - 기존 `<source>`, `<target>` 내부에 존재하던 `<jdbc>` 설정을 최상위 `<connections>` 태그로 분리
 - ConnectionsNodeHandler, ConnectionsNodeWriter 신규 구현

**File Repository (<file_repository>)**
 - 기존`<target>` 내에 있던 파일 출력(오프라인 마이그레이션) 설정을 최상위 `<file_repository>` 태그로 이동
 - TargetFileRepositoryNodeHandler, TargetFileRepositoryNodeWriter 신규 구현

**Schema Mappings (<schemas>)**
 - `<source>` 및 `<target>`에 분산되어 있던 `<schema_info>` 를 최상위 `<schemas> `태그로 이동
 - 스키마 매핑 형식을 `<schema source="..." target="...">` 형태로 단순화함
 - SchemasNodeHandler, SchemasNodeWriter 신규 구현

### Remarks
N/A
