### PR TITLE
[TOOLS-4835] Fix NPE when restarting MySQL XML dump migration

### DIFF
--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
@@ -477,7 +477,11 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
         } else if (config.targetIsFile()) {
             String prefix = dbProperties.getProperty(tvalue + ".file_prefix");
             config.setTargetFilePrefix(
-                    prefix == null ? config.getSourceConParams().getDbName() : prefix);
+                    prefix == null
+                            ? (config.getSourceConParams() == null
+                                    ? config.getSrcConnOwner()
+                                    : config.getSourceConParams().getDbName())
+                            : prefix);
             config.setFileRepositroyPath(dbProperties.getProperty(tvalue + ".output"));
             config.setTargetCharSet(dbProperties.getProperty(tvalue + ".charset"));
             config.setTargetFileTimeZone("Default");

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -3099,7 +3099,7 @@ public class MigrationConfiguration {
     public String getFullTargetFilePrefix() {
         String filePrefix = getTargetFilePrefix();
         if (filePrefix == null) {
-            filePrefix = srcCatalog.getName();
+            filePrefix = srcCatalog == null ? "" : srcCatalog.getName();
         }
         if (StringUtils.isNotBlank(filePrefix)) {
             filePrefix = filePrefix + "_";
@@ -5710,9 +5710,11 @@ public class MigrationConfiguration {
 
     public String getSrcConnOwner() {
         if (this.sourceIsXMLDump()) {
-            return getSrcCatalog().getName();
+            Catalog catalog = getSrcCatalog();
+            return catalog == null ? "" : catalog.getName();
         } else {
-            return getSourceConParams().getConUser();
+            ConnParameters params = getSourceConParams();
+            return params == null ? "" : params.getConUser();
         }
     }
 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/SourceNodeWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/SourceNodeWriter.java
@@ -83,11 +83,12 @@ public class SourceNodeWriter {
         }
 
         if (config.sourceIsOnline()) {
-            writeOnlineSource(writer, config, saveSchema);
+            writeDatabaseSource(writer, config, saveSchema);
         } else if (config.sourceIsSQL()) {
             writeSQLSource(writer, config);
         } else if (config.sourceIsXMLDump()) {
             writeXMLDumpSource(writer, config);
+            writeDatabaseSource(writer, config, saveSchema);
         } else if (config.sourceIsCSV()) {
             writeCSVSource(writer, config);
         }
@@ -95,7 +96,7 @@ public class SourceNodeWriter {
         writer.writeEndElement(); // </source>
     }
 
-    private void writeOnlineSource(
+    private void writeDatabaseSource(
             XMLStreamWriter writer, MigrationConfiguration config, boolean saveSchema)
             throws XMLStreamException, IOException {
         if (saveSchema) {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4835>

### Purpose
Local MySQL XML 덤프 파일을 소스로 설정하여 마이그레이션을 진행한 후, 생성된 마이그레이션 스크립트(.xml)를 사용하여 마이그레이션을 재시작할 때 NullPointerException을 해결합니다.

### Implementation
 - 소스 정보 참조 시 Null 체크 강화
 - XML Dump 템플릿 저장 시 DB 설정이 누락되지 않도록 로직 보완

### Remarks
N/A
