### PR TITLE
[TOOLS-4837] Add Tibero DB Type and JDBC Connection Support

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/META-INF/MANIFEST.MF
+++ b/plugins/com.cubrid.cubridmigration.core/META-INF/MANIFEST.MF
@@ -176,4 +176,22 @@ Export-Package:
    com.cubrid.cubridmigration.core.mapping,
    com.cubrid.cubridmigration.core.trans,
    com.cubrid.cubridmigration.core.mapping.model,
+   com.cubrid.cubridmigration.cubrid.trans",
+ com.cubrid.cubridmigration.tibero;uses:="com.cubrid.cubridmigration.core.dbobject,com.cubrid.cubridmigration.core.dbtype,com.cubrid.cubridmigration.core.sql",
+ com.cubrid.cubridmigration.tibero.export;
+  uses:="com.cubrid.cubridmigration.core.export,
+   com.cubrid.cubridmigration.core.dbobject,
+   com.cubrid.cubridmigration.core.dbtype",
+ com.cubrid.cubridmigration.tibero.export.handler;uses:="com.cubrid.cubridmigration.core.dbobject,com.cubrid.cubridmigration.core.export.handler,com.cubrid.cubridmigration.core.export",
+ com.cubrid.cubridmigration.tibero.meta;
+  uses:="com.cubrid.cubridmigration.core.dbobject,
+  com.cubrid.cubridmigration.core.dbmetadata,
+  com.cubrid.cubridmigration.core.connection,
+  com.cubrid.cubridmigration.core.export",
+ com.cubrid.cubridmigration.tibero.trans;
+  uses:="com.cubrid.cubridmigration.core.engine.config,
+   com.cubrid.cubridmigration.core.dbobject,
+   com.cubrid.cubridmigration.core.mapping,
+   com.cubrid.cubridmigration.core.trans,
+   com.cubrid.cubridmigration.core.mapping.model,
    com.cubrid.cubridmigration.cubrid.trans"

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/connection/ConnParameters.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/connection/ConnParameters.java
@@ -457,7 +457,8 @@ public final class ConnParameters implements Serializable, IDBSource, IJDBCConne
     public static String getDefaultSchema(DatabaseType dt, String dbName, String userName) {
         if (dt.getID() == DatabaseType.MSSQL.getID()) {
             return "dbo";
-        } else if (dt.getID() == DatabaseType.ORACLE.getID()) {
+        } else if (dt.getID() == DatabaseType.ORACLE.getID()
+                || dt.getID() == DatabaseType.TIBERO.getID()) {
             return StringUtils.upperCase(userName);
         }
         return dbName;

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbtype/DBConstant.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbtype/DBConstant.java
@@ -36,18 +36,18 @@ package com.cubrid.cubridmigration.core.dbtype;
  * @author moulinwang
  * @version 1.0 - 2010-11-13
  */
-public class DBConstant { // NOPMD
+public class DBConstant {
 
-    // public static final int DBTYPE_XML_MYSQL = 4;
     public static final int DBTYPE_MYSQL = 0;
     public static final int DBTYPE_CUBRID = 1;
     public static final int DBTYPE_MSSQL = 2;
     public static final int DBTYPE_ORACLE = 3;
     public static final int DBTYPE_MARIADB = 4;
     public static final int DBTYPE_INFORMIX = 5;
+    public static final int DBTYPE_TIBERO = 6;
 
     public static final String[] DB_NAMES =
-            new String[] {"MYSQL", "CUBRID", "MSSQL", "ORACLE", "MARIADB", "INFORMIX"};
+            new String[] {"MYSQL", "CUBRID", "MSSQL", "ORACLE", "MARIADB", "INFORMIX", "TIBERO"};
 
     public static final String JDBC_CLASS_ORACLE = "oracle.jdbc.OracleDriver";
     public static final String JDBC_CLASS_MSSQL = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
@@ -56,21 +56,16 @@ public class DBConstant { // NOPMD
     public static final String JDBC_CLASS_MYSQL8_OR_LATER = "com.mysql.cj.jdbc.Driver";
     public static final String JDBC_CLASS_MSSQL_JTDS = "net.sourceforge.jtds.jdbc.Driver";
     public static final String JDBC_CLASS_MARIADB = "org.mariadb.jdbc.Driver";
-
     public static final String JDBC_CLASS_INFORMIX = "com.informix.jdbc.IfxDriver";
+    public static final String JDBC_CLASS_TIBERO = "com.tmax.tibero.jdbc.TbDriver";
 
     public static final String DEF_PORT_MSSQL = "1433";
     public static final String DEF_PORT_MYSQL = "3306";
     public static final String DEF_PORT_CUBRID = "33000";
     public static final String DEF_PORT_ORACLE = "1521";
     public static final String DEF_PORT_MARIADB = "3306";
-
     public static final String DEF_PORT_INFORMIX = "9088";
-
-    //	public static final String PATTERN_JAR_FILE_MSSQL = "^sqljdbc\\S*.jar";
-    //	public static final String PATTERN_JAR_FILE_MYSQL = "^mysql\\S*.jar";
-    //	public static final String PATTERN_JAR_FILE_CUBRID = "^jdbc\\S*.jar";
-    //	public static final String PATTERN_JAR_FILE_ORACLE = "^ojdbc\\S*.jar";
+    public static final String DEF_PORT_TIBERO = "8629";
 
     public static final String PREFIX_QUOTE_MSSQL = "[";
     public static final String SUFFIX_QUOTE_MSSQL = "]";
@@ -84,6 +79,8 @@ public class DBConstant { // NOPMD
     public static final String SUFFIX_QUOTE_MARIADB = "`";
     public static final String PREFIX_QUOTE_INFORMIX = "`";
     public static final String SUFFIX_QUOTE_INFOMRIX = "`";
+    public static final String PREFIX_QUOTE_TIBERO = "\"";
+    public static final String SUFFIX_QUOTE_TIBERO = "\"";
 
     public static final String DB_NULL_VALUE = "NULL";
 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbtype/DatabaseType.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbtype/DatabaseType.java
@@ -43,6 +43,7 @@ import com.cubrid.cubridmigration.mariadb.MariaDBDatabase;
 import com.cubrid.cubridmigration.mssql.MSSQLDatabase;
 import com.cubrid.cubridmigration.mysql.MySQLDatabase;
 import com.cubrid.cubridmigration.oracle.OracleDatabase;
+import com.cubrid.cubridmigration.tibero.TiberoDatabase;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -60,8 +61,6 @@ import java.util.List;
  */
 public abstract class DatabaseType {
 
-    // private static final Logger LOG = LogUtil.getLogger(DatabaseType.class);
-
     public static final DatabaseType MYSQL = new MySQLDatabase();
 
     public static final DatabaseType CUBRID = new CUBRIDDatabase();
@@ -74,8 +73,10 @@ public abstract class DatabaseType {
 
     public static final DatabaseType INFORMIX = new InformixDatabase();
 
+    public static final DatabaseType TIBERO = new TiberoDatabase();
+
     private static final DatabaseType[] DTS =
-            new DatabaseType[] {MYSQL, CUBRID, ORACLE, MSSQL, MARIADB, INFORMIX};
+            new DatabaseType[] {MYSQL, CUBRID, ORACLE, MSSQL, MARIADB, INFORMIX, TIBERO};
 
     /**
      * Retrieves all Database types

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -123,6 +123,7 @@ public class MigrationConfiguration {
     public static final int SOURCE_TYPE_MSSQL = DatabaseType.MSSQL.getID();
     public static final int SOURCE_TYPE_MARIADB = DatabaseType.MARIADB.getID();
     public static final int SOURCE_TYPE_INFORMIX = DatabaseType.INFORMIX.getID();
+    public static final int SOURCE_TYPE_TIBERO = DatabaseType.TIBERO.getID();
 
     public static final int SOURCE_TYPE_XML_1 = 101;
     public static final int SOURCE_TYPE_SQL = 102;
@@ -134,6 +135,7 @@ public class MigrationConfiguration {
     public static final String CUBRID = "cubrid";
     public static final String MYSQL = "mysql";
     public static final String ORACLE = "oracle";
+    public static final String TIBERO = "tibero";
 
     public static final int RPT_LEVEL_BRIEF = 0;
     public static final int RPT_LEVEL_ERROR = 1;
@@ -1281,7 +1283,7 @@ public class MigrationConfiguration {
         String catalogName;
         String defSchemaName;
         DatabaseType databaseType = sourceConParams.getDatabaseType();
-        if (DatabaseType.ORACLE == databaseType) {
+        if (DatabaseType.ORACLE == databaseType || DatabaseType.TIBERO == databaseType) {
             // If DB name is SID/schemaName pattern
             if (dbName.startsWith("/")) {
                 dbName = dbName.substring(1, dbName.length());
@@ -5361,7 +5363,8 @@ public class MigrationConfiguration {
                 || (sourceType == SOURCE_TYPE_ORACLE)
                 || (sourceType == SOURCE_TYPE_MSSQL)
                 || (sourceType == SOURCE_TYPE_MARIADB)
-                || (sourceType == SOURCE_TYPE_INFORMIX);
+                || (sourceType == SOURCE_TYPE_INFORMIX)
+                || (sourceType == SOURCE_TYPE_TIBERO);
     }
 
     /**

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/TiberoDatabase.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/TiberoDatabase.java
@@ -34,6 +34,7 @@ import com.cubrid.cubridmigration.core.connection.IConnHelper;
 import com.cubrid.cubridmigration.core.datatype.DBDataTypeHelper;
 import com.cubrid.cubridmigration.core.dbtype.DBConstant;
 import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
+import com.cubrid.cubridmigration.core.engine.exception.JDBCConnectErrorException;
 import com.cubrid.cubridmigration.core.sql.SQLHelper;
 import com.cubrid.cubridmigration.tibero.export.TiberoExportHelper;
 import com.cubrid.cubridmigration.tibero.meta.TiberoSchemaFetcher;
@@ -94,7 +95,7 @@ public class TiberoDatabase extends DatabaseType {
             try {
                 Driver driver = conParam.getDriver();
                 if (driver == null) {
-                    throw new RuntimeException("JDBC driver can't be null.");
+                    throw new IllegalArgumentException("JDBC driver can't be null.");
                 }
                 Properties props = new Properties();
                 props.put("user", conParam.getConUser());
@@ -111,7 +112,7 @@ public class TiberoDatabase extends DatabaseType {
             } catch (SQLException e) {
                 throw e;
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                throw new JDBCConnectErrorException(e);
             }
         }
     }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/TiberoDatabase.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/TiberoDatabase.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.tibero;
+
+import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.connection.IConnHelper;
+import com.cubrid.cubridmigration.core.datatype.DBDataTypeHelper;
+import com.cubrid.cubridmigration.core.dbtype.DBConstant;
+import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
+import com.cubrid.cubridmigration.core.sql.SQLHelper;
+import com.cubrid.cubridmigration.tibero.export.TiberoExportHelper;
+import com.cubrid.cubridmigration.tibero.meta.TiberoSchemaFetcher;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/** Tibero Database Description */
+public class TiberoDatabase extends DatabaseType {
+
+    public TiberoDatabase() {
+        super(
+                DBConstant.DBTYPE_TIBERO,
+                DBConstant.DB_NAMES[DBConstant.DBTYPE_TIBERO],
+                new String[] {DBConstant.JDBC_CLASS_TIBERO},
+                DBConstant.DEF_PORT_TIBERO,
+                new TiberoSchemaFetcher(),
+                new TiberoExportHelper(),
+                new TiberoConnHelper(),
+                false);
+    }
+
+    /** TiberoConnHelper */
+    private static class TiberoConnHelper implements IConnHelper {
+        /**
+         * return the jdbc url to connect the database
+         *
+         * @param connParameters ConnParameters
+         * @return String
+         */
+        public String makeUrl(ConnParameters connParameters) {
+            String dbName = connParameters.getDbName();
+            if (dbName == null) {
+                throw new IllegalArgumentException("DB name can't be NULL.");
+            }
+            if (dbName.startsWith("/")) {
+                dbName = dbName.substring(1, dbName.length());
+            }
+            String url =
+                    String.format(
+                            "jdbc:tibero:thin:@%s:%s:%s",
+                            connParameters.getHost(), connParameters.getPort(), dbName);
+            return url;
+        }
+
+        /**
+         * get a Connection
+         *
+         * @param conParam ConnParameters
+         * @return Connection
+         * @throws SQLException e
+         */
+        public Connection createConnection(ConnParameters conParam) throws SQLException {
+            try {
+                Driver driver = conParam.getDriver();
+                if (driver == null) {
+                    throw new RuntimeException("JDBC driver can't be null.");
+                }
+                Properties props = new Properties();
+                props.put("user", conParam.getConUser());
+                props.put("password", conParam.getConPassword());
+                props.put("characterencoding", conParam.getCharset());
+
+                Connection conn;
+                if (StringUtils.isBlank(conParam.getUserJDBCURL())) {
+                    conn = driver.connect(makeUrl(conParam), props);
+                } else {
+                    conn = driver.connect(conParam.getUserJDBCURL(), props);
+                }
+                return conn;
+            } catch (SQLException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * Retrieves the databases SQL helper
+     *
+     * @param version Database version
+     * @return SQLHelper
+     */
+    public SQLHelper getSQLHelper(String version) {
+        return TiberoSQLHelper.getInstance(version);
+    }
+
+    /**
+     * Retrieves the databases data type helper
+     *
+     * @param version Database version
+     * @return DBDataTypeHelper
+     */
+    public DBDataTypeHelper getDataTypeHelper(String version) {
+        return TiberoDataTypeHelper.getInstance(version);
+    }
+
+    /**
+     * The database type is supporting multi-schema.
+     *
+     * @return true if supporting.
+     */
+    public boolean isSupportMultiSchema() {
+        return true;
+    }
+}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4837>

### Purpose
 - DatabaseType에 Tibero 등록, JDBC URL 생성 및 커넥션 수립

### Implementation
 - 신규 DB 타입 "TIBERO" (ID:6) 등록 및 JDBC 드라이버/포트/따옴표 상수 추가
 - Tibero 전용 JDBC URL 생성 및 커넥션 수립 로직 구현
 - Oracle과 동일한 DB명 파싱 로직(SID 구분) 정책 적용

### Remarks
N/A
