### PR TITLE
[TOOLS-4823] Enable restart options for canceled migrations

### DIFF
--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/MigrationWizardFactory.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/MigrationWizardFactory.java
@@ -41,6 +41,7 @@ import com.cubrid.cubridmigration.core.engine.config.SourceSequenceConfig;
 import com.cubrid.cubridmigration.core.engine.config.SourceViewConfig;
 import com.cubrid.cubridmigration.core.engine.report.DBObjMigrationResult;
 import com.cubrid.cubridmigration.core.engine.report.DataFileImportResult;
+import com.cubrid.cubridmigration.core.engine.report.MigrationBriefReport;
 import com.cubrid.cubridmigration.core.engine.report.MigrationReport;
 import com.cubrid.cubridmigration.core.engine.report.MigrationReportFileUtils;
 import com.cubrid.cubridmigration.core.engine.report.RecordMigrationResult;
@@ -369,7 +370,9 @@ public final class MigrationWizardFactory {
         MigrationConfiguration config = MigrationTemplateReader.parse(scriptFile);
         // Get open mode
         int handlingMode = 0;
-        if (rpt.hasError()) {
+        if (rpt.hasError()
+                || (rpt.getBrief() != null
+                        && rpt.getBrief().getStatus() == MigrationBriefReport.MS_CANCELED)) {
             OpenWizardWithHistoryDialog dlg =
                     new OpenWizardWithHistoryDialog(shell, config.targetIsOnline());
             if (dlg.open() != IDialogConstants.OK_ID) {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4823>

### Purpose
마이그레이션 수행 중 사용자가 작업을 취소(Stop)하여 Canceld 상태가 된 경우, History에서 "Restart migration"을 실행하면 재시작 옵션을 묻는 팝업 없이 즉시 마이그레이션 마법사가 수행됩니다. 
취소된 작업에 대해서도 사용자가 재시작 방식을 선택할 수 있도록 수정했습니다.

### Implementation
- 기존에는 리포트에 에러가 있는 경우에만 팝업이 표시되었으나, 마이그레이션 상태가 Canceled인 경우에도 팝업이 뜨도록 조건 추가

### Remarks
N/A
