### PR TITLE
[TOOLS-4821] Fix incorrect status "Accomplished" on canceled migration

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationProcessManager.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationProcessManager.java
@@ -238,6 +238,7 @@ public class MigrationProcessManager {
 
     /** Interrupt the migration process by Users. It should be called in a progress dialog. */
     public void interruptMigration() {
+        context.getEventsHandler().handleEvent(new MigrationCanceledEvent());
         context.getEventsHandler().handleEvent(new MigrationFinishedEvent(true));
         // waiting for stopping.
         while (mainThread != null) {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4821>

### Purpose
사용자가 마이그레이션을 취소했음에도 불구하고, 마이그레이션 히스토리에 "**Accomplished**" 상태로 표시되는 문제가 있습니다.
이를 사용자의 동작에 맞게 "**Canceled**"로 정확히 표시되도록 합니다.

### Implementation
- 종료 이벤트를 발생시키기 전에 MigrationCanceledEvent를 명시적으로 전달하도록 수정

### Remarks
N/A
