### PR TITLE
[TOOLS-4808] Fix missing schema tags and attributes in console

### DIFF
--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
@@ -254,6 +254,19 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
                 outPrinter.println("Build source schema error.");
                 return;
             }
+            List<Schema> schemaMappingList = new ArrayList<Schema>();
+            for (Schema schema : srcCat.getSchemas()) {
+                String schemaName = schema.getName();
+                if (StringUtils.isEmpty(schema.getTargetSchemaName())) {
+                    schema.setTargetSchemaName(schemaName);
+                }
+                Schema mappingSchema = new Schema();
+                mappingSchema.setName(schemaName);
+                mappingSchema.setTargetSchemaName(schemaName);
+                schemaMappingList.add(mappingSchema);
+            }
+            config.removeTargetSchemaList();
+            config.setTargetSchemaList(schemaMappingList);
             config.setSrcCatalog(srcCat, isNeedReset);
             if (isNeedReset) {
                 config.setAll(true);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4808>

### Purpose
Console 버전에서 script 명령어로 생성한 마이그레이션 스크립트 파일에 스키마 정보가 누락되는 문제를 해결합니다.

### Implementation
- Schema 객체의 `targetSchemaName`을 소스와 동일한 이름으로 초기화
- 조회된 스키마 리스트를 `targetSchemaList`에도 동일한 리스트로 초기화

### Remarks
N/A
