### PR TITLE
[TOOLS-4802] Fix missing drop SQL files for renamed target schema

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/CleanDBTask.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/CleanDBTask.java
@@ -266,10 +266,11 @@ public class CleanDBTask extends ImportTask {
 
             if (isSourceDBSupportMultiSchema) {
                 for (Schema schema : schemaList) {
-                    String ownerName = schema.getName();
-                    writeFile(dropQueryBySchemaMap, ownerName, CLEAR_SQL);
-                    writeFile(fkDropQueryBySchemaMap, ownerName, DROP_FK_SQL);
-                    writeFile(tbTruncateQueryBySchemaMap, ownerName, TRUNCATE_SQL);
+                    String ownerName = schema.getTargetSchemaName();
+                    String fileNameSchema = schema.getName();
+                    writeFile(dropQueryBySchemaMap, ownerName, fileNameSchema, CLEAR_SQL);
+                    writeFile(fkDropQueryBySchemaMap, ownerName, fileNameSchema, DROP_FK_SQL);
+                    writeFile(tbTruncateQueryBySchemaMap, ownerName, fileNameSchema, TRUNCATE_SQL);
                 }
             } else {
                 writeFile(dropQueryBySchemaMap, conUser, CLEAR_SQL);
@@ -279,14 +280,24 @@ public class CleanDBTask extends ImportTask {
         }
     }
 
+    /** Drop queries are written to a file */
+    private void writeFile(Map<String, List<String>> map, String ownerName, String fileName) {
+        writeFile(map, ownerName, ownerName, fileName);
+    }
+
     /**
      * Drop queries are written to a file
      *
      * @param map Map<String, List<String>>
      * @param ownerName String
+     * @param fileNameSchema Schema name used in the file name
      * @param fileName String
      */
-    private void writeFile(Map<String, List<String>> map, String ownerName, String fileName) {
+    private void writeFile(
+            Map<String, List<String>> map,
+            String ownerName,
+            String fileNameSchema,
+            String fileName) {
         if (!map.isEmpty()) {
             File clearFile =
                     new File(
@@ -294,9 +305,9 @@ public class CleanDBTask extends ImportTask {
                                     + File.separator
                                     + config.getName()
                                     + File.separator
-                                    + ownerName
+                                    + fileNameSchema
                                     + File.separator
-                                    + ownerName
+                                    + fileNameSchema
                                     + fileName);
             try {
                 PathUtils.deleteFile(clearFile);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4802>

### Purpose
대상 스키마 이름 변경 시 `_drop.sql`, `_drop_fk.sql`, `_truncate.sql` 파일이 생성되지 않는 문제를 수정합니다.

### Implementation
- 파일 경로 조회 시에는 타겟 스키마명(getTargetSchemaName)을 사용하도록 변경
- 기존 코드와의 호환성 유지를 위해 메서드 오버로딩 적용

### Remarks
N/A
