### PR TITLE
[TOOLS-4818] Fix missing error popup in Step 3 connection failure

### DIFF
--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCConnectionMgrView.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/database/JDBCConnectionMgrView.java
@@ -377,6 +377,13 @@ public class JDBCConnectionMgrView {
                 SchemaFetcherWithProgress fetcher = SchemaFetcherWithProgress.getInstance(cp);
                 catalog = fetcher.fetch();
                 if (catalog == null) {
+                    if (fetcher.getError() != null) {
+                        DetailMessageDialog.openError(
+                                getActiveShell(),
+                                Messages.msgError,
+                                fetcher.getErrorMessage(),
+                                fetcher.getError().getMessage());
+                    }
                     return null;
                 }
                 instance.updateCatalog(dbID, catalog);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4818>

### Purpose
마이그레이션 마법사 Step 3에서 Online CUBRID 연결에 실패했을 때, 에러 경고창이 뜨지 않는 버그를 수정합니다.

### Implementation
- 연결 실패 시 에러 메시지가 포함된 팝업이 정상적으로 표시되도록 복구

### Remarks
N/A
