### PR TITLE
[TOOLS-4803] problems where the selected connection info also appears on the next page

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/connection/ConnParameters.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/connection/ConnParameters.java
@@ -393,7 +393,7 @@ public final class ConnParameters implements Serializable, IDBSource, IJDBCConne
 
         String u1 = StringUtils.defaultString(conUser);
         String u2 = StringUtils.defaultString(cp.conUser);
-        if (u1.equalsIgnoreCase(u2)) {
+        if (!u1.equalsIgnoreCase(u2)) {
             return false;
         }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4803>

### Purpose
- sourceDB 선택 페이지에서 선택된 연결 정보가 targetDB 선택 페이지에서도 표시되지 않게 수정

### Implementation
- isSameDB 메소드에서 잘못된 조건문 수정

### Remarks
N/A
