### PR TITLE
[TOOLS-4824] Fix incorrect PK count in migration report

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/MigrationReport.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/MigrationReport.java
@@ -107,7 +107,7 @@ public class MigrationReport implements Serializable {
             if (StringUtils.isBlank(name) || "primary".equalsIgnoreCase(name)) {
                 return "primary key of " + ((PK) obj).getTable().getName();
             }
-            return "[" + ((PK) obj).getTable().getName() + "]" + obj.getName();
+            return "[" + ((PK) obj).getTable().getName() + "]" + name;
         } else if (obj instanceof Index) {
             return "[" + ((Index) obj).getTable().getName() + "]" + obj.getName();
         } else if (obj instanceof Table) {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/MigrationReport.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/report/MigrationReport.java
@@ -102,8 +102,12 @@ public class MigrationReport implements Serializable {
      * @return name displayed in table
      */
     private static String getDBObjName(DBObject obj) {
-        if (obj instanceof PK && ("PRIMARY".equals(obj.getName()) || obj.getName() == null)) {
-            return "primary key of " + ((PK) obj).getTable().getName();
+        if (obj instanceof PK) {
+            String name = obj.getName();
+            if (StringUtils.isBlank(name) || "primary".equalsIgnoreCase(name)) {
+                return "primary key of " + ((PK) obj).getTable().getName();
+            }
+            return "[" + ((PK) obj).getTable().getName() + "]" + obj.getName();
         } else if (obj instanceof Index) {
             return "[" + ((Index) obj).getTable().getName() + "]" + obj.getName();
         } else if (obj instanceof Table) {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4824>

### Purpose
MySQL, MariaDB, CUBRID 마이그레이션 시 마이그레이션 리포트에 PK 개수가 실제 값보다 적게 집계되는 문제를 해결합니다.

### Implementation
- 마이그레이션 처리 과정에서 PK 이름이 소문자로 변환되며, 기존 코드에서는 equals 비교만 사용하고 있어 대소문자가 다른 경우 PK를 올바르게 식별하지 못하는 문제가 있음
- 이에 따라 PK 이름 비교 로직을 대소문자를 구분하지 않는 방식으로 변경
- 사용자가 지정한 PK 이름에 대해서는 인덱스 표시 방식과의 일관성을 유지하기 위해 **`[테이블명] PK이름`** 형식으로 표시하도록 수정

### Remarks
N/A
