### PR TITLE
[TOOLS-4773] fix IllegalArgumentException

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -5446,7 +5446,7 @@ public class MigrationConfiguration {
      * @return Retrieves true If source is a JDBC connection and can't be connected
      */
     public boolean isSourceOfflineMode() {
-        if (sourceIsOnline()) {
+        if (!sourceIsOnline()) {
             return false;
         }
         try {
@@ -5461,7 +5461,7 @@ public class MigrationConfiguration {
      * @return Retrieves true If target is a JDBC connection and can't be connected
      */
     public boolean isTargetOfflineMode() {
-        if (targetIsOnline()) {
+        if (!targetIsOnline()) {
             return false;
         }
         try {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -5446,7 +5446,7 @@ public class MigrationConfiguration {
      * @return Retrieves true If source is a JDBC connection and can't be connected
      */
     public boolean isSourceOfflineMode() {
-        if (!sourceIsOnline()) {
+        if (sourceIsOnline()) {
             return false;
         }
         try {
@@ -5461,7 +5461,7 @@ public class MigrationConfiguration {
      * @return Retrieves true If target is a JDBC connection and can't be connected
      */
     public boolean isTargetOfflineMode() {
-        if (!targetIsOnline()) {
+        if (targetIsOnline()) {
             return false;
         }
         try {

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -90,6 +90,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 
 /**
@@ -619,10 +620,12 @@ public class SQLTableManageView extends AbstractMappingView {
             Catalog catalog = config.getTarCatalog().orElse(config.getSrcCatalog());
 
             if (catalog != null && catalog.getSchemas() != null) {
+                Function<Schema, String> schemaNameMapper =
+                        config.isTargetOfflineMode()
+                                ? Schema::getTargetSchemaName
+                                : Schema::getName;
                 tarSchemaList =
-                        catalog.getSchemas().stream()
-                                .map(Schema::getTargetSchemaName)
-                                .toArray(String[]::new);
+                        catalog.getSchemas().stream().map(schemaNameMapper).toArray(String[]::new);
             }
         }
 

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -621,9 +621,7 @@ public class SQLTableManageView extends AbstractMappingView {
 
             if (catalog != null && catalog.getSchemas() != null) {
                 Function<Schema, String> schemaNameMapper =
-                        config.targetIsOnline()
-                                ? Schema::getName
-                                : Schema::getTargetSchemaName;
+                        config.targetIsOnline() ? Schema::getName : Schema::getTargetSchemaName;
                 tarSchemaList =
                         catalog.getSchemas().stream().map(schemaNameMapper).toArray(String[]::new);
             }

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SQLTableManageView.java
@@ -621,9 +621,9 @@ public class SQLTableManageView extends AbstractMappingView {
 
             if (catalog != null && catalog.getSchemas() != null) {
                 Function<Schema, String> schemaNameMapper =
-                        config.isTargetOfflineMode()
-                                ? Schema::getTargetSchemaName
-                                : Schema::getName;
+                        config.targetIsOnline()
+                                ? Schema::getName
+                                : Schema::getTargetSchemaName;
                 tarSchemaList =
                         catalog.getSchemas().stream().map(schemaNameMapper).toArray(String[]::new);
             }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4773>

### Purpose
- object mapping page에서 target schema 이름을 null로 가져와서 발생하는 Illegal Argument Exception 문제 수정

### Implementation
- target type에 따라 제대로 schema name list를 가져오도록 수정

### Remarks
- Migration Configuration의 isSourceOfflineMode, isTargetOfflineMode 메소드가 의도와 다르게 동작하고 있는 것이 발견되어 해당 이슈에서 함께 수정함
