### PR TITLE
[TOOLS-4780] Fix the problem that the file name contains null when migrating from a particular db

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/SourceSQLTableConfig.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/SourceSQLTableConfig.java
@@ -61,11 +61,6 @@ public class SourceSQLTableConfig extends SourceTableConfig {
     }
 
     @Override
-    public String getPathID() {
-        return MigrationConfiguration.SQLTABLE;
-    }
-
-    @Override
     public String getPathID(String schemaName) {
         return MigrationConfiguration.SQLTABLE;
     }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/SourceSQLTableConfig.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/SourceSQLTableConfig.java
@@ -64,4 +64,9 @@ public class SourceSQLTableConfig extends SourceTableConfig {
     public String getPathID() {
         return MigrationConfiguration.SQLTABLE;
     }
+
+    @Override
+    public String getPathID(String schemaName) {
+        return MigrationConfiguration.SQLTABLE;
+    }
 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/SourceTableConfig.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/SourceTableConfig.java
@@ -165,6 +165,17 @@ public class SourceTableConfig {
         return getOwner();
     }
 
+    /**
+     * Get path ID for file naming. If class type is SourceSQLTableConfig, return SQLTABLE,
+     * otherwise return schemaName.
+     *
+     * @param schemaName the schema name to use when class type is not SourceSQLTableConfig
+     * @return path ID string
+     */
+    public String getPathID(String schemaName) {
+        return schemaName;
+    }
+
     public String getComment() {
         return comment;
     }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -217,7 +217,7 @@ public class LoadFileImporter extends OfflineImporter {
                                     schemaName,
                                     stc.getName(),
                                     config.getDataFileExt(),
-                                    stc.getPathID()));
+                                    stc.getPathID(schemaName)));
 
             CurrentDataFileInfo es = tableFiles.get(schemaName + stc.getName());
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4780>

### Purpose
특정 db에서 source table config의 owner가 null로 설정되어 파일 이름이 제대로 출력되지 않는 문제 수정

### Implementation
특정 db에서 source table config의 owner가 null일 시 schema name을 사용하도록 수정

### Remarks
N/A
