### PR TITLE
[TOOLS-4795] Decouple SchemaTableView from SchemaMappingPage

### DIFF
--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -366,70 +366,83 @@ public class SchemaMappingPage extends MigrationWizardPage {
                         : config.getSrcConnOwner();
 
         if (splitSchema) {
-            pathContext.tableFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "class", null));
-            pathContext.viewFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "vclass", null));
-            pathContext.viewQuerySpecFullName.put(
-                    schemaName,
-                    config.buildLocalFileFullPath(schemaName, "vclass_query_spec", null));
-            pathContext.pkFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "pk", null));
-            pathContext.fkFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "fk", null));
-            pathContext.uniqueIndexFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "uk", null));
-            pathContext.serialFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "serial", null));
-            pathContext.schemaFileListFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "info", null));
-            pathContext.synonymFileListFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "synonym", null));
-
-            for (Grant grant : schema.getGrantList()) {
-                pathContext.grantFileListFullName.putIfAbsent(schemaName, new HashMap<>());
-                Map<String, String> grantMap = pathContext.grantFileListFullName.get(schemaName);
-                grantMap.putIfAbsent(
-                        grant.getSourceObjectOwner(),
-                        config.buildLocalFileFullPath(
-                                schemaName, "grant", grant.getSourceObjectOwner()));
-            }
-
-            pathContext.plcsqlProcedureHeaderFullName.put(
-                    schemaName,
-                    config.buildLocalFileFullPath(schemaName, "procedure_header", null));
-            pathContext.plcsqlFunctionHeaderFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "function_header", null));
-
-            pathContext.plcsqlProcedureFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "procedure", null));
-            pathContext.plcsqlFunctionFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "function", null));
-
-            Map<String, String> procedureFiles = new HashMap<>();
-            schema.getPlcsqlProcedures()
-                    .forEach(
-                            proc ->
-                                    procedureFiles.put(
-                                            proc.getName(),
-                                            config.buildPlcsqlProcedureFileFullPath(
-                                                    schemaName, proc.getName(), "procedure")));
-            pathContext.plcsqlProcedureFileListFullName.put(schemaName, procedureFiles);
-
-            Map<String, String> functionFiles = new HashMap<>();
-            schema.getPlcsqlFunctions()
-                    .forEach(
-                            func ->
-                                    functionFiles.put(
-                                            func.getName(),
-                                            config.buildPlcsqlProcedureFileFullPath(
-                                                    schemaName, func.getName(), "function")));
-            pathContext.plcsqlFunctionFileListFullName.put(schemaName, functionFiles);
-
+            populateSplitSchemaPaths(schema, schemaName, pathContext);
         } else {
             pathContext.schemaFullName.put(
                     schemaName, config.buildLocalFileFullPath(schemaName, "schema", null));
         }
+
+        populateDataAndIndexPaths(schema, schemaName, pathContext);
+    }
+
+    private void populateSplitSchemaPaths(
+            Schema schema, String schemaName, OfflineFilePathContext pathContext) {
+        pathContext.tableFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "class", null));
+        pathContext.viewFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "vclass", null));
+        pathContext.viewQuerySpecFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "vclass_query_spec", null));
+        pathContext.pkFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "pk", null));
+        pathContext.fkFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "fk", null));
+        pathContext.uniqueIndexFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "uk", null));
+        pathContext.serialFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "serial", null));
+        pathContext.schemaFileListFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "info", null));
+        pathContext.synonymFileListFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "synonym", null));
+
+        for (Grant grant : schema.getGrantList()) {
+            pathContext.grantFileListFullName.putIfAbsent(schemaName, new HashMap<>());
+            Map<String, String> grantMap = pathContext.grantFileListFullName.get(schemaName);
+            grantMap.putIfAbsent(
+                    grant.getSourceObjectOwner(),
+                    config.buildLocalFileFullPath(
+                            schemaName, "grant", grant.getSourceObjectOwner()));
+        }
+
+        populatePlcsqlPaths(schema, schemaName, pathContext);
+    }
+
+    private void populatePlcsqlPaths(
+            Schema schema, String schemaName, OfflineFilePathContext pathContext) {
+        pathContext.plcsqlProcedureHeaderFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "procedure_header", null));
+        pathContext.plcsqlFunctionHeaderFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "function_header", null));
+
+        pathContext.plcsqlProcedureFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "procedure", null));
+        pathContext.plcsqlFunctionFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "function", null));
+
+        Map<String, String> procedureFiles = new HashMap<>();
+        schema.getPlcsqlProcedures()
+                .forEach(
+                        proc ->
+                                procedureFiles.put(
+                                        proc.getName(),
+                                        config.buildPlcsqlProcedureFileFullPath(
+                                                schemaName, proc.getName(), "procedure")));
+        pathContext.plcsqlProcedureFileListFullName.put(schemaName, procedureFiles);
+
+        Map<String, String> functionFiles = new HashMap<>();
+        schema.getPlcsqlFunctions()
+                .forEach(
+                        func ->
+                                functionFiles.put(
+                                        func.getName(),
+                                        config.buildPlcsqlProcedureFileFullPath(
+                                                schemaName, func.getName(), "function")));
+        pathContext.plcsqlFunctionFileListFullName.put(schemaName, functionFiles);
+    }
+
+    private void populateDataAndIndexPaths(
+            Schema schema, String schemaName, OfflineFilePathContext pathContext) {
         if (config.isOneTableOneFile()) {
             List<String> tableList = new ArrayList<>();
             schema.getTables()

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -31,177 +31,39 @@
 package com.cubrid.cubridmigration.ui.wizard.page;
 
 import com.cubrid.common.log.LogUtil;
-import com.cubrid.common.ui.swt.table.celleditor.CheckboxCellEditorFactory;
-import com.cubrid.common.ui.swt.table.celleditor.EditableComboBoxCellEditor;
-import com.cubrid.common.ui.swt.table.listener.CheckBoxColumnSelectionListener;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
 import com.cubrid.cubridmigration.core.dbobject.Grant;
 import com.cubrid.cubridmigration.core.dbobject.Schema;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
-import com.cubrid.cubridmigration.ui.common.CompositeUtils;
-import com.cubrid.cubridmigration.ui.common.dialog.DetailMessageDialog;
 import com.cubrid.cubridmigration.ui.message.Messages;
 import com.cubrid.cubridmigration.ui.wizard.MigrationWizard;
+import com.cubrid.cubridmigration.ui.wizard.page.view.SchemaTableView;
+import com.cubrid.cubridmigration.ui.wizard.page.view.SchemaTableView.SrcTable;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.dialogs.PageChangedEvent;
 import org.eclipse.jface.dialogs.PageChangingEvent;
-import org.eclipse.jface.viewers.CellEditor;
-import org.eclipse.jface.viewers.ColumnWeightData;
-import org.eclipse.jface.viewers.ComboBoxCellEditor;
-import org.eclipse.jface.viewers.ICellModifier;
-import org.eclipse.jface.viewers.ILabelProviderListener;
-import org.eclipse.jface.viewers.IStructuredContentProvider;
-import org.eclipse.jface.viewers.ITableLabelProvider;
-import org.eclipse.jface.viewers.TableLayout;
-import org.eclipse.jface.viewers.TableViewer;
-import org.eclipse.jface.viewers.TextCellEditor;
-import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Group;
-import org.eclipse.swt.widgets.TableColumn;
-import org.eclipse.swt.widgets.TableItem;
 import org.slf4j.Logger;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 public class SchemaMappingPage extends MigrationWizardPage {
+    private static final Logger LOG = LogUtil.getLogger(SchemaMappingPage.class);
 
-    private Logger logger = LogUtil.getLogger(SchemaMappingPage.class);
-
-    private MigrationWizard wizard = null;
-    private MigrationConfiguration config = null;
-
-    private String[] propertyList = {
-        "",
-        Messages.sourceSchema,
-        Messages.msgNote,
-        Messages.msgSrcType,
-        Messages.targetSchema,
-        Messages.msgTarType
-    };
-    private String[] tarSchemaNameArray = null;
-
-    Catalog srcCatalog;
-    Catalog tarCatalog;
-
-    TableViewer srcTableViewer = null;
-    TableViewer tarTableViewer = null;
-
-    ArrayList<String> tarSchemaNameList = new ArrayList<String>();
-    ArrayList<SrcTable> srcTableList = new ArrayList<SrcTable>();
-
-    List<Schema> srcSchemaList = null;
-    List<Schema> tarSchemaList = null;
-
-    ComboBoxCellEditor comboEditor = null;
-
-    TextCellEditor textEditor = null;
-
-    private boolean firstVisible = true;
-
-    Map<String, String> schemaFullName;
-    Map<String, String> tableFullName;
-    Map<String, String> viewFullName;
-    Map<String, String> viewQuerySpecFullName;
-    Map<String, String> pkFullName;
-    Map<String, String> fkFullName;
-    Map<String, String> dataFullName;
-    Map<String, String> indexFullName;
-    Map<String, String> uniqueIndexFullName;
-    Map<String, String> serialFullName;
-    Map<String, String> updateStatisticFullName;
-    Map<String, String> schemaFileListFullName;
-    Map<String, String> synonymFileListFullName;
-    Map<String, Map<String, String>> grantFileListFullName;
-    Map<String, List<String>> tableDataFileListFullName;
-    Map<String, String> plcsqlProcedureHeaderFullName;
-    Map<String, String> plcsqlFunctionHeaderFullName;
-    Map<String, String> plcsqlProcedureFullName;
-    Map<String, String> plcsqlFunctionFullName;
-    Map<String, Map<String, String>> plcsqlProcedureFileListFullName;
-    Map<String, Map<String, String>> plcsqlFunctionFileListFullName;
-
-    protected class SrcTable {
-        private boolean isSelected;
-
-        private String note;
-
-        private String srcSchema;
-        private String srcDBType;
-
-        private String tarSchema;
-        private String tarDBType;
-
-        public boolean isSelected() {
-            return isSelected;
-        }
-
-        public void setSelected(boolean isSelected) {
-            this.isSelected = isSelected;
-        }
-
-        public String getNote() {
-            return note;
-        }
-
-        public void setNote(String note) {
-            this.note = note;
-        }
-
-        public void setNote(boolean note) {
-            if (note == true) {
-                setNote(Messages.msgGrantSchema);
-            } else {
-                setNote(Messages.msgMainSchema);
-            }
-        }
-
-        public String getSrcSchema() {
-            return srcSchema;
-        }
-
-        public void setSrcSchema(String srcSchema) {
-            this.srcSchema = srcSchema;
-        }
-
-        public String getSrcDBType() {
-            return srcDBType;
-        }
-
-        public void setSrcDBType(String srcDBtype) {
-            this.srcDBType = srcDBtype;
-        }
-
-        public String getTarSchema() {
-            return tarSchema;
-        }
-
-        public void setTarSchema(String tarSchema) {
-            this.tarSchema = tarSchema;
-        }
-
-        public String getTarDBType() {
-            return tarDBType;
-        }
-
-        public void setTarDBType(String tarDBType) {
-            this.tarDBType = tarDBType;
-        }
-    }
+    private MigrationWizard wizard;
+    private MigrationConfiguration config;
+    private SchemaTableView schemaTableView;
+    private final List<SrcTable> srcTableList = new ArrayList<>();
+    private Catalog srcCatalog;
 
     public SchemaMappingPage(String pageName) {
         super(pageName);
@@ -213,336 +75,26 @@ public class SchemaMappingPage extends MigrationWizardPage {
         container.setLayout(new FillLayout());
         container.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
-        createSrcTable(container);
+        schemaTableView = new SchemaTableView(container, getMigrationWizard().getMigrationConfig());
 
         setControl(container);
     }
 
-    private void createSrcTable(Composite container) {
-        Group srcTableViewerGroup = new Group(container, SWT.NONE);
-        srcTableViewerGroup.setLayout(new FillLayout());
-        srcTableViewer = new TableViewer(srcTableViewerGroup, SWT.FULL_SELECTION);
-
-        srcTableViewer.setContentProvider(
-                new IStructuredContentProvider() {
-                    @Override
-                    public Object[] getElements(Object inputElement) {
-                        if (inputElement instanceof List) {
-
-                            @SuppressWarnings("unchecked")
-                            List<SrcTable> schemaObj = (ArrayList<SrcTable>) inputElement;
-
-                            return schemaObj.toArray();
-                        } else {
-                            return new Object[0];
-                        }
-                    }
-
-                    @Override
-                    public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {}
-
-                    @Override
-                    public void dispose() {}
-                });
-
-        srcTableViewer.setLabelProvider(
-                new ITableLabelProvider() {
-                    @Override
-                    public String getColumnText(Object element, int columnIndex) {
-                        SrcTable obj = (SrcTable) element;
-
-                        switch (columnIndex) {
-                            case 0:
-                                return null;
-                            case 1:
-                                return obj.getSrcSchema();
-                            case 2:
-                                return obj.getNote();
-                            case 3:
-                                return obj.getSrcDBType();
-                            case 4:
-                                return obj.getTarSchema().toUpperCase(Locale.US);
-                            case 5:
-                                return obj.getTarDBType();
-                            default:
-                                return null;
-                        }
-                    }
-
-                    @Override
-                    public Image getColumnImage(Object element, int columnIndex) {
-                        SrcTable srcTable = (SrcTable) element;
-
-                        if (columnIndex == 0) {
-                            if (firstVisible) {
-                                if (srcTable.getNote().equals(Messages.msgMainSchema)
-                                        || srcTable.isSelected()) {
-                                    srcTable.setSelected(true);
-                                    return CompositeUtils.CHECK_IMAGE;
-                                } else {
-                                    srcTable.setSelected(false);
-                                    return CompositeUtils.UNCHECK_IMAGE;
-                                }
-                            } else {
-                                if (srcTable.isSelected()) {
-                                    return CompositeUtils.CHECK_IMAGE;
-                                } else {
-                                    return CompositeUtils.UNCHECK_IMAGE;
-                                }
-                            }
-                        }
-                        return null;
-                    }
-
-                    @Override
-                    public void removeListener(ILabelProviderListener listener) {}
-
-                    @Override
-                    public boolean isLabelProperty(Object element, String property) {
-                        return false;
-                    }
-
-                    @Override
-                    public void dispose() {}
-
-                    @Override
-                    public void addListener(ILabelProviderListener listener) {}
-                });
-
-        srcTableViewer.setColumnProperties(propertyList);
-
-        TableLayout tableLayout = new TableLayout();
-
-        tableLayout.addColumnData(new ColumnWeightData(5, true));
-        tableLayout.addColumnData(new ColumnWeightData(20, true));
-        tableLayout.addColumnData(new ColumnWeightData(13, true));
-        tableLayout.addColumnData(new ColumnWeightData(20, true));
-        tableLayout.addColumnData(new ColumnWeightData(20, true));
-        tableLayout.addColumnData(new ColumnWeightData(20, true));
-
-        srcTableViewer.getTable().setLayout(tableLayout);
-        srcTableViewer.getTable().setLinesVisible(true);
-        srcTableViewer.getTable().setHeaderVisible(true);
-
-        TableColumn col1 = new TableColumn(srcTableViewer.getTable(), SWT.LEFT);
-        TableColumn col2 = new TableColumn(srcTableViewer.getTable(), SWT.LEFT);
-        TableColumn col3 = new TableColumn(srcTableViewer.getTable(), SWT.LEFT);
-        TableColumn col4 = new TableColumn(srcTableViewer.getTable(), SWT.LEFT);
-        TableColumn col5 = new TableColumn(srcTableViewer.getTable(), SWT.LEFT);
-        TableColumn col6 = new TableColumn(srcTableViewer.getTable(), SWT.LEFT);
-
-        final SelectionListener[] selectionListeners =
-                new SelectionListener[] {
-                    new CheckBoxColumnSelectionListener(), null, null, null, null, null
-                };
-        CompositeUtils.setTableColumnSelectionListener(srcTableViewer, selectionListeners);
-
-        col1.setImage(CompositeUtils.getCheckImage(false));
-        col2.setText(propertyList[1]);
-        col3.setText(propertyList[2]);
-        col4.setText(propertyList[3]);
-        col5.setText(propertyList[4]);
-        col6.setText(propertyList[5]);
-    }
-
-    private void getSchemaValues() {
-        Catalog targetCatalog = wizard.getTargetCatalog();
-        Catalog sourceCatalog = wizard.getOriginalSourceCatalog();
-
-        List<Schema> targetSchemaList = targetCatalog.getSchemas();
-        List<Schema> sourceSchemaList = sourceCatalog.getSchemas();
-
-        tarSchemaNameList = new ArrayList<String>();
-        ArrayList<String> dropDownSchemaList = new ArrayList<String>();
-
-        for (Schema schema : targetSchemaList) {
-            tarSchemaNameList.add(schema.getName());
-            dropDownSchemaList.add(schema.getName());
-        }
-
-        for (Schema schema : sourceSchemaList) {
-            if (tarSchemaNameList.contains(schema.getName().toUpperCase())) {
-                continue;
-            }
-
-            dropDownSchemaList.add(schema.getName());
-        }
-
-        if (targetCatalog.isDBAGroup()) {
-            tarSchemaNameArray = dropDownSchemaList.toArray(new String[] {});
-
-        } else {
-            tarSchemaNameArray =
-                    new String[] {targetCatalog.getConnectionParameters().getConUser()};
-        }
-    }
-
-    private void setOnlineEditor() {
-        comboEditor =
-                new EditableComboBoxCellEditor(
-                        srcTableViewer.getTable(), tarSchemaNameArray, SWT.READ_ONLY);
-
-        CellEditor[] editors =
-                new CellEditor[] {
-                    new CheckboxCellEditorFactory().getCellEditor(srcTableViewer.getTable()),
-                    null,
-                    null,
-                    null,
-                    comboEditor,
-                    null
-                };
-
-        srcTableViewer.setCellEditors(editors);
-        srcTableViewer.setCellModifier(
-                new ICellModifier() {
-
-                    @Override
-                    public void modify(Object element, String property, Object value) {
-                        TableItem tabItem = (TableItem) element;
-                        SrcTable srcTable = (SrcTable) tabItem.getData();
-
-                        if (property.equals(propertyList[4])) {
-                            srcTable.setTarSchema(returnValue((Integer) value, tabItem));
-                            addSelectCheckboxValue();
-                            srcTableViewer.refresh();
-                        } else if (property.equals(propertyList[0])) {
-                            tabItem.setImage(CompositeUtils.getCheckImage(!srcTable.isSelected));
-                            srcTable.setSelected(!srcTable.isSelected);
-                        }
-                    }
-
-                    @Override
-                    public Object getValue(Object element, String property) {
-                        if (property.equals(propertyList[4])) {
-                            return returnIndex(element);
-                        } else if (property.equals(propertyList[0])) {
-                            return true;
-                        } else {
-                            return null;
-                        }
-                    }
-
-                    @Override
-                    public boolean canModify(Object element, String property) {
-                        if (property.equals(propertyList[4]) || property.equals(propertyList[0])) {
-                            return true;
-                        } else {
-                            return false;
-                        }
-                    }
-
-                    public int returnIndex(Object element) {
-                        if (element instanceof SrcTable) {
-                            SrcTable srcTable = (SrcTable) element;
-
-                            for (int i = 0; i < tarSchemaNameArray.length; i++) {
-                                if (tarSchemaNameArray[i].equals(srcTable.getTarSchema())) {
-                                    return i;
-                                }
-                            }
-                        }
-
-                        return 0;
-                    }
-
-                    public String returnValue(int index, TableItem item) {
-                        return tarSchemaNameArray[index];
-                    }
-
-                    private void addSelectCheckboxValue() {
-                        TableItem[] tableItems = srcTableViewer.getTable().getItems();
-                        for (int i = 0; i < tableItems.length; i++) {
-                            if (tableItems[i].getImage().equals(CompositeUtils.CHECK_IMAGE)) {
-                                srcTableList.get(i).setSelected(true);
-                            } else {
-                                srcTableList.get(i).setSelected(false);
-                            }
-                        }
-                    }
-                });
-    }
-
-    private void setOfflineEditor(boolean isAddUserSchema) {
-        textEditor = new TextCellEditor(srcTableViewer.getTable());
-
-        CellEditor[] editors =
-                new CellEditor[] {
-                    new CheckboxCellEditorFactory().getCellEditor(srcTableViewer.getTable()),
-                    null,
-                    null,
-                    null,
-                    isAddUserSchema ? textEditor : null,
-                    null
-                };
-
-        srcTableViewer.setCellEditors(editors);
-        srcTableViewer.setCellModifier(
-                new ICellModifier() {
-
-                    @Override
-                    public boolean canModify(Object element, String property) {
-                        if (property.equals(propertyList[4]) || property.equals(propertyList[0])) {
-                            return true;
-                        } else {
-                            return false;
-                        }
-                    }
-
-                    @Override
-                    public Object getValue(Object element, String property) {
-                        if (property.equals(propertyList[4])) {
-                            return ((SrcTable) element).getTarSchema().toUpperCase(Locale.US);
-                        } else if (property.equals(propertyList[0])) {
-                            return true;
-                        } else {
-                            return null;
-                        }
-                    }
-
-                    @Override
-                    public void modify(Object element, String property, Object value) {
-                        TableItem tabItem = (TableItem) element;
-                        SrcTable srcTable = (SrcTable) tabItem.getData();
-
-                        if (property.equals(propertyList[4])) {
-                            srcTable.setTarSchema(((String) value).toUpperCase(Locale.US));
-                            addSelectCheckboxValue();
-                            srcTableViewer.refresh();
-                        } else if (property.equals(propertyList[0])) {
-                            tabItem.setImage(CompositeUtils.getCheckImage(!srcTable.isSelected));
-                            srcTable.setSelected(!srcTable.isSelected);
-                        }
-                    }
-
-                    private void addSelectCheckboxValue() {
-                        TableItem[] tableItems = srcTableViewer.getTable().getItems();
-                        for (int i = 0; i < tableItems.length; i++) {
-                            if (tableItems[i].getImage().equals(CompositeUtils.CHECK_IMAGE)) {
-                                srcTableList.get(i).setSelected(true);
-                            } else {
-                                srcTableList.get(i).setSelected(false);
-                            }
-                        }
-                    }
-                });
-    }
-
     private void setOfflineSchemaMappingPage() {
         setOfflineData();
-        setOfflineEditor(config.isAddUserSchema());
+        schemaTableView.updateCellEditors();
+    }
+
+    private void setOnlineSchemaMappingPage() {
+        setOnlineData();
+        schemaTableView.updateCellEditors();
     }
 
     private void setOfflineData() {
-        srcCatalog = wizard.getOriginalSourceCatalog().createCatalog();
-        srcSchemaList = srcCatalog.getSchemas();
-        Map<String, Schema> scriptSchemaMap = config.getScriptSchemaMapping();
-        List<Schema> targetSchemaList = config.getTargetSchemaList();
+        final Catalog catalog = wizard.getOriginalSourceCatalog().createCatalog();
 
-        for (Schema schema : srcSchemaList) {
-            SrcTable srcTable = new SrcTable();
-            srcTable.setSrcDBType(srcCatalog.getDatabaseType().getName());
-            srcTable.setSrcSchema(schema.getName());
-            srcTable.setNote(schema.isGrantorSchema());
+        for (Schema schema : catalog.getSchemas()) {
+            SrcTable srcTable = createSrcTable(catalog, schema);
 
             if (config.targetIsSQL()) {
                 srcTable.setTarDBType(Messages.msgCubridSQL);
@@ -553,100 +105,90 @@ public class SchemaMappingPage extends MigrationWizardPage {
             } else {
                 srcTable.setTarDBType(Messages.msgCubridDump);
             }
-
-            if (!schema.isGrantorSchema()) {
-                srcTableList.add(0, srcTable);
-            } else {
-                srcTableList.add(srcTable);
-            }
-
-            if (scriptSchemaMap.size() != 0) {
-                logger.info("offline script schema");
-                Schema scriptSchema = scriptSchemaMap.get(srcTable.getSrcSchema());
-                if (scriptSchema != null) {
-                    srcTable.setTarSchema(
-                            scriptSchemaMap.get(srcTable.getSrcSchema()).getTargetSchemaName());
-                    srcTable.setSelected(
-                            scriptSchemaMap.get(srcTable.getSrcSchema()).isMigration());
-                }
-
-                if (srcTable.getTarSchema() == null || srcTable.getTarSchema().isEmpty()) {
-                    srcTable.setTarSchema(srcTable.getSrcSchema());
-                }
-
-            } else if (config.isAddUserSchema() && !targetSchemaList.isEmpty()) {
-                for (Schema targetSchema : targetSchemaList) {
-                    if (targetSchema.getName().equals(schema.getName())) {
-                        srcTable.setTarSchema(targetSchema.getTargetSchemaName());
-                        break;
-                    }
-                }
-                if (srcTable.getTarSchema() == null || srcTable.getTarSchema().isEmpty()) {
-                    srcTable.setTarSchema(srcTable.getSrcSchema());
-                }
-            } else {
-                srcTable.setTarSchema(srcTable.getSrcSchema());
-            }
+            setOfflineTargetSchema(srcTable, schema);
         }
     }
 
-    private void setOnlineSchemaMappingPage() {
-        setOnlineData();
-        getSchemaValues();
-        setOnlineEditor();
+    private void setOfflineTargetSchema(SrcTable srcTable, Schema schema) {
+        final Map<String, Schema> scriptSchemaMap = config.getScriptSchemaMapping();
+        final List<Schema> targetSchemaList = config.getTargetSchemaList();
+
+        String tarSchemaName = null;
+        if (!scriptSchemaMap.isEmpty()) {
+            LOG.info("offline script schema");
+            Schema scriptSchema = scriptSchemaMap.get(srcTable.getSrcSchema());
+            if (scriptSchema != null) {
+                tarSchemaName = scriptSchema.getTargetSchemaName();
+                srcTable.setSelected(scriptSchema.isMigration());
+            }
+        } else if (config.isAddUserSchema() && !targetSchemaList.isEmpty()) {
+            Optional<String> result =
+                    targetSchemaList.stream()
+                            .filter(ts -> ts.getName().equals(schema.getName()))
+                            .map(Schema::getTargetSchemaName)
+                            .findFirst();
+            if (result.isPresent()) {
+                tarSchemaName = result.get();
+            }
+        }
+
+        srcTable.setTarSchema(
+                StringUtils.isEmpty(tarSchemaName) ? srcTable.getSrcSchema() : tarSchemaName);
+    }
+
+    private SrcTable createSrcTable(Catalog catalog, Schema schema) {
+        SrcTable srcTable = new SrcTable();
+        srcTable.setSrcDBType(catalog.getDatabaseType().getName());
+        srcTable.setSrcSchema(schema.getName());
+        srcTable.setNote(schema.isGrantorSchema());
+
+        if (!schema.isGrantorSchema()) {
+            srcTableList.add(0, srcTable);
+        } else {
+            srcTableList.add(srcTable);
+        }
+        return srcTable;
     }
 
     private void setOnlineData() {
-        srcCatalog = wizard.getOriginalSourceCatalog().createCatalog();
-        tarCatalog = wizard.getTargetCatalog();
+        final Catalog catalog = wizard.getOriginalSourceCatalog().createCatalog();
+        final Catalog tarCatalog = wizard.getTargetCatalog();
 
-        srcSchemaList = srcCatalog.getSchemas();
-        tarSchemaList = tarCatalog.getSchemas();
-
-        Map<String, Schema> scriptSchemaMap = config.getScriptSchemaMapping();
-
-        for (Schema schema : srcSchemaList) {
-            SrcTable srcTable = new SrcTable();
-            srcTable.setSrcDBType(srcCatalog.getDatabaseType().getName());
-            srcTable.setSrcSchema(schema.getName());
-            srcTable.setNote(schema.isGrantorSchema());
-
-            if (!schema.isGrantorSchema()) {
-                srcTableList.add(0, srcTable);
-            } else {
-                srcTableList.add(srcTable);
-            }
-
+        for (Schema schema : catalog.getSchemas()) {
+            SrcTable srcTable = createSrcTable(catalog, schema);
             srcTable.setTarDBType(tarCatalog.getDatabaseType().getName());
+            setOnlineTargetSchema(srcTable, tarCatalog);
+        }
+    }
 
-            if (scriptSchemaMap.size() != 0) {
-                logger.info("script schema");
+    private void setOnlineTargetSchema(SrcTable srcTable, Catalog tarCatalog) {
+        final Map<String, Schema> scriptSchemaMap = config.getScriptSchemaMapping();
+        if (!scriptSchemaMap.isEmpty()) {
+            LOG.info("script schema");
 
-                Schema scriptSchema = scriptSchemaMap.get(srcTable.getSrcSchema());
-                String tarSchemaName = null;
-                if (scriptSchema != null) {
-                    srcTable.setTarSchema(scriptSchema.getTargetSchemaName().toUpperCase());
-                    tarSchemaName = scriptSchema.getTargetSchemaName().toUpperCase();
-                    srcTable.setSelected(
-                            scriptSchemaMap.get(srcTable.getSrcSchema()).isMigration());
-                }
-
-                if (tarSchemaName == null || tarSchemaName.isEmpty()) {
-                    srcTable.setTarSchema(srcTable.getSrcSchema());
-                }
-
-                logger.info("srcTable target schema : " + srcTable.getTarSchema());
-            } else {
-                int version =
-                        tarCatalog.getVersion().getDbMajorVersion() * 10
-                                + tarCatalog.getVersion().getDbMinorVersion();
-
-                if (tarCatalog.isDBAGroup() && version >= 112) {
-                    srcTable.setTarSchema(srcTable.getSrcSchema());
-                } else {
-                    srcTable.setTarSchema(tarCatalog.getSchemas().get(0).getName());
-                }
+            Schema scriptSchema = scriptSchemaMap.get(srcTable.getSrcSchema());
+            String tarSchemaName = null;
+            if (scriptSchema != null) {
+                tarSchemaName = scriptSchema.getTargetSchemaName().toUpperCase();
+                srcTable.setTarSchema(tarSchemaName);
+                srcTable.setSelected(scriptSchema.isMigration());
             }
+
+            if (StringUtils.isEmpty(tarSchemaName)) {
+                srcTable.setTarSchema(srcTable.getSrcSchema());
+            }
+            LOG.info("srcTable target schema : " + srcTable.getTarSchema());
+            return;
+        }
+
+        int version =
+                tarCatalog.getVersion().getDbMajorVersion() * 10
+                        + tarCatalog.getVersion().getDbMinorVersion();
+
+        if (tarCatalog.isDBAGroup() && version >= 112) {
+            srcTable.setTarSchema(srcTable.getSrcSchema());
+        } else {
+            srcTable.setTarSchema(tarCatalog.getSchemas().get(0).getName());
         }
     }
 
@@ -655,7 +197,7 @@ public class SchemaMappingPage extends MigrationWizardPage {
         wizard = getMigrationWizard();
         config = wizard.getMigrationConfig();
 
-        if (srcTableList != null) {
+        if (!srcTableList.isEmpty()) {
             srcTableList.clear();
         }
 
@@ -667,14 +209,17 @@ public class SchemaMappingPage extends MigrationWizardPage {
             setDescription(Messages.schemaMappingPageDescription);
         }
 
+        schemaTableView.setSrcCatalog(wizard.getOriginalSourceCatalog());
+        schemaTableView.setTarCatalog(wizard.getTargetCatalog());
+        schemaTableView.updateCellEditors();
+
         if (!config.targetIsOnline()) {
             setOfflineSchemaMappingPage();
         } else {
             setOnlineSchemaMappingPage();
         }
 
-        srcTableViewer.setInput(srcTableList);
-        firstVisible = firstVisible ? false : true;
+        schemaTableView.setInput(srcTableList);
     }
 
     @Override
@@ -683,396 +228,252 @@ public class SchemaMappingPage extends MigrationWizardPage {
             return;
         }
         if (isGotoNextPage(event)) {
-            Catalog originalSrcCatlog = wizard.getOriginalSourceCatalog();
-            if (originalSrcCatlog.getSchemas().size() != srcCatalog.getSchemas().size()) {
-                srcCatalog.getSchemas().clear();
-                srcCatalog.setSchemas(originalSrcCatlog.getSchemas());
+            srcCatalog = wizard.getOriginalSourceCatalog().createCatalog();
+            List<SrcTable> currentSrcTables = schemaTableView.getSrcTableList();
+
+            for (SrcTable srcTable : currentSrcTables) {
+                if (!srcTable.isSelected()) {
+                    Schema srcSchema = srcCatalog.getSchemaByName(srcTable.getSrcSchema());
+                    srcCatalog.removeOneSchema(srcSchema);
+                }
             }
+            wizard.setSourceCatalog(srcCatalog);
+
             if (config.targetIsOnline()) {
-                event.doit = saveOnlineData();
+                event.doit = saveOnlineData(currentSrcTables);
             } else {
-                event.doit = saveOfflineData(config.isAddUserSchema(), config.isSplitSchema());
+                event.doit =
+                        saveOfflineData(
+                                config.isAddUserSchema(), config.isSplitSchema(), currentSrcTables);
             }
         }
     }
 
-    private boolean saveOnlineData() {
-        if (!isSelectCheckbox()) {
+    private boolean saveOnlineData(final List<SrcTable> currentSrcTables) {
+        final Catalog tarCatalog = wizard.getTargetCatalog();
+        if (currentSrcTables.stream().noneMatch(SrcTable::isSelected)) {
             MessageDialog.openError(
                     getShell(), Messages.msgError, Messages.msgErrEmptySchemaCheckbox);
             return false;
         }
 
-        List<String> checkNewSchemaDuplicate = new ArrayList<String>();
-        for (SrcTable srcTable : srcTableList) {
-            if (!(tarCatalog.isDbHasUserSchema())) {
-                srcTable.setTarSchema(null);
-                if (!srcTable.isSelected) {
-                    srcCatalog.removeOneSchema(srcCatalog.getSchemaByName(srcTable.getSrcSchema()));
-                }
+        List<String> checkNewSchemaDuplicate = new ArrayList<>();
+        for (SrcTable srcTable : currentSrcTables) {
+            if (!srcTable.isSelected()) {
                 continue;
             }
 
-            if (srcTable.getTarSchema().isEmpty()) {
+            if (!(tarCatalog.isDbHasUserSchema())) {
+                srcTable.setTarSchema(null);
+                continue;
+            }
+
+            if (StringUtils.isEmpty(srcTable.getTarSchema())) {
                 MessageDialog.openError(
                         getShell(), Messages.msgError, Messages.msgErrEmptySchemaName);
                 return false;
             }
 
-            if (!srcTable.isSelected) {
-                Schema srcSchema = srcCatalog.getSchemaByName(srcTable.getSrcSchema());
-                srcCatalog.removeOneSchema(srcSchema);
-                continue;
-            }
-
-            logger.info("src schema : " + srcTable.getSrcSchema());
-            logger.info("tar schema : " + srcTable.getTarSchema());
-
             Schema targetSchema = tarCatalog.getSchemaByName(srcTable.getTarSchema());
-
+            final Schema srcSchema = srcCatalog.getSchemaByName(srcTable.getSrcSchema());
             if (targetSchema != null) {
-                Schema srcSchema = srcCatalog.getSchemaByName(srcTable.getSrcSchema());
                 srcSchema.setTargetSchemaName(targetSchema.getName());
-
             } else {
-                logger.info("need to create a new schema for target db");
                 Schema newSchema = new Schema();
                 newSchema.setName(srcTable.getTarSchema());
                 newSchema.setNewTargetSchema(true);
-
-                Schema srcSchema = srcCatalog.getSchemaByName(srcTable.getSrcSchema());
                 srcSchema.setTargetSchemaName(newSchema.getName());
-
                 if (checkNewSchemaDuplicate.contains(newSchema.getName())) {
                     config.setTarSchemaDuplicate(true);
                     continue;
                 }
-
                 checkNewSchemaDuplicate.add(newSchema.getName());
                 config.setNewTargetSchema(newSchema.getName());
             }
         }
-        wizard.setSourceCatalog(srcCatalog);
-        getMigrationWizard().setSourceDBNode(srcCatalog);
-
+        wizard.setSourceDBNode(srcCatalog);
         return true;
     }
 
-    private boolean saveOfflineData(boolean addUserSchema, boolean splitSchema) {
-        if (!isSelectCheckbox()) {
+    private static class OfflineFilePathContext {
+        final Map<String, String> schemaFullName = new HashMap<>();
+        final Map<String, String> tableFullName = new HashMap<>();
+        final Map<String, String> viewFullName = new HashMap<>();
+        final Map<String, String> viewQuerySpecFullName = new HashMap<>();
+        final Map<String, String> pkFullName = new HashMap<>();
+        final Map<String, String> fkFullName = new HashMap<>();
+        final Map<String, String> dataFullName = new HashMap<>();
+        final Map<String, String> indexFullName = new HashMap<>();
+        final Map<String, String> uniqueIndexFullName = new HashMap<>();
+        final Map<String, String> serialFullName = new HashMap<>();
+        final Map<String, String> updateStatisticFullName = new HashMap<>();
+        final Map<String, String> schemaFileListFullName = new HashMap<>();
+        final Map<String, String> synonymFileListFullName = new HashMap<>();
+        final Map<String, Map<String, String>> grantFileListFullName = new HashMap<>();
+        final Map<String, List<String>> tableDataFileListFullName = new HashMap<>();
+        final Map<String, String> plcsqlProcedureHeaderFullName = new HashMap<>();
+        final Map<String, String> plcsqlFunctionHeaderFullName = new HashMap<>();
+        final Map<String, String> plcsqlProcedureFullName = new HashMap<>();
+        final Map<String, String> plcsqlFunctionFullName = new HashMap<>();
+        final Map<String, Map<String, String>> plcsqlProcedureFileListFullName = new HashMap<>();
+        final Map<String, Map<String, String>> plcsqlFunctionFileListFullName = new HashMap<>();
+    }
+
+    private boolean saveOfflineData(
+            boolean addUserSchema, boolean splitSchema, List<SrcTable> currentSrcTables) {
+        if (currentSrcTables.stream().noneMatch(SrcTable::isSelected)) {
             MessageDialog.openError(
                     getShell(), Messages.msgError, Messages.msgErrEmptySchemaCheckbox);
             return false;
         }
 
-        List<Schema> targetSchemaList = new ArrayList<Schema>();
-        schemaFullName = new HashMap<String, String>();
-        tableFullName = new HashMap<String, String>();
-        viewFullName = new HashMap<String, String>();
-        viewQuerySpecFullName = new HashMap<String, String>();
-        pkFullName = new HashMap<String, String>();
-        fkFullName = new HashMap<String, String>();
-        dataFullName = new HashMap<String, String>();
-        indexFullName = new HashMap<String, String>();
-        uniqueIndexFullName = new HashMap<String, String>();
-        serialFullName = new HashMap<String, String>();
-        updateStatisticFullName = new HashMap<String, String>();
-        schemaFileListFullName = new HashMap<String, String>();
-        synonymFileListFullName = new HashMap<String, String>();
-        grantFileListFullName = new HashMap<String, Map<String, String>>();
-        tableDataFileListFullName = new HashMap<String, List<String>>();
-        plcsqlProcedureFullName = new HashMap<>();
-        plcsqlFunctionFullName = new HashMap<>();
-        plcsqlProcedureHeaderFullName = new HashMap<>();
-        plcsqlFunctionHeaderFullName = new HashMap<>();
-        plcsqlProcedureFileListFullName = new HashMap<>();
-        plcsqlFunctionFileListFullName = new HashMap<>();
+        List<Schema> targetSchemaList = new ArrayList<>();
+        OfflineFilePathContext pathContext = new OfflineFilePathContext();
 
-        for (SrcTable srcTable : srcTableList) {
+        for (SrcTable srcTable : currentSrcTables) {
+            if (!srcTable.isSelected()) {
+                continue;
+            }
+
             String targetSchemaName = srcTable.getTarSchema();
-            if (addUserSchema
-                    && srcTable.isSelected()
-                    && (targetSchemaName == null
-                            || targetSchemaName.isEmpty()
-                            || StringUtils.trimToEmpty(targetSchemaName).equals(""))) {
+            if (addUserSchema && StringUtils.trimToEmpty(targetSchemaName).isEmpty()) {
                 MessageDialog.openError(
                         getShell(), Messages.msgError, Messages.msgErrEmptySchemaName);
                 return false;
-            }
-
-            if (!srcTable.isSelected) {
-                Schema srcSchema = srcCatalog.getSchemaByName(srcTable.getSrcSchema());
-                srcCatalog.removeOneSchema(srcSchema);
-                continue;
             }
 
             Schema schema = srcCatalog.getSchemaByName(srcTable.getSrcSchema());
             schema.setTargetSchemaName(srcTable.getTarSchema());
             targetSchemaList.add(schema);
 
-            String schemaName =
-                    srcCatalog.getDatabaseType().isSupportMultiSchema()
-                            ? srcTable.getSrcSchema()
-                            : config.getSrcConnOwner();
-
-            if (splitSchema) {
-                tableFullName.put(
-                        schemaName, config.buildLocalFileFullPath(schemaName, "class", null));
-                viewFullName.put(
-                        schemaName, config.buildLocalFileFullPath(schemaName, "vclass", null));
-                viewQuerySpecFullName.put(
-                        schemaName,
-                        config.buildLocalFileFullPath(schemaName, "vclass_query_spec", null));
-                pkFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "pk", null));
-                fkFullName.put(schemaName, config.buildLocalFileFullPath(schemaName, "fk", null));
-                uniqueIndexFullName.put(
-                        schemaName, config.buildLocalFileFullPath(schemaName, "uk", null));
-                serialFullName.put(
-                        schemaName, config.buildLocalFileFullPath(schemaName, "serial", null));
-                schemaFileListFullName.put(
-                        schemaName, config.buildLocalFileFullPath(schemaName, "info", null));
-                synonymFileListFullName.put(
-                        schemaName, config.buildLocalFileFullPath(schemaName, "synonym", null));
-
-                List<Grant> grantList = schema.getGrantList();
-                for (Grant grant : grantList) {
-                    if (!grantFileListFullName.containsKey(schemaName)) {
-                        grantFileListFullName.put(schemaName, new HashMap<String, String>());
-                    }
-                    Map<String, String> grantMap = grantFileListFullName.get(schemaName);
-                    if (!grantMap.containsKey(grant.getSourceObjectOwner())) {
-                        grantMap.put(
-                                grant.getSourceObjectOwner(),
-                                config.buildLocalFileFullPath(
-                                        schemaName, "grant", grant.getSourceObjectOwner()));
-                    }
-                }
-
-                plcsqlProcedureHeaderFullName.put(
-                        schemaName,
-                        config.buildLocalFileFullPath(schemaName, "procedure_header", null));
-                plcsqlFunctionHeaderFullName.put(
-                        schemaName,
-                        config.buildLocalFileFullPath(schemaName, "function_header", null));
-
-                plcsqlProcedureFullName.put(
-                        schemaName, config.buildLocalFileFullPath(schemaName, "procedure", null));
-                plcsqlFunctionFullName.put(
-                        schemaName, config.buildLocalFileFullPath(schemaName, "function", null));
-
-                Map<String, String> procedureFiles = new HashMap<>();
-                schema.getPlcsqlProcedures()
-                        .forEach(
-                                proc ->
-                                        procedureFiles.put(
-                                                proc.getName(),
-                                                config.buildPlcsqlProcedureFileFullPath(
-                                                        schemaName, proc.getName(), "procedure")));
-                plcsqlProcedureFileListFullName.put(schemaName, procedureFiles);
-
-                Map<String, String> functionFiles = new HashMap<>();
-                schema.getPlcsqlFunctions()
-                        .forEach(
-                                func ->
-                                        functionFiles.put(
-                                                func.getName(),
-                                                config.buildPlcsqlProcedureFileFullPath(
-                                                        schemaName, func.getName(), "function")));
-                plcsqlFunctionFileListFullName.put(schemaName, functionFiles);
-
-            } else {
-                schemaFullName.put(
-                        schemaName, config.buildLocalFileFullPath(schemaName, "schema", null));
-            }
-            if (config.isOneTableOneFile()) {
-                List<String> tableList = new ArrayList<>();
-                schema.getTables()
-                        .forEach(
-                                table ->
-                                        tableList.add(
-                                                config.buildDataFileFullPath(
-                                                        schemaName, table.getName())));
-                tableDataFileListFullName.put(schemaName, tableList);
-            }
-            dataFullName.put(schemaName, config.buildDataFileFullPath(schemaName, "objects"));
-            indexFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "indexes", null));
-            updateStatisticFullName.put(
-                    schemaName, config.buildLocalFileFullPath(schemaName, "updatestatistic", null));
+            populateFilePathsForSchema(schema, srcTable.getSrcSchema(), splitSchema, pathContext);
         }
 
-        if (!checkFileRepository()) {
-            return false;
-        }
+        updateConfigurationWithPaths(targetSchemaList, pathContext);
+        wizard.setSourceDBNode(srcCatalog);
 
+        return true;
+    }
+
+    private void populateFilePathsForSchema(
+            Schema schema,
+            String srcSchemaName,
+            boolean splitSchema,
+            OfflineFilePathContext pathContext) {
+        String schemaName =
+                srcCatalog.getDatabaseType().isSupportMultiSchema()
+                        ? srcSchemaName
+                        : config.getSrcConnOwner();
+
+        if (splitSchema) {
+            pathContext.tableFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "class", null));
+            pathContext.viewFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "vclass", null));
+            pathContext.viewQuerySpecFullName.put(
+                    schemaName,
+                    config.buildLocalFileFullPath(schemaName, "vclass_query_spec", null));
+            pathContext.pkFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "pk", null));
+            pathContext.fkFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "fk", null));
+            pathContext.uniqueIndexFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "uk", null));
+            pathContext.serialFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "serial", null));
+            pathContext.schemaFileListFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "info", null));
+            pathContext.synonymFileListFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "synonym", null));
+
+            for (Grant grant : schema.getGrantList()) {
+                pathContext.grantFileListFullName.putIfAbsent(schemaName, new HashMap<>());
+                Map<String, String> grantMap = pathContext.grantFileListFullName.get(schemaName);
+                grantMap.putIfAbsent(
+                        grant.getSourceObjectOwner(),
+                        config.buildLocalFileFullPath(
+                                schemaName, "grant", grant.getSourceObjectOwner()));
+            }
+
+            pathContext.plcsqlProcedureHeaderFullName.put(
+                    schemaName,
+                    config.buildLocalFileFullPath(schemaName, "procedure_header", null));
+            pathContext.plcsqlFunctionHeaderFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "function_header", null));
+
+            pathContext.plcsqlProcedureFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "procedure", null));
+            pathContext.plcsqlFunctionFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "function", null));
+
+            Map<String, String> procedureFiles = new HashMap<>();
+            schema.getPlcsqlProcedures()
+                    .forEach(
+                            proc ->
+                                    procedureFiles.put(
+                                            proc.getName(),
+                                            config.buildPlcsqlProcedureFileFullPath(
+                                                    schemaName, proc.getName(), "procedure")));
+            pathContext.plcsqlProcedureFileListFullName.put(schemaName, procedureFiles);
+
+            Map<String, String> functionFiles = new HashMap<>();
+            schema.getPlcsqlFunctions()
+                    .forEach(
+                            func ->
+                                    functionFiles.put(
+                                            func.getName(),
+                                            config.buildPlcsqlProcedureFileFullPath(
+                                                    schemaName, func.getName(), "function")));
+            pathContext.plcsqlFunctionFileListFullName.put(schemaName, functionFiles);
+
+        } else {
+            pathContext.schemaFullName.put(
+                    schemaName, config.buildLocalFileFullPath(schemaName, "schema", null));
+        }
+        if (config.isOneTableOneFile()) {
+            List<String> tableList = new ArrayList<>();
+            schema.getTables()
+                    .forEach(
+                            table ->
+                                    tableList.add(
+                                            config.buildDataFileFullPath(
+                                                    schemaName, table.getName())));
+            pathContext.tableDataFileListFullName.put(schemaName, tableList);
+        }
+        pathContext.dataFullName.put(
+                schemaName, config.buildDataFileFullPath(schemaName, "objects"));
+        pathContext.indexFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "indexes", null));
+        pathContext.updateStatisticFullName.put(
+                schemaName, config.buildLocalFileFullPath(schemaName, "updatestatistic", null));
+    }
+
+    private void updateConfigurationWithPaths(
+            List<Schema> targetSchemaList, OfflineFilePathContext pathContext) {
         if (config.getTargetSchemaList().size() > 0) {
             config.removeTargetSchemaList();
         }
         config.setTargetSchemaList(targetSchemaList);
-        config.setTargetSchemaFileName(schemaFullName);
-        config.setTargetTableFileName(tableFullName);
-        config.setTargetViewFileName(viewFullName);
-        config.setTargetViewQuerySpecFileName(viewQuerySpecFullName);
-        config.setTargetDataFileName(dataFullName);
-        config.setTargetIndexFileName(indexFullName);
-        config.setTargetPkFileName(pkFullName);
-        config.setTargetFkFileName(fkFullName);
-        config.setTargetUniqueIndexFileName(uniqueIndexFullName);
-        config.setTargetSerialFileName(serialFullName);
-        config.setTargetUpdateStatisticFileName(updateStatisticFullName);
-        config.setTargetSchemaFileListName(schemaFileListFullName);
-        config.setTargetSynonymFileName(synonymFileListFullName);
-        config.setTargetGrantFileName(grantFileListFullName);
-        config.setTargetTableDataFileName(tableDataFileListFullName);
-        config.setTargetAllPlcsqlProcedureHeaderFileName(plcsqlProcedureHeaderFullName);
-        config.setTargetAllPlcsqlFunctionHeaderFileName(plcsqlFunctionHeaderFullName);
-        config.setTargetAllPlcsqlProcedureFileName(plcsqlProcedureFullName);
-        config.setTargetAllPlcsqlFunctionFileName(plcsqlFunctionFullName);
-        config.setTargetPlcsqlProcedureFileName(plcsqlProcedureFileListFullName);
-        config.setTargetPlcsqlFunctionFileName(plcsqlFunctionFileListFullName);
-
-        wizard.setSourceCatalog(srcCatalog);
-        getMigrationWizard().setSourceDBNode(srcCatalog);
-
-        return true;
-    }
-
-    /**
-     * Check if overwriting to a file
-     *
-     * @param schemaFullName
-     * @param dataFullName
-     * @param indexFullName
-     * @return boolean
-     */
-    private boolean checkFileRepository() {
-        StringBuffer buffer = new StringBuffer();
-
-        if (srcCatalog.getDatabaseType().isSupportMultiSchema()) {
-            for (SrcTable srcTable : srcTableList) {
-                if (!srcTable.isSelected) {
-                    continue;
-                }
-                duplicateFilePath(buffer, srcTable.getSrcSchema());
-            }
-        } else {
-            duplicateFilePath(buffer, config.getSrcConnOwner());
-        }
-
-        if (buffer.length() > 0) {
-            return DetailMessageDialog.openConfirm(
-                    getShell(),
-                    Messages.msgConfirmation,
-                    Messages.msgDuplicateFileDetail,
-                    buffer.toString());
-        }
-        return true;
-    }
-
-    private void duplicateFilePath(StringBuffer buffer, String schemaName) {
-        String lineSeparator = System.getProperty("line.separator");
-        try {
-            if (config.isSplitSchema()) {
-                File tableFile = new File(tableFullName.get(schemaName));
-                File viewFile = new File(viewFullName.get(schemaName));
-                File viewQuerySpecFile = new File(viewQuerySpecFullName.get(schemaName));
-                File pkFile = new File(pkFullName.get(schemaName));
-                File fkFile = new File(fkFullName.get(schemaName));
-                File uniqueIndexFile = new File(uniqueIndexFullName.get(schemaName));
-                File serialFile = new File(serialFullName.get(schemaName));
-                File infoFile = new File(schemaFileListFullName.get(schemaName));
-                File synonymFile = new File(synonymFileListFullName.get(schemaName));
-                Map<String, String> grantFilePaths = grantFileListFullName.get(schemaName);
-                Iterator<String> keys = null;
-                if (grantFilePaths != null) {
-                    keys = grantFilePaths.keySet().iterator();
-                }
-
-                if (tableFile.exists()) {
-                    buffer.append(tableFile.getCanonicalPath()).append(lineSeparator);
-                }
-                if (viewFile.exists()) {
-                    buffer.append(viewFile.getCanonicalPath()).append(lineSeparator);
-                }
-                if (viewQuerySpecFile.exists()) {
-                    buffer.append(viewQuerySpecFile.getCanonicalPath()).append(lineSeparator);
-                }
-                if (pkFile.exists()) {
-                    buffer.append(pkFile.getCanonicalPath()).append(lineSeparator);
-                }
-                if (fkFile.exists()) {
-                    buffer.append(fkFile.getCanonicalPath()).append(lineSeparator);
-                }
-                if (uniqueIndexFile.exists()) {
-                    buffer.append(uniqueIndexFile.getCanonicalPath()).append(lineSeparator);
-                }
-                if (serialFile.exists()) {
-                    buffer.append(serialFile.getCanonicalPath()).append(lineSeparator);
-                }
-                if (infoFile.exists()) {
-                    buffer.append(infoFile.getCanonicalPath()).append(lineSeparator);
-                }
-                if (synonymFile.exists()) {
-                    buffer.append(synonymFile.getCanonicalPath()).append(lineSeparator);
-                }
-                if (keys != null) {
-                    while (keys.hasNext()) {
-                        File grantFile = new File(grantFilePaths.get(keys.next()));
-                        if (grantFile.exists()) {
-                            buffer.append(grantFile.getCanonicalPath()).append(lineSeparator);
-                        }
-                    }
-                }
-            } else {
-                File schemaFile = new File(schemaFullName.get(schemaName));
-                if (schemaFile.exists()) {
-                    buffer.append(schemaFile.getCanonicalPath()).append(lineSeparator);
-                }
-            }
-
-            if (config.isOneTableOneFile()) {
-                for (String tableDataFilePath : tableDataFileListFullName.get(schemaName)) {
-                    File tableDataFile = new File(tableDataFilePath);
-                    if (tableDataFile.exists()) {
-                        buffer.append(tableDataFile.getCanonicalPath()).append(lineSeparator);
-                    }
-                }
-            } else {
-                File dataFile = new File(dataFullName.get(schemaName));
-                if (dataFile.exists()) {
-                    buffer.append(dataFile.getCanonicalPath()).append(lineSeparator);
-                }
-            }
-
-            File indexFile = new File(indexFullName.get(schemaName));
-            File updateStatisticFile = new File(updateStatisticFullName.get(schemaName));
-
-            if (indexFile.exists()) {
-                buffer.append(indexFile.getCanonicalPath()).append(lineSeparator);
-            }
-            if (updateStatisticFile.exists()) {
-                buffer.append(updateStatisticFile.getCanonicalPath()).append(lineSeparator);
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private boolean isSelectCheckbox() {
-        TableItem[] tableItems = srcTableViewer.getTable().getItems();
-        for (int i = 0; i < tableItems.length; i++) {
-            if (tableItems[i].getImage().equals(CompositeUtils.CHECK_IMAGE)) {
-                srcTableList.get(i).setSelected(true);
-            } else {
-                srcTableList.get(i).setSelected(false);
-            }
-        }
-
-        for (SrcTable srcTable : srcTableList) {
-            if (srcTable.isSelected) {
-                return true;
-            }
-        }
-        return false;
+        config.setTargetSchemaFileName(pathContext.schemaFullName);
+        config.setTargetTableFileName(pathContext.tableFullName);
+        config.setTargetViewFileName(pathContext.viewFullName);
+        config.setTargetViewQuerySpecFileName(pathContext.viewQuerySpecFullName);
+        config.setTargetDataFileName(pathContext.dataFullName);
+        config.setTargetIndexFileName(pathContext.indexFullName);
+        config.setTargetPkFileName(pathContext.pkFullName);
+        config.setTargetFkFileName(pathContext.fkFullName);
+        config.setTargetUniqueIndexFileName(pathContext.uniqueIndexFullName);
+        config.setTargetSerialFileName(pathContext.serialFullName);
+        config.setTargetUpdateStatisticFileName(pathContext.updateStatisticFullName);
+        config.setTargetSchemaFileListName(pathContext.schemaFileListFullName);
+        config.setTargetSynonymFileName(pathContext.synonymFileListFullName);
+        config.setTargetGrantFileName(pathContext.grantFileListFullName);
+        config.setTargetTableDataFileName(pathContext.tableDataFileListFullName);
+        config.setTargetAllPlcsqlProcedureHeaderFileName(pathContext.plcsqlProcedureHeaderFullName);
+        config.setTargetAllPlcsqlFunctionHeaderFileName(pathContext.plcsqlFunctionHeaderFullName);
+        config.setTargetAllPlcsqlProcedureFileName(pathContext.plcsqlProcedureFullName);
+        config.setTargetAllPlcsqlFunctionFileName(pathContext.plcsqlFunctionFullName);
+        config.setTargetPlcsqlProcedureFileName(pathContext.plcsqlProcedureFileListFullName);
+        config.setTargetPlcsqlFunctionFileName(pathContext.plcsqlFunctionFileListFullName);
     }
 }

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SchemaTableView.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/SchemaTableView.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.ui.wizard.page.view;
+
+import com.cubrid.common.ui.swt.table.celleditor.CheckboxCellEditorFactory;
+import com.cubrid.common.ui.swt.table.listener.CheckBoxColumnSelectionListener;
+import com.cubrid.cubridmigration.core.dbobject.Catalog;
+import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+import com.cubrid.cubridmigration.ui.common.CompositeUtils;
+import com.cubrid.cubridmigration.ui.message.Messages;
+
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.jface.viewers.ColumnWeightData;
+import org.eclipse.jface.viewers.ComboBoxCellEditor;
+import org.eclipse.jface.viewers.ICellModifier;
+import org.eclipse.jface.viewers.ILabelProviderListener;
+import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.ITableLabelProvider;
+import org.eclipse.jface.viewers.TableLayout;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TextCellEditor;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.TableItem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+public class SchemaTableView {
+
+    private static final String MSG_GRANT_SCHEMA = Messages.msgGrantSchema;
+    private static final String MSG_MAIN_SCHEMA = Messages.msgMainSchema;
+
+    private final TableViewer srcTableViewer;
+    private final String[] propertyList = {
+        "",
+        Messages.sourceSchema,
+        Messages.msgNote,
+        Messages.msgSrcType,
+        Messages.targetSchema,
+        Messages.msgTarType
+    };
+    private String[] tarSchemaNameArray;
+    private final MigrationConfiguration config;
+    private Catalog srcCatalog;
+    private Catalog tarCatalog;
+    private SchemaLabelProvider labelProvider;
+
+    public static class SrcTable {
+        private boolean isSelected;
+        private String note;
+        private String srcSchema;
+        private String srcDBType;
+        private String tarSchema;
+        private String tarDBType;
+
+        public boolean isSelected() {
+            return isSelected;
+        }
+
+        public void setSelected(boolean isSelected) {
+            this.isSelected = isSelected;
+        }
+
+        public String getNote() {
+            return note;
+        }
+
+        public void setNote(String note) {
+            this.note = note;
+        }
+
+        public void setNote(boolean note) {
+            this.note = note ? MSG_GRANT_SCHEMA : MSG_MAIN_SCHEMA;
+        }
+
+        public String getSrcSchema() {
+            return srcSchema;
+        }
+
+        public void setSrcSchema(String srcSchema) {
+            this.srcSchema = srcSchema;
+        }
+
+        public String getSrcDBType() {
+            return srcDBType;
+        }
+
+        public void setSrcDBType(String srcDBtype) {
+            this.srcDBType = srcDBtype;
+        }
+
+        public String getTarSchema() {
+            return tarSchema;
+        }
+
+        public void setTarSchema(String tarSchema) {
+            this.tarSchema = tarSchema;
+        }
+
+        public String getTarDBType() {
+            return tarDBType;
+        }
+
+        public void setTarDBType(String tarDBType) {
+            this.tarDBType = tarDBType;
+        }
+    }
+
+    private final class SchemaContentProvider implements IStructuredContentProvider {
+        @Override
+        public Object[] getElements(Object inputElement) {
+            if (inputElement instanceof List) {
+                @SuppressWarnings("unchecked")
+                final List<SrcTable> schemaObj = (ArrayList<SrcTable>) inputElement;
+                return schemaObj.toArray();
+            }
+            return new Object[0];
+        }
+
+        @Override
+        public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+            // No action needed
+        }
+
+        @Override
+        public void dispose() {
+            // No action needed
+        }
+    }
+
+    private final class SchemaLabelProvider implements ITableLabelProvider {
+        private boolean firstVisible = true;
+
+        public void setFirstVisible(boolean firstVisible) {
+            this.firstVisible = firstVisible;
+        }
+
+        @Override
+        public String getColumnText(Object element, int columnIndex) {
+            final SrcTable obj = (SrcTable) element;
+            switch (columnIndex) {
+                case 1:
+                    return obj.getSrcSchema();
+                case 2:
+                    return obj.getNote();
+                case 3:
+                    return obj.getSrcDBType();
+                case 4:
+                    return obj.getTarSchema().toUpperCase(Locale.US);
+                case 5:
+                    return obj.getTarDBType();
+                case 0:
+                default:
+                    return null;
+            }
+        }
+
+        @Override
+        public Image getColumnImage(Object element, int columnIndex) {
+            if (columnIndex == 0) {
+                final SrcTable srcTable = (SrcTable) element;
+                if (firstVisible) {
+                    final boolean isSelected =
+                            MSG_MAIN_SCHEMA.equals(srcTable.getNote()) || srcTable.isSelected();
+                    srcTable.setSelected(isSelected);
+                    return isSelected ? CompositeUtils.CHECK_IMAGE : CompositeUtils.UNCHECK_IMAGE;
+                }
+                return srcTable.isSelected()
+                        ? CompositeUtils.CHECK_IMAGE
+                        : CompositeUtils.UNCHECK_IMAGE;
+            }
+            return null;
+        }
+
+        @Override
+        public void removeListener(ILabelProviderListener listener) {
+            // No action needed
+        }
+
+        @Override
+        public boolean isLabelProperty(Object element, String property) {
+            return false;
+        }
+
+        @Override
+        public void dispose() {
+            // No action needed
+        }
+
+        @Override
+        public void addListener(ILabelProviderListener listener) {
+            // No action needed
+        }
+    }
+
+    private final class SchemaCellModifier implements ICellModifier {
+        @Override
+        public boolean canModify(Object element, String property) {
+            return propertyList[4].equals(property) || propertyList[0].equals(property);
+        }
+
+        @Override
+        public Object getValue(Object element, String property) {
+            final SrcTable srcTable = (SrcTable) element;
+            if (propertyList[4].equals(property)) {
+                if (config.targetIsOnline()) {
+                    for (int i = 0; i < tarSchemaNameArray.length; i++) {
+                        if (tarSchemaNameArray[i].equalsIgnoreCase(srcTable.getTarSchema())) {
+                            return i;
+                        }
+                    }
+                    return 0; // Default to first item if not found
+                }
+                return srcTable.getTarSchema().toUpperCase(Locale.US);
+            } else if (propertyList[0].equals(property)) {
+                return srcTable.isSelected();
+            }
+            return null;
+        }
+
+        @Override
+        public void modify(Object element, String property, Object value) {
+            final TableItem tabItem = (TableItem) element;
+            final SrcTable srcTable = (SrcTable) tabItem.getData();
+
+            if (propertyList[4].equals(property)) {
+                if (config.targetIsOnline()) {
+                    srcTable.setTarSchema(tarSchemaNameArray[(Integer) value]);
+                } else {
+                    srcTable.setTarSchema(((String) value).toUpperCase(Locale.US));
+                }
+                srcTableViewer.refresh();
+            } else if (propertyList[0].equals(property)) {
+                final boolean newSelectedState = !srcTable.isSelected();
+                tabItem.setImage(CompositeUtils.getCheckImage(newSelectedState));
+                srcTable.setSelected(newSelectedState);
+            }
+        }
+    }
+
+    public SchemaTableView(Composite parent, MigrationConfiguration config) {
+        this.config = config;
+        final Group srcTableViewerGroup = new Group(parent, SWT.NONE);
+        srcTableViewerGroup.setLayout(new FillLayout());
+        srcTableViewer = new TableViewer(srcTableViewerGroup, SWT.FULL_SELECTION);
+
+        srcTableViewer.setContentProvider(new SchemaContentProvider());
+        labelProvider = new SchemaLabelProvider();
+        srcTableViewer.setLabelProvider(labelProvider);
+        srcTableViewer.setColumnProperties(propertyList);
+
+        final TableLayout tableLayout = new TableLayout();
+        tableLayout.addColumnData(new ColumnWeightData(5, true));
+        tableLayout.addColumnData(new ColumnWeightData(20, true));
+        tableLayout.addColumnData(new ColumnWeightData(13, true));
+        tableLayout.addColumnData(new ColumnWeightData(20, true));
+        tableLayout.addColumnData(new ColumnWeightData(20, true));
+        tableLayout.addColumnData(new ColumnWeightData(20, true));
+
+        srcTableViewer.getTable().setLayout(tableLayout);
+        srcTableViewer.getTable().setLinesVisible(true);
+        srcTableViewer.getTable().setHeaderVisible(true);
+
+        createTableColumn(propertyList[0], SWT.LEFT, new CheckBoxColumnSelectionListener());
+        srcTableViewer.getTable().getColumn(0).setImage(CompositeUtils.UNCHECK_IMAGE);
+        createTableColumn(propertyList[1], SWT.LEFT, null);
+        createTableColumn(propertyList[2], SWT.LEFT, null);
+        createTableColumn(propertyList[3], SWT.LEFT, null);
+        createTableColumn(propertyList[4], SWT.LEFT, null);
+        createTableColumn(propertyList[5], SWT.LEFT, null);
+
+        updateCellEditors();
+    }
+
+    private void createTableColumn(String text, int style, SelectionListener listener) {
+        final TableColumn column = new TableColumn(srcTableViewer.getTable(), style);
+        column.setText(text);
+        if (listener != null) {
+            column.addSelectionListener(listener);
+        }
+    }
+
+    public void updateCellEditors() {
+        if (config.targetIsOnline()) {
+            tarSchemaNameArray = getDropdownSchemaNames();
+            final CellEditor[] editors =
+                    new CellEditor[] {
+                        new CheckboxCellEditorFactory().getCellEditor(srcTableViewer.getTable()),
+                        null,
+                        null,
+                        null,
+                        new ComboBoxCellEditor(
+                                srcTableViewer.getTable(), tarSchemaNameArray, SWT.READ_ONLY),
+                        null
+                    };
+            srcTableViewer.setCellEditors(editors);
+        } else {
+            final CellEditor[] editors =
+                    new CellEditor[] {
+                        new CheckboxCellEditorFactory().getCellEditor(srcTableViewer.getTable()),
+                        null,
+                        null,
+                        null,
+                        config.isAddUserSchema()
+                                ? new TextCellEditor(srcTableViewer.getTable())
+                                : null,
+                        null
+                    };
+            srcTableViewer.setCellEditors(editors);
+        }
+        srcTableViewer.setCellModifier(new SchemaCellModifier());
+    }
+
+    private String[] getDropdownSchemaNames() {
+        final List<String> dropDownSchemaList = new ArrayList<>();
+        final Optional<Catalog> targetCatalogOptional = Optional.ofNullable(this.tarCatalog);
+        targetCatalogOptional.ifPresent(
+                targetCatalog ->
+                        targetCatalog
+                                .getSchemas()
+                                .forEach(schema -> dropDownSchemaList.add(schema.getName())));
+
+        final Optional<Catalog> srcCatalogOptional = Optional.ofNullable(this.srcCatalog);
+        srcCatalogOptional.ifPresent(
+                srcCatalog ->
+                        srcCatalog
+                                .getSchemas()
+                                .forEach(
+                                        schema -> {
+                                            final String schemaName =
+                                                    schema.getName().toUpperCase(Locale.US);
+                                            if (!dropDownSchemaList.contains(schemaName)) {
+                                                dropDownSchemaList.add(schemaName);
+                                            }
+                                        }));
+
+        return config.isTargetDBAGroup()
+                ? dropDownSchemaList.toArray(String[]::new)
+                : new String[] {config.getTargetConParams().getConUser().toUpperCase(Locale.US)};
+    }
+
+    public void setSrcCatalog(Catalog srcCatalog) {
+        this.srcCatalog = srcCatalog;
+    }
+
+    public void setTarCatalog(Catalog tarCatalog) {
+        this.tarCatalog = tarCatalog;
+    }
+
+    public void setInput(List<SrcTable> input) {
+        srcTableViewer.setInput(input);
+        labelProvider.setFirstVisible(false);
+    }
+
+    public TableViewer getViewer() {
+        return srcTableViewer;
+    }
+
+    public List<SrcTable> getSrcTableList() {
+        final TableItem[] items = srcTableViewer.getTable().getItems();
+        final List<SrcTable> tables = new ArrayList<>(items.length);
+        for (final TableItem item : items) {
+            final SrcTable srcTable = (SrcTable) item.getData();
+            srcTable.setSelected(item.getImage(0) == CompositeUtils.CHECK_IMAGE);
+            tables.add(srcTable);
+        }
+        return tables;
+    }
+}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4795>

### Purpose
`SchemaMappingPage` 클래스에 혼재되어 있던 UI 구성 로직(TableViewer)과 데이터 처리 로직을 분리하여 코드의 복잡도를 낮추고 가독성을 향상시켰습니다. UI 코드는 별도의 클래스로 분리하고, 페이지 내에 산재해 있던 파일 경로 관련 변수들을 구조화했습니다.

### Implementation
UI 로직 분리(`SchemaTableView` 신규 생성)
  - `SchemaMappingPage`에 있던 TableViewr 생성, 컬럼 정의 등 UI 설정 로직을 신규 클래스인 `SchemaTableView`로 이동했습니다.

데이터 처리 로직 구조화 (`SchemaMappingPage` 리팩토링)
  - 클래스 멤버 변수로 산재해 있던 파일 경로 맵들을 `OfflineFilePathContext` 정적 내부 클래스로 묶어 캡슐화했습니다.

### Remarks
N/A
