### PR TITLE
[TOOLS-4791] Fix missing version attribute in target tag

### DIFF
--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
@@ -57,6 +57,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.PrintStream;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
@@ -448,6 +449,11 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
             }
             try {
                 Connection con = tcp.createConnection();
+                DatabaseMetaData metaData = con.getMetaData();
+                int version =
+                        metaData.getDatabaseMajorVersion() * 10
+                                + metaData.getDatabaseMinorVersion();
+                config.setTargetDBVersion(String.valueOf(version));
                 con.close();
             } catch (Exception e) {
                 outPrinter.println("Can't connect database:" + tvalue);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4791>

### Purpose
Script 명령어로 생성한 스크립트 XML에서 <target> 태그의 version 속성이 비어 있는 문제를 해결합니다.

### Implementation

- 대상 DB 정보 초기화 과정에서 버전 정보도 함께 설정되도록 처리 로직을 추가

### Remarks
N/A
