### PR TITLE
[TOOLS-4816] Math Console script default thread and timezone to Dekstop

### DIFF
--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
@@ -134,6 +134,7 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
             String username = dbProperties.getProperty(cpname + ".user");
             String password = dbProperties.getProperty(cpname + ".password");
             String driverPath = dbProperties.getProperty(cpname + ".driver");
+            String timeZone = dbProperties.getProperty(cpname + ".timezone");
             ConnParameters cp =
                     ConnParameters.getConParam(
                             cpname,
@@ -146,6 +147,7 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
                             password,
                             driverPath,
                             null);
+            cp.setTimeZone(timeZone);
             return cp;
         } catch (Exception ex) {
             LOG.error("Failed to build connection parameters for [{}].", cpname, ex);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/JDBCDBSchemaFetcherFacade.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbmetadata/JDBCDBSchemaFetcherFacade.java
@@ -88,7 +88,9 @@ public class JDBCDBSchemaFetcherFacade implements IDBSchemaInfoFetcher {
                 } else {
                     cp.setCharset(catalog.getCharset());
                 }
-                cp.setTimeZone(catalog.getTimezone());
+                if (cp.getTimeZone() == null || cp.getTimeZone().isEmpty()) {
+                    cp.setTimeZone(catalog.getTimezone());
+                }
                 return catalog;
             } finally {
                 cancelRunable = null;
@@ -160,7 +162,9 @@ public class JDBCDBSchemaFetcherFacade implements IDBSchemaInfoFetcher {
                 } else {
                     cp.setCharset(catalog.getCharset());
                 }
-                cp.setTimeZone(catalog.getTimezone());
+                if (cp.getTimeZone() == null || cp.getTimeZone().isEmpty()) {
+                    cp.setTimeZone(catalog.getTimezone());
+                }
                 return catalog;
             } finally {
                 cancelRunable = null;
@@ -209,7 +213,9 @@ public class JDBCDBSchemaFetcherFacade implements IDBSchemaInfoFetcher {
                 } else {
                     cp.setCharset(catalog.getCharset());
                 }
-                cp.setTimeZone(catalog.getTimezone());
+                if (cp.getTimeZone() == null || cp.getTimeZone().isEmpty()) {
+                    cp.setTimeZone(catalog.getTimezone());
+                }
                 return catalog;
             } finally {
                 cancelRunable = null;

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -140,6 +140,9 @@ public class MigrationConfiguration {
     public static final int RPT_LEVEL_INFO = 2;
     public static final int RPT_LEVEL_DEBUG = 3;
 
+    public static final int DEFAULT_EXPORT_THREAD_COUNT = 4;
+    public static final int DEFAULT_IMPORT_THREAD_COUNT = 3;
+
     // Used to set the name of the data file extracted by SQL.
     public static final String SQLTABLE = "__SQLTABLE__";
 
@@ -160,8 +163,8 @@ public class MigrationConfiguration {
 
     private int commitCount = 1000;
     private int maxCountPerFile = 0;
-    private int exportThreadCount = 2;
-    private int importThreadCount = 2;
+    private int exportThreadCount = DEFAULT_EXPORT_THREAD_COUNT;
+    private int importThreadCount = DEFAULT_IMPORT_THREAD_COUNT;
 
     private boolean deleteTempFile = true;
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/meta/CUBRIDSchemaFetcher.java
@@ -34,7 +34,6 @@ import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.common.Closer;
 import com.cubrid.cubridmigration.core.common.CommonUtils;
 import com.cubrid.cubridmigration.core.common.DBUtils;
-import com.cubrid.cubridmigration.core.common.TimeZoneUtils;
 import com.cubrid.cubridmigration.core.connection.ConnParameters;
 import com.cubrid.cubridmigration.core.datatype.DataTypeInstance;
 import com.cubrid.cubridmigration.core.dbmetadata.AbstractJDBCSchemaFetcher;
@@ -144,7 +143,6 @@ public final class CUBRIDSchemaFetcher extends AbstractJDBCSchemaFetcher {
         Catalog catalog = super.buildCatalog(conn, cp, filter);
         catalog.setDatabaseType(DatabaseType.CUBRID);
         catalog.setCreateSql(null);
-        catalog.setTimezone(TimeZoneUtils.getDefaultID2GMT());
         List<Schema> schemaList = catalog.getSchemas();
 
         CUBRIDSQLHelper ddlUtil = CUBRIDSQLHelper.getInstance(null);

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/preference/MigrationConfigPage.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/preference/MigrationConfigPage.java
@@ -30,6 +30,9 @@
  */
 package com.cubrid.cubridmigration.ui.preference;
 
+import static com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration.DEFAULT_EXPORT_THREAD_COUNT;
+import static com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration.DEFAULT_IMPORT_THREAD_COUNT;
+
 import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.common.PathUtils;
 import com.cubrid.cubridmigration.ui.MigrationUIPlugin;
@@ -65,8 +68,6 @@ import org.slf4j.Logger;
 public class MigrationConfigPage extends PreferencePage implements IWorkbenchPreferencePage {
     private static final String DEFAULT_FETCHING_COUNT = "defaultFetchingCount";
     private static final int DEFAULT_MAX_RECORD_COUNT_EACH_DATA_FILE = 0;
-    private static final int DEFAULT_IMPORT_THREAD_COUNT_OF_EACHE_TARGET_TABLE = 3;
-    private static final int DEFAULT_EXPORT_THREAD_COUNT = 4;
     public static final int MIN_CC = 1;
     public static final int MAX_CC = 50000;
     public static final int DEFAULT_PAGE_COUNT = 1000;
@@ -100,8 +101,7 @@ public class MigrationConfigPage extends PreferencePage implements IWorkbenchPre
      * @return 4 is default value
      */
     public static int getDefaultImpportThreadCountEachTable() {
-        return NODE.getInt(
-                "importThreadCountSpinner", DEFAULT_IMPORT_THREAD_COUNT_OF_EACHE_TARGET_TABLE);
+        return NODE.getInt("importThreadCountSpinner", DEFAULT_IMPORT_THREAD_COUNT);
     }
 
     /**
@@ -270,7 +270,7 @@ public class MigrationConfigPage extends PreferencePage implements IWorkbenchPre
     /** performDefaults */
     protected void performDefaults() {
         exportThreadCountSpinner.setSelection(DEFAULT_EXPORT_THREAD_COUNT);
-        importThreadCountSpinner.setSelection(DEFAULT_IMPORT_THREAD_COUNT_OF_EACHE_TARGET_TABLE);
+        importThreadCountSpinner.setSelection(DEFAULT_IMPORT_THREAD_COUNT);
         txtFetchCount.setSelection(DEFAULT_PAGE_COUNT);
         onlineDefaultCommitCount.setSelection(ONLINE_DEFAULT_CC);
         edtTempFilePath.setText(PathUtils.getDefaultBaseTempDir());


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4816>

### Purpose
Console의 script 명령어를 통해 생성되는 마이그레이션 스크립트 파일(XML)의 태그의 옵션 일부분을  Desktop(UI)과 동일하게 생성될 수 있도록 수정합니다.

1. params 태그의 thread 옵션
    - export_thread 4 / import_thread 3
2. connection 태그의 timezone 옵션
    - 별도 지정 없으면 빈 값

### Implementation
Thread 설정 관리 방식 개선
 - MigrationConfiguration에 `DEFAULT_EXPORT_THREAD_COUNT(4)`, `DEFAULT_IMPORT_THREAD_COUNT(3)`상수 추가
 - MigrationConfigPage에 하드코딩된 상수를 제거하고 MigrationConfiguration에 있는 상수를 사용하도록 수정

Timezone 주입 방식 개선
 - CUBRIDSchemaFetcher: buildCatalog 시 현재 PC의 시스템 시간대를 강제 주입하는 로직 삭제
 - ScriptCommandHandler: db.conf 파일의 `.timezone` 속성을 읽어 설정할 수 있도록 기능 추가
 - JDBCDBSchemaFetcherFacade: 스키마 정보를 가져온 후 ConnParamters를 갱신할 때, 이미 Timezone이 설정되어 있다면 덮어쓰지 않도록 방어 코드 추가

### Remarks
N/A
