### PR TITLE
[TOOLS-4797] Console: Selected-only Schema Fetch

### DIFF
--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/ConsoleSourceSchemaBuilder.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/ConsoleSourceSchemaBuilder.java
@@ -53,6 +53,25 @@ public final class ConsoleSourceSchemaBuilder {
         if (config == null) {
             return null;
         }
+        Set<String> selectedSchemas = requireSelectedSchemas(config, outPrinter);
+        if (selectedSchemas == null) {
+            return null;
+        }
+        IBuildSchemaFilter filter = BuildSchemaFilterFactory.from(config);
+
+        if (config.sourceIsOnline()) {
+            return buildOnlineSchema(config, outPrinter, selectedSchemas, filter);
+        }
+
+        if (config.sourceIsXMLDump()) {
+            return buildXmlDumpSchema(config, outPrinter, selectedSchemas, filter);
+        }
+
+        return null;
+    }
+
+    private static Set<String> requireSelectedSchemas(
+            MigrationConfiguration config, PrintStream outPrinter) {
         Set<String> selectedSchemas = config.getSelectedSrcSchemas();
         if (selectedSchemas == null || selectedSchemas.isEmpty()) {
             if (outPrinter != null) {
@@ -60,39 +79,43 @@ public final class ConsoleSourceSchemaBuilder {
             }
             return null;
         }
-        IBuildSchemaFilter filter = BuildSchemaFilterFactory.from(config);
+        return selectedSchemas;
+    }
 
-        if (config.sourceIsOnline()) {
-            ConnParameters cp = config.getSourceConParams();
-            if (cp == null) {
-                if (outPrinter != null) {
-                    outPrinter.println("Invalid source database connection.");
-                }
-                return null;
-            }
-            JDBCDBSchemaFetcherFacade facade = new JDBCDBSchemaFetcherFacade();
-            List<String> schemaList = new ArrayList<String>(selectedSchemas);
-            return facade.fetchSchemaObjectsForSchemas(cp, schemaList, filter);
-        }
-
-        if (config.sourceIsXMLDump()) {
+    private static Catalog buildOnlineSchema(
+            MigrationConfiguration config,
+            PrintStream outPrinter,
+            Set<String> selectedSchemas,
+            IBuildSchemaFilter filter) {
+        ConnParameters cp = config.getSourceConParams();
+        if (cp == null) {
             if (outPrinter != null) {
-                outPrinter.println(
-                        "Warning: XML dump loads full schema metadata before filtering.");
+                outPrinter.println("Invalid source database connection.");
             }
-            MysqlXmlDumpSource ds =
-                    new MysqlXmlDumpSource(
-                            config.getSourceFileName(), config.getSourceFileEncoding());
-            IDBSchemaInfoFetcher fetcher = DBSchemaInfoFetcherFactory.createFetcher(ds);
-            Catalog catalog = fetcher.fetchSchema(ds, filter);
-            if (catalog == null) {
-                return null;
-            }
-            filterSchemas(catalog, selectedSchemas);
-            return catalog;
+            return null;
         }
+        JDBCDBSchemaFetcherFacade facade = new JDBCDBSchemaFetcherFacade();
+        List<String> schemaList = new ArrayList<String>(selectedSchemas);
+        return facade.fetchSchemaObjectsForSchemas(cp, schemaList, filter);
+    }
 
-        return null;
+    private static Catalog buildXmlDumpSchema(
+            MigrationConfiguration config,
+            PrintStream outPrinter,
+            Set<String> selectedSchemas,
+            IBuildSchemaFilter filter) {
+        if (outPrinter != null) {
+            outPrinter.println("Warning: XML dump loads full schema metadata before filtering.");
+        }
+        MysqlXmlDumpSource ds =
+                new MysqlXmlDumpSource(config.getSourceFileName(), config.getSourceFileEncoding());
+        IDBSchemaInfoFetcher fetcher = DBSchemaInfoFetcherFactory.createFetcher(ds);
+        Catalog catalog = fetcher.fetchSchema(ds, filter);
+        if (catalog == null) {
+            return null;
+        }
+        filterSchemas(catalog, selectedSchemas);
+        return catalog;
     }
 
     private static void filterSchemas(Catalog catalog, Set<String> selectedSchemas) {

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/ConsoleSourceSchemaBuilder.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/ConsoleSourceSchemaBuilder.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.command;
+
+import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbmetadata.BuildSchemaFilterFactory;
+import com.cubrid.cubridmigration.core.dbmetadata.DBSchemaInfoFetcherFactory;
+import com.cubrid.cubridmigration.core.dbmetadata.IBuildSchemaFilter;
+import com.cubrid.cubridmigration.core.dbmetadata.IDBSchemaInfoFetcher;
+import com.cubrid.cubridmigration.core.dbmetadata.JDBCDBSchemaFetcherFacade;
+import com.cubrid.cubridmigration.core.dbobject.Catalog;
+import com.cubrid.cubridmigration.core.dbobject.Schema;
+import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+import com.cubrid.cubridmigration.mysql.MysqlXmlDumpSource;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public final class ConsoleSourceSchemaBuilder {
+
+    private ConsoleSourceSchemaBuilder() {}
+
+    public static Catalog buildSelectedOnly(MigrationConfiguration config, PrintStream outPrinter) {
+        if (config == null) {
+            return null;
+        }
+        Set<String> selectedSchemas = config.getSelectedSrcSchemas();
+        if (selectedSchemas == null || selectedSchemas.isEmpty()) {
+            if (outPrinter != null) {
+                outPrinter.println("Invalid migration script: <schemas> is required for console.");
+            }
+            return null;
+        }
+        IBuildSchemaFilter filter = BuildSchemaFilterFactory.from(config);
+
+        if (config.sourceIsOnline()) {
+            ConnParameters cp = config.getSourceConParams();
+            if (cp == null) {
+                if (outPrinter != null) {
+                    outPrinter.println("Invalid source database connection.");
+                }
+                return null;
+            }
+            JDBCDBSchemaFetcherFacade facade = new JDBCDBSchemaFetcherFacade();
+            List<String> schemaList = new ArrayList<String>(selectedSchemas);
+            return facade.fetchSchemaObjectsForSchemas(cp, schemaList, filter);
+        }
+
+        if (config.sourceIsXMLDump()) {
+            if (outPrinter != null) {
+                outPrinter.println(
+                        "Warning: XML dump loads full schema metadata before filtering.");
+            }
+            MysqlXmlDumpSource ds =
+                    new MysqlXmlDumpSource(
+                            config.getSourceFileName(), config.getSourceFileEncoding());
+            IDBSchemaInfoFetcher fetcher = DBSchemaInfoFetcherFactory.createFetcher(ds);
+            Catalog catalog = fetcher.fetchSchema(ds, filter);
+            if (catalog == null) {
+                return null;
+            }
+            filterSchemas(catalog, selectedSchemas);
+            return catalog;
+        }
+
+        return null;
+    }
+
+    private static void filterSchemas(Catalog catalog, Set<String> selectedSchemas) {
+        if (catalog == null || selectedSchemas == null || selectedSchemas.isEmpty()) {
+            return;
+        }
+        List<Schema> removeSchemas = new ArrayList<Schema>();
+        for (Schema schema : catalog.getSchemas()) {
+            if (!containsIgnoreCase(selectedSchemas, schema.getName())) {
+                removeSchemas.add(schema);
+            }
+        }
+        if (!removeSchemas.isEmpty()) {
+            catalog.removeSchema(removeSchemas);
+        }
+    }
+
+    private static boolean containsIgnoreCase(Set<String> selectedSchemas, String schemaName) {
+        if (schemaName == null) {
+            return false;
+        }
+        for (String s : selectedSchemas) {
+            if (schemaName.equalsIgnoreCase(s)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/StartCommandHandler.java
@@ -34,6 +34,7 @@ import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.command.CmdMigrationMonitor;
 import com.cubrid.cubridmigration.command.ConsoleCommandHandler;
 import com.cubrid.cubridmigration.command.ConsoleMigrationReporter;
+import com.cubrid.cubridmigration.command.ConsoleSourceSchemaBuilder;
 import com.cubrid.cubridmigration.command.ConsoleUtils;
 import com.cubrid.cubridmigration.command.DoMigration;
 import com.cubrid.cubridmigration.core.common.PathUtils;
@@ -117,7 +118,7 @@ public class StartCommandHandler implements ConsoleCommandHandler {
             if (migrateDataOnly) {
                 result = config.buildSourceSchemaForDataMigration();
             } else {
-                result = config.buildRequiredSourceSchema();
+                result = ConsoleSourceSchemaBuilder.buildSelectedOnly(config, outPrinter);
             }
         } catch (Exception ex) {
             outPrinter.println("Get schema information error:" + ex.getMessage());
@@ -126,6 +127,7 @@ public class StartCommandHandler implements ConsoleCommandHandler {
         }
         if (result == null) {
             outPrinter.println("Can not get schema information.");
+            return null;
         }
         return result;
     }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
@@ -198,10 +198,21 @@ public abstract class AbstractJDBCSchemaFetcher implements IDependOnDatabaseType
             final Connection conn, final ConnParameters cp, final List<String> schemaNames)
             throws SQLException {
 
+        List<String> normalizedSchemaNames = normalizeSchemaNames(schemaNames);
+        DatabaseType databaseType = cp.getDatabaseType();
+        String catalogName = resolveCatalogName(cp);
+        Version version = getVersion(conn);
+        Map<String, List<DataType>> supportedDataType = getSupportedSqlTypes(conn);
+        SchemaCatalog schemaCatalog =
+                new SchemaCatalog(catalogName, databaseType, cp, version, supportedDataType);
+        addSchemaEntries(schemaCatalog, normalizedSchemaNames, databaseType, cp.getConUser());
+        return schemaCatalog;
+    }
+
+    private List<String> normalizeSchemaNames(List<String> schemaNames) {
         if (schemaNames == null || schemaNames.isEmpty()) {
             throw new IllegalArgumentException("Invalid schema or no schema specified.");
         }
-
         Set<String> normalizedSchemaNames = new LinkedHashSet<String>();
         for (String raw : schemaNames) {
             if (raw == null) {
@@ -213,11 +224,13 @@ public abstract class AbstractJDBCSchemaFetcher implements IDependOnDatabaseType
             }
             normalizedSchemaNames.add(trimmed.toUpperCase(Locale.ENGLISH));
         }
-
         if (normalizedSchemaNames.isEmpty()) {
             throw new IllegalArgumentException("Invalid schema or no schema specified.");
         }
+        return new ArrayList<String>(normalizedSchemaNames);
+    }
 
+    private String resolveCatalogName(ConnParameters cp) {
         DatabaseType databaseType = cp.getDatabaseType();
         String dbName = cp.getDbName();
         if (DatabaseType.ORACLE == databaseType && dbName != null) {
@@ -228,25 +241,22 @@ public abstract class AbstractJDBCSchemaFetcher implements IDependOnDatabaseType
             final int slash = upper.indexOf('/');
             dbName = (slash >= 0) ? upper.substring(0, slash) : upper;
         }
+        return dbName;
+    }
 
-        String catalogName = dbName;
-        Version version = getVersion(conn);
-        Map<String, List<DataType>> supportedDataType = getSupportedSqlTypes(conn);
-        SchemaCatalog schemaCatalog =
-                new SchemaCatalog(catalogName, databaseType, cp, version, supportedDataType);
+    private void addSchemaEntries(
+            SchemaCatalog schemaCatalog,
+            List<String> schemaNames,
+            DatabaseType databaseType,
+            String conUser) {
         boolean multiSchema = databaseType.isSupportMultiSchema();
-        String conUser = cp.getConUser();
-
-        for (String schemaName : normalizedSchemaNames) {
+        for (String schemaName : schemaNames) {
             final boolean grantorSchema =
                     multiSchema
                             ? (conUser == null || !schemaName.equalsIgnoreCase(conUser))
                             : false;
-
             schemaCatalog.getSchemas().add(new SchemaEntry(schemaName, grantorSchema));
         }
-
-        return schemaCatalog;
     }
 
     /** Builds a Catalog with objects only for the given schemas using the given SchemaCatalog. */

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
@@ -266,6 +266,10 @@ public abstract class AbstractJDBCSchemaFetcher implements IDependOnDatabaseType
         if (schemaNames == null || schemaNames.isEmpty()) {
             throw new IllegalArgumentException("Invalid schema or no schema specified.");
         }
+        LOG.debug(
+                "[SCHEMA_SELECTED_ONLY] buildSchemaObjects schemaNames={} count={}",
+                schemaNames,
+                schemaNames.size());
         Catalog catalog = SchemaCatalogMapper.createEmptyCatalogFromSchemaCatalog(sc, schemaNames);
         for (String schemaName : schemaNames) {
             Schema schema = catalog.getSchemaByName(schemaName);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/AbstractJDBCSchemaFetcher.java
@@ -65,9 +65,11 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * AbstractJDBCSchemaFetcher
@@ -182,10 +184,88 @@ public abstract class AbstractJDBCSchemaFetcher implements IDependOnDatabaseType
         return schemaCatalog;
     }
 
+    /**
+     * Builds a SchemaCatalog using JDBC metadata and the given schema names, without querying the
+     * full schema list from the database.
+     *
+     * @param conn JDBC connection
+     * @param cp connection parameters
+     * @param schemaNames schema names provided by caller (required)
+     * @return SchemaCatalog
+     * @throws SQLException if JDBC metadata access fails
+     */
+    public SchemaCatalog buildSchemaCatalogForSchemas(
+            final Connection conn, final ConnParameters cp, final List<String> schemaNames)
+            throws SQLException {
+
+        if (schemaNames == null || schemaNames.isEmpty()) {
+            throw new IllegalArgumentException("Invalid schema or no schema specified.");
+        }
+
+        Set<String> normalizedSchemaNames = new LinkedHashSet<String>();
+        for (String raw : schemaNames) {
+            if (raw == null) {
+                continue;
+            }
+            final String trimmed = raw.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            normalizedSchemaNames.add(trimmed.toUpperCase(Locale.ENGLISH));
+        }
+
+        if (normalizedSchemaNames.isEmpty()) {
+            throw new IllegalArgumentException("Invalid schema or no schema specified.");
+        }
+
+        DatabaseType databaseType = cp.getDatabaseType();
+        String dbName = cp.getDbName();
+        if (DatabaseType.ORACLE == databaseType && dbName != null) {
+            if (dbName.startsWith("/")) {
+                dbName = dbName.substring(1);
+            }
+            final String upper = dbName.toUpperCase(Locale.ENGLISH);
+            final int slash = upper.indexOf('/');
+            dbName = (slash >= 0) ? upper.substring(0, slash) : upper;
+        }
+
+        String catalogName = dbName;
+        Version version = getVersion(conn);
+        Map<String, List<DataType>> supportedDataType = getSupportedSqlTypes(conn);
+        SchemaCatalog schemaCatalog =
+                new SchemaCatalog(catalogName, databaseType, cp, version, supportedDataType);
+        boolean multiSchema = databaseType.isSupportMultiSchema();
+        String conUser = cp.getConUser();
+
+        for (String schemaName : normalizedSchemaNames) {
+            final boolean grantorSchema =
+                    multiSchema
+                            ? (conUser == null || !schemaName.equalsIgnoreCase(conUser))
+                            : false;
+
+            schemaCatalog.getSchemas().add(new SchemaEntry(schemaName, grantorSchema));
+        }
+
+        return schemaCatalog;
+    }
+
     /** Builds a Catalog with objects only for the given schemas using the given SchemaCatalog. */
     public Catalog buildSchemaObjects(
             final Connection conn, final SchemaCatalog sc, List<String> schemaNames)
             throws SQLException {
+        return buildSchemaObjects(conn, sc, schemaNames, null);
+    }
+
+    /** Builds a Catalog with objects only for the given schemas using the given SchemaCatalog. */
+    public Catalog buildSchemaObjects(
+            final Connection conn,
+            final SchemaCatalog sc,
+            List<String> schemaNames,
+            IBuildSchemaFilter filter)
+            throws SQLException {
+        if (schemaNames == null || schemaNames.isEmpty()) {
+            throw new IllegalArgumentException("Invalid schema or no schema specified.");
+        }
         Catalog catalog = SchemaCatalogMapper.createEmptyCatalogFromSchemaCatalog(sc, schemaNames);
         for (String schemaName : schemaNames) {
             Schema schema = catalog.getSchemaByName(schemaName);
@@ -193,14 +273,16 @@ public abstract class AbstractJDBCSchemaFetcher implements IDependOnDatabaseType
                 continue;
             }
 
-            runSchemaTask("buildTables", true, () -> buildTables(conn, catalog, schema, null));
-            runSchemaTask("buildViews", false, () -> buildViews(conn, catalog, schema, null));
+            runSchemaTask("buildTables", true, () -> buildTables(conn, catalog, schema, filter));
+            runSchemaTask("buildViews", false, () -> buildViews(conn, catalog, schema, filter));
             runSchemaTask(
-                    "buildProcedures", false, () -> buildProcedures(conn, catalog, schema, null));
-            runSchemaTask("buildTriggers", false, () -> buildTriggers(conn, catalog, schema, null));
-            runSchemaTask("buildSequence", false, () -> buildSequence(conn, catalog, schema, null));
-            runSchemaTask("buildSynonym", false, () -> buildSynonym(conn, catalog, schema, null));
-            runSchemaTask("buildGrant", false, () -> buildGrant(conn, catalog, schema, null));
+                    "buildProcedures", false, () -> buildProcedures(conn, catalog, schema, filter));
+            runSchemaTask(
+                    "buildTriggers", false, () -> buildTriggers(conn, catalog, schema, filter));
+            runSchemaTask(
+                    "buildSequence", false, () -> buildSequence(conn, catalog, schema, filter));
+            runSchemaTask("buildSynonym", false, () -> buildSynonym(conn, catalog, schema, filter));
+            runSchemaTask("buildGrant", false, () -> buildGrant(conn, catalog, schema, filter));
         }
         return catalog;
     }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/BuildSchemaFilterFactory.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/BuildSchemaFilterFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.core.dbmetadata;
+
+import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+
+/** Factory for building schema object filters from migration configuration. */
+public final class BuildSchemaFilterFactory {
+
+    private BuildSchemaFilterFactory() {}
+
+    public static IBuildSchemaFilter from(final MigrationConfiguration config) {
+        return new IBuildSchemaFilter() {
+            public boolean filter(String schema, String objName) {
+                // If database don't support multi schema, the schema name will be passed as null.
+                String tmpSchema = null;
+                if (config.sourceIsOnline() && config.getSourceDBType().isSupportMultiSchema()) {
+                    tmpSchema = schema;
+                }
+                if (config.getExpEntryTableCfg(tmpSchema, objName) != null
+                        || config.getExpViewCfg(tmpSchema, objName) != null
+                        || config.getExpSerialCfg(tmpSchema, objName) != null
+                        || config.getExpSynonymCfg(tmpSchema, objName) != null) {
+                    return false;
+                }
+                return true;
+            }
+        };
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/JDBCDBSchemaFetcherFacade.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/JDBCDBSchemaFetcherFacade.java
@@ -34,10 +34,12 @@ import com.cubrid.cubridmigration.core.common.Closer;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
 import com.cubrid.cubridmigration.core.dbobject.Catalog;
 import com.cubrid.cubridmigration.core.dbobject.SchemaCatalog;
+import com.cubrid.cubridmigration.core.dbobject.SchemaEntry;
 import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -153,6 +155,55 @@ public class JDBCDBSchemaFetcherFacade implements IDBSchemaInfoFetcher {
                 DatabaseType dt = cp.getDatabaseType();
                 AbstractJDBCSchemaFetcher builder = dt.getMetaDataBuilder();
                 Catalog catalog = builder.buildSchemaObjects(conn, sc, schemas);
+                if (catalog.getCharset() == null) {
+                    catalog.setCharset(cp.getCharset());
+                } else {
+                    cp.setCharset(catalog.getCharset());
+                }
+                cp.setTimeZone(catalog.getTimezone());
+                return catalog;
+            } finally {
+                cancelRunable = null;
+                Closer.close(conn);
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Fetches schema objects only for the given schema names, without querying the full schema
+     * list.
+     *
+     * <p>This method builds a minimal SchemaCatalog using JDBC metadata (e.g., version/type info)
+     * and then loads schema objects for the provided schemas using a single JDBC connection.
+     */
+    public Catalog fetchSchemaObjectsForSchemas(
+            ConnParameters cp, List<String> schemas, IBuildSchemaFilter filter) {
+        if (cancelRunable != null) {
+            throw new RuntimeException("One fetching work is running.");
+        }
+        try {
+            final Connection conn = cp.createConnection();
+            cancelRunable =
+                    new Runnable() {
+                        public void run() {
+                            try {
+                                conn.close();
+                            } catch (Exception ex) {
+                                // Do nothing
+                            }
+                        }
+                    };
+            try {
+                DatabaseType dt = cp.getDatabaseType();
+                AbstractJDBCSchemaFetcher builder = dt.getMetaDataBuilder();
+                SchemaCatalog sc = builder.buildSchemaCatalogForSchemas(conn, cp, schemas);
+                List<String> schemaNames = new ArrayList<String>();
+                for (SchemaEntry se : sc.getSchemas()) {
+                    schemaNames.add(se.name());
+                }
+                Catalog catalog = builder.buildSchemaObjects(conn, sc, schemaNames, filter);
                 if (catalog.getCharset() == null) {
                     catalog.setCharset(cp.getCharset());
                 } else {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -43,6 +43,7 @@ import com.cubrid.cubridmigration.core.common.CharsetUtils;
 import com.cubrid.cubridmigration.core.common.PathUtils;
 import com.cubrid.cubridmigration.core.common.TimeZoneUtils;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbmetadata.BuildSchemaFilterFactory;
 import com.cubrid.cubridmigration.core.dbmetadata.DBSchemaInfoFetcherFactory;
 import com.cubrid.cubridmigration.core.dbmetadata.IBuildSchemaFilter;
 import com.cubrid.cubridmigration.core.dbmetadata.IDBSchemaInfoFetcher;
@@ -782,27 +783,8 @@ public class MigrationConfiguration {
             return null;
         }
         IDBSchemaInfoFetcher bcf = DBSchemaInfoFetcherFactory.createFetcher(ds);
-        Catalog cl =
-                bcf.fetchSchema(
-                        ds,
-                        new IBuildSchemaFilter() {
-
-                            public boolean filter(String schema, String objName) {
-                                // If database don't support multi schema, the schema name will be
-                                // pass as null.
-                                String tmpSchema = null;
-                                if (sourceIsOnline() && getSourceDBType().isSupportMultiSchema()) {
-                                    tmpSchema = schema;
-                                }
-                                if (getExpEntryTableCfg(tmpSchema, objName) != null
-                                        || getExpViewCfg(tmpSchema, objName) != null
-                                        || getExpSerialCfg(tmpSchema, objName) != null
-                                        || getExpSynonymCfg(tmpSchema, objName) != null) {
-                                    return false;
-                                }
-                                return true;
-                            }
-                        });
+        IBuildSchemaFilter filter = BuildSchemaFilterFactory.from(this);
+        Catalog cl = bcf.fetchSchema(ds, filter);
         if (cl == null || cl.getSchemas().isEmpty()) {
             return null;
         }
@@ -5060,6 +5042,7 @@ public class MigrationConfiguration {
             throw new IllegalArgumentException("Catalog can't not be null.");
         }
         this.srcCatalog = srcCatalog;
+        applyScriptSchemaMappingToCatalog();
         if (reset) {
             clearAll();
         }
@@ -5653,6 +5636,35 @@ public class MigrationConfiguration {
         String fullPath = mergePath(typePath, fileName.toString());
 
         return fullPath;
+    }
+
+    private void applyScriptSchemaMappingToCatalog() {
+        if (srcCatalog == null) {
+            return;
+        }
+        if (scriptSchemaMapping == null || scriptSchemaMapping.isEmpty()) {
+            return;
+        }
+        for (Schema srcSchema : srcCatalog.getSchemas()) {
+            if (srcSchema == null || StringUtils.isEmpty(srcSchema.getName())) {
+                continue;
+            }
+            Schema mapped = scriptSchemaMapping.get(srcSchema.getName());
+            if (mapped == null) {
+                for (Map.Entry<String, Schema> entry : scriptSchemaMapping.entrySet()) {
+                    if (srcSchema.getName().equalsIgnoreCase(entry.getKey())) {
+                        mapped = entry.getValue();
+                        break;
+                    }
+                }
+            }
+            if (mapped == null || StringUtils.isEmpty(mapped.getTargetSchemaName())) {
+                continue;
+            }
+            if (StringUtils.isEmpty(srcSchema.getTargetSchemaName())) {
+                srcSchema.setTargetSchemaName(mapped.getTargetSchemaName());
+            }
+        }
     }
 
     /**

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/MigrationTemplateHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/MigrationTemplateHandler.java
@@ -110,13 +110,12 @@ public final class MigrationTemplateHandler extends DefaultHandler {
             return;
         }
 
-        if (TAG_MIGRATION.equals(qName)) {
-            if (config.targetIsFile()
-                    && config.getFileRepositroyPath() != null
-                    && config.getFileRepositroyPath().length() > 0
-                    && config.getTargetTableFileName().isEmpty()) {
-                config.createDumpfile(config.isSplitSchema(), config.isOneTableOneFile());
-            }
+        if (TAG_MIGRATION.equals(qName)
+                && config.targetIsFile()
+                && config.getFileRepositroyPath() != null
+                && config.getFileRepositroyPath().length() > 0
+                && config.getTargetTableFileName().isEmpty()) {
+            config.createDumpfile(config.isSplitSchema(), config.isOneTableOneFile());
         }
     }
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/MigrationTemplateHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/MigrationTemplateHandler.java
@@ -109,6 +109,15 @@ public final class MigrationTemplateHandler extends DefaultHandler {
             }
             return;
         }
+
+        if (TAG_MIGRATION.equals(qName)) {
+            if (config.targetIsFile()
+                    && config.getFileRepositroyPath() != null
+                    && config.getFileRepositroyPath().length() > 0
+                    && config.getTargetTableFileName().isEmpty()) {
+                config.createDumpfile(config.isSplitSchema(), config.isOneTableOneFile());
+            }
+        }
     }
 
     @Override

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/TargetFileRepositoryNodeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/TargetFileRepositoryNodeHandler.java
@@ -79,6 +79,5 @@ public class TargetFileRepositoryNodeHandler {
         config.setAddUserSchema(getBoolean(attributes.getValue(ATTR_ADD_SCHEMA), false));
         config.setSplitSchema(getBoolean(attributes.getValue(ATTR_SPLIT_SCHEMA), false));
         config.setCreateUserSQL(getBoolean(attributes.getValue(ATTR_CREATE_USER_SQL), false));
-        config.createDumpfile(config.isSplitSchema(), config.isOneTableOneFile());
     }
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4797>

### Purpose
Console 마이그레이션은 스크립트의 `<schemas>`에 명시된 스키마만 대상으로 메타데이터 조회 및 마이그레이션을 수행해야 합니다.
기존 Console 경로는 내부적으로 DB의 전체 스키마 목록을 조회할 수 있어, 스크립트에 포함되지 않은 스키마까지 조회가 발생할 가능성이 있었습니다.
이번 변경은 Console 경로에서 `<schemas>`에 선택된 스키마만 대상으로 조회하도록 제한하여 불필요한 스키마 조회를 제거하고, 기존 오브젝트 선택 필터 동작은 그대로 유지하는 것을 목표로 합니다.

### Implementation

**Console 경로에서 selected-only 스키마 빌드로 전환**
- StartCommandHandler에서 스키마와 레코드 마이그레이션 시 `ConsoleSourceSchemaBuilder.buildSelectedOnly()`을 호출하도록 변경
- ConsoleSourceSchemaBuilder 추가: `<schemas>` 유효성 검증 후 선택 스키마 목록 기반으로 Catalog 빌드

**전체 스키마 목록 조회 없이 SchemaCatalog / Catalog 구성**
- `buildSchemaCatalogForSchemas(...)` 추가하여 DB 메타데이터(버전/타입 등)만 조회하고, 스키마 목록은 스크립트에서 전달된 값으로 구성
- buildSchemaObjects(..., filter) 오버로드 추가

**Console 전용 단일 Connection fetch 메서드 추가**
- `fetchSchemaObjectsForSchemas(...)` 추가하여 단일 Connection으로 SchemaCatalog 생성 + 선택 스키마의 오브젝트 조회를 한번에 수행

**스크립트 내용 순서 변경으로 인한 createDumpfile() 호출 시점 변경**
- `<file_repository>`가 상단으로 이동함에 따라, `<target>` 파싱 전에 createDumpfile()이 실행되어 설정값 누락 발생
- createDumpfile()이 필요한 정보를 모두 확보한 뒤 실행되도록, 호출 시점을 스크립트 파싱 완료 직후로 변경
 
### Remarks
N/A
