### PR TITLE
[TOOLS-4840] Improve Tibero Data Export and Migration Core Engine Integration

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/exporter/impl/JDBCExporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/exporter/impl/JDBCExporter.java
@@ -479,7 +479,6 @@ public class JDBCExporter extends MigrationExporter {
         int sourceDBTypeID = config.getSourceDBType().getID();
         if (config.isImplicitEstimate()
                 && (sourceDBTypeID == DatabaseType.ORACLE.getID()
-                        || sourceDBTypeID == DatabaseType.TIBERO.getID()
                         || sourceDBTypeID == DatabaseType.MYSQL.getID())) {
             return true;
         }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/exporter/impl/JDBCExporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/exporter/impl/JDBCExporter.java
@@ -479,6 +479,7 @@ public class JDBCExporter extends MigrationExporter {
         int sourceDBTypeID = config.getSourceDBType().getID();
         if (config.isImplicitEstimate()
                 && (sourceDBTypeID == DatabaseType.ORACLE.getID()
+                        || sourceDBTypeID == DatabaseType.TIBERO.getID()
                         || sourceDBTypeID == DatabaseType.MYSQL.getID())) {
             return true;
         }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
@@ -107,7 +107,8 @@ public class MigrationTasksScheduler {
         createSerials();
 
         // procedure, function header
-        if (config.getSourceDBType().getID() == MigrationConfiguration.SOURCE_TYPE_ORACLE) {
+        if (config.getSourceDBType().getID() == MigrationConfiguration.SOURCE_TYPE_ORACLE
+                || config.getSourceDBType().getID() == MigrationConfiguration.SOURCE_TYPE_TIBERO) {
             createProcedureHeaders();
             createFunctionHeaders();
         }
@@ -142,7 +143,8 @@ public class MigrationTasksScheduler {
         alterViews();
 
         // procedure, function body
-        if (config.getSourceDBType().getID() == MigrationConfiguration.SOURCE_TYPE_ORACLE) {
+        if (config.getSourceDBType().getID() == MigrationConfiguration.SOURCE_TYPE_ORACLE
+                || config.getSourceDBType().getID() == MigrationConfiguration.SOURCE_TYPE_TIBERO) {
             createProcedureBodies();
             createFunctionBodies();
         } else {
@@ -154,7 +156,9 @@ public class MigrationTasksScheduler {
 
         if (!config.targetIsOnline()) {
             if (config.isSplitSchema()) {
-                if (config.getSourceDBType().getID() == MigrationConfiguration.SOURCE_TYPE_ORACLE) {
+                if (config.getSourceDBType().getID() == MigrationConfiguration.SOURCE_TYPE_ORACLE
+                        || config.getSourceDBType().getID()
+                                == MigrationConfiguration.SOURCE_TYPE_TIBERO) {
                     createAllPlcsqlProcedureHeaderDDL();
                     createAllPlcsqlProcedureDDL();
                     createAllPlcsqlFunctionHeaderDDL();

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/TiberoDataTypeHelper.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/TiberoDataTypeHelper.java
@@ -68,7 +68,11 @@ public final class TiberoDataTypeHelper extends DBDataTypeHelper {
         String normalizedType = dataType.trim().toUpperCase(Locale.ENGLISH).replaceAll("\\s+", " ");
         String key = normalizedType;
 
-        if (normalizedType.matches("TIMESTAMP\\(\\d*\\)")) {
+        if ("JSON".equals(normalizedType)) {
+            key = "JSON";
+        } else if ("XMLTYPE".equals(normalizedType) || normalizedType.endsWith(" XMLTYPE")) {
+            key = "XMLTYPE";
+        } else if (normalizedType.matches("TIMESTAMP\\(\\d*\\)")) {
             key = "TIMESTAMP";
         } else if (normalizedType.matches("TIME\\(\\d*\\)")) {
             key = "TIME";

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/TiberoSQLHelper.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/TiberoSQLHelper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.tibero;
+
+import com.cubrid.cubridmigration.core.sql.SQLHelper;
+
+public class TiberoSQLHelper extends SQLHelper {
+
+    private static final TiberoSQLHelper INS = new TiberoSQLHelper();
+
+    /**
+     * Singleton factory.
+     *
+     * @param version Tibero server version
+     * @return TiberoSQLHelper
+     */
+    public static TiberoSQLHelper getInstance(String version) {
+        return INS;
+    }
+
+    private TiberoSQLHelper() {
+        // Hide the constructor for singleton
+    }
+
+    /**
+     * append "rownum = 0" to SELECT statement
+     *
+     * @param sql SELECT statement
+     * @return String
+     */
+    public String getTestSelectSQL(String sql) {
+        return "SELECT * FROM ( " + sql + " ) WHERE 1<>1";
+    }
+
+    /**
+     * return database object name
+     *
+     * @param objectName String
+     * @return String
+     */
+    public String getQuotedObjName(String objectName) {
+        return new StringBuffer("\"").append(objectName).append("\"").toString();
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/TiberoExportHelper.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/TiberoExportHelper.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.tibero.export;
+
+import com.cubrid.common.log.LogUtil;
+import com.cubrid.cubridmigration.core.common.Closer;
+import com.cubrid.cubridmigration.core.connection.ConnParameters;
+import com.cubrid.cubridmigration.core.dbobject.Column;
+import com.cubrid.cubridmigration.core.dbobject.PK;
+import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
+import com.cubrid.cubridmigration.core.engine.config.SourceSequenceConfig;
+import com.cubrid.cubridmigration.core.engine.event.LobMigrationErrorEvent;
+import com.cubrid.cubridmigration.core.export.DBExportHelper;
+import com.cubrid.cubridmigration.core.export.IExportDataHandler;
+import com.cubrid.cubridmigration.core.export.handler.CharTypeHandler;
+import com.cubrid.cubridmigration.core.export.handler.TimestampTypeHandler;
+import com.cubrid.cubridmigration.tibero.TiberoDataTypeHelper;
+import com.cubrid.cubridmigration.tibero.export.handler.TiberoIntervalDSTypeHandler;
+import com.cubrid.cubridmigration.tibero.export.handler.TiberoIntervalYMTypeHandler;
+
+import org.slf4j.Logger;
+
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/** a class help to export Tibero data and verify Tibero sql statement */
+public class TiberoExportHelper extends DBExportHelper {
+    private static final Logger LOG = LogUtil.getLogger(TiberoExportHelper.class);
+
+    /** constructor */
+    public TiberoExportHelper() {
+        super();
+        handlerMap1.put(Types.DATE, new TimestampTypeHandler());
+        handlerMap2.put("INTERVALDS", new TiberoIntervalDSTypeHandler());
+        handlerMap2.put("INTERVALYM", new TiberoIntervalYMTypeHandler());
+        handlerMap2.put("TIMESTAMP WITH LOCAL TIME ZONE", new TimestampTypeHandler());
+        handlerMap2.put("TIMESTAMP WITH TIME ZONE", new CharTypeHandler());
+    }
+
+    /**
+     * get JDBC Object
+     *
+     * @param rs ResultSet
+     * @param column Column
+     * @return Object
+     * @throws SQLException e
+     */
+    public Object getJdbcObject(final ResultSet rs, final Column column) throws SQLException {
+        String tibType = TiberoDataTypeHelper.getTiberoDataTypeKey(column.getDataType());
+        IExportDataHandler edh = handlerMap2.get(tibType);
+        try {
+            if (edh != null) {
+                return edh.getJdbcObject(rs, column);
+            }
+            return super.getJdbcObject(rs, column);
+        } catch (SQLException e) {
+            if (column.getDataType().equalsIgnoreCase("BLOB")
+                    || column.getDataType().equalsIgnoreCase("CLOB")) {
+                return new LobMigrationErrorEvent(e);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * return database object name
+     *
+     * @param objectName String
+     * @return String
+     */
+    protected String getQuotedObjName(String objectName) {
+        return DatabaseType.TIBERO.getSQLHelper(null).getQuotedObjName(objectName);
+    }
+
+    /**
+     * Retrieves the sql with page condition
+     *
+     * @param sql to be change
+     * @param rows per-page
+     * @param exportedRecords start position
+     * @param pk table's primary key
+     * @return SQL
+     */
+    public String getPagedSelectSQL(String sql, long rows, long exportedRecords, PK pk) {
+        return sql;
+    }
+
+    /**
+     * Retrieves the Database type.
+     *
+     * @return DatabaseType
+     */
+    public DatabaseType getDBType() {
+        return DatabaseType.TIBERO;
+    }
+
+    private static final String SEQUENCE_LAST_NUMBER_SQL =
+            "SELECT S.LAST_NUMBER,S.SEQUENCE_OWNER FROM ALL_SEQUENCES S "
+                    + "WHERE S.SEQUENCE_NAME=? ORDER BY S.SEQUENCE_OWNER";
+
+    /**
+     * Retrieves the current value of input serial.
+     *
+     * @param sourceConParams JDBC connection configuration
+     * @param sq sequence to be synchronized.
+     * @return The current value of the input SQ
+     */
+    public BigInteger getSerialStartValue(ConnParameters sourceConParams, SourceSequenceConfig sq) {
+        Connection conn = null;
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        try {
+            conn = sourceConParams.createConnection();
+            stmt = conn.prepareStatement(SEQUENCE_LAST_NUMBER_SQL);
+            stmt.setString(1, sq.getName());
+            rs = stmt.executeQuery();
+            while (rs.next()) {
+                if (sq.getOwner() == null) {
+                    return new BigInteger(rs.getString(1));
+                }
+                if (rs.getString(2).equalsIgnoreCase(sq.getOwner())) {
+                    return new BigInteger(rs.getString(1));
+                }
+            }
+        } catch (SQLException e) {
+            LOG.error("TIBERO_SEQUENCE_LAST_NUMBER_SQL", e);
+        } finally {
+            Closer.close(rs);
+            Closer.close(stmt);
+            Closer.close(conn);
+        }
+        return null;
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/TiberoExportHelper.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/TiberoExportHelper.java
@@ -62,8 +62,8 @@ public class TiberoExportHelper extends DBExportHelper {
     public TiberoExportHelper() {
         super();
         handlerMap1.put(Types.DATE, new TimestampTypeHandler());
-        handlerMap2.put("INTERVALDS", new TiberoIntervalDSTypeHandler());
-        handlerMap2.put("INTERVALYM", new TiberoIntervalYMTypeHandler());
+        handlerMap2.put("INTERVAL DAY TO SECOND", new TiberoIntervalDSTypeHandler());
+        handlerMap2.put("INTERVAL YEAR TO MONTH", new TiberoIntervalYMTypeHandler());
         handlerMap2.put("TIMESTAMP WITH LOCAL TIME ZONE", new TimestampTypeHandler());
         handlerMap2.put("TIMESTAMP WITH TIME ZONE", new CharTypeHandler());
     }
@@ -113,7 +113,14 @@ public class TiberoExportHelper extends DBExportHelper {
      * @return SQL
      */
     public String getPagedSelectSQL(String sql, long rows, long exportedRecords, PK pk) {
-        return sql;
+        String cleanSql = sql.trim();
+        long endRow = exportedRecords + rows;
+        StringBuilder buf = new StringBuilder(cleanSql.length() + 128);
+        buf.append("SELECT * FROM (SELECT CMT_PAGED_.*, ROWNUM CMT_ROWNUM FROM (");
+        buf.append(cleanSql);
+        buf.append(") CMT_PAGED_ WHERE ROWNUM <= ").append(endRow);
+        buf.append(") WHERE CMT_ROWNUM > ").append(exportedRecords);
+        return buf.toString();
     }
 
     /**

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/TiberoExportHelper.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/TiberoExportHelper.java
@@ -44,6 +44,8 @@ import com.cubrid.cubridmigration.core.export.handler.TimestampTypeHandler;
 import com.cubrid.cubridmigration.tibero.TiberoDataTypeHelper;
 import com.cubrid.cubridmigration.tibero.export.handler.TiberoIntervalDSTypeHandler;
 import com.cubrid.cubridmigration.tibero.export.handler.TiberoIntervalYMTypeHandler;
+import com.cubrid.cubridmigration.tibero.export.handler.TiberoJsonTypeHandler;
+import com.cubrid.cubridmigration.tibero.export.handler.TiberoXmlTypeHandler;
 
 import org.slf4j.Logger;
 
@@ -64,8 +66,10 @@ public class TiberoExportHelper extends DBExportHelper {
         handlerMap1.put(Types.DATE, new TimestampTypeHandler());
         handlerMap2.put("INTERVAL DAY TO SECOND", new TiberoIntervalDSTypeHandler());
         handlerMap2.put("INTERVAL YEAR TO MONTH", new TiberoIntervalYMTypeHandler());
+        handlerMap2.put("JSON", new TiberoJsonTypeHandler());
         handlerMap2.put("TIMESTAMP WITH LOCAL TIME ZONE", new TimestampTypeHandler());
         handlerMap2.put("TIMESTAMP WITH TIME ZONE", new CharTypeHandler());
+        handlerMap2.put("XMLTYPE", new TiberoXmlTypeHandler());
     }
 
     /**

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/AbstractTiberoTextTypeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/AbstractTiberoTextTypeHandler.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.tibero.export.handler;
+
+import com.cubrid.cubridmigration.core.common.Closer;
+import com.cubrid.cubridmigration.core.dbobject.Column;
+import com.cubrid.cubridmigration.core.export.handler.ClobTypeHandler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLXML;
+
+/** Base handler for Tibero text-oriented source types. */
+public abstract class AbstractTiberoTextTypeHandler extends ClobTypeHandler {
+
+    protected abstract String getTypeNameForError();
+
+    protected Object readTextValue(ResultSet rs, Column column) throws SQLException {
+        final String colName = column.getName();
+        try {
+            return readTextValue(rs.getObject(colName), rs, colName);
+        } catch (Exception e) {
+            if (e instanceof SQLException) {
+                throw (SQLException) e;
+            }
+            throw new SQLException(buildReadErrorMessage(colName), e);
+        }
+    }
+
+    protected Object readTextValue(Object value, ResultSet rs, String colName) throws SQLException {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String) {
+            return value;
+        }
+        if (value instanceof SQLXML) {
+            return readFromSqlXml((SQLXML) value);
+        }
+        if (value instanceof Clob) {
+            return getCharObject(((Clob) value).getCharacterStream());
+        }
+        return rs.getString(colName);
+    }
+
+    protected String readFromSqlXml(SQLXML sqlxml) throws SQLException {
+        try {
+            return sqlxml.getString();
+        } finally {
+            try {
+                sqlxml.free();
+            } catch (Exception ignored) {
+                // ignore SQLXML cleanup failure
+            }
+        }
+    }
+
+    protected String readFromBlob(Blob blob, ResultSet rs, String colName) throws SQLException {
+        if (blob == null) {
+            return null;
+        }
+        try {
+            String value = tryGetString(rs, colName);
+            if (value != null) {
+                return value;
+            }
+            return readFromInputStream(blob.getBinaryStream());
+        } finally {
+            try {
+                blob.free();
+            } catch (Exception ignored) {
+                // ignore BLOB cleanup failure
+            }
+        }
+    }
+
+    protected String readFromInputStream(InputStream inputStream) throws SQLException {
+        if (inputStream == null) {
+            return null;
+        }
+        ByteArrayOutputStream out = null;
+        try {
+            out = new ByteArrayOutputStream();
+            byte[] buffer = new byte[2048];
+            int len = inputStream.read(buffer);
+            while (len != -1) {
+                out.write(buffer, 0, len);
+                len = inputStream.read(buffer);
+            }
+            return decodeBinary(out.toByteArray());
+        } catch (Exception e) {
+            throw new SQLException(
+                    "Failed to decode Tibero " + getTypeNameForError() + " binary value", e);
+        } finally {
+            Closer.close(inputStream);
+        }
+    }
+
+    protected String decodeBinary(byte[] bytes) throws SQLException {
+        try {
+            if (bytes == null) {
+                return null;
+            }
+            if (bytes.length == 0) {
+                return "";
+            }
+            CharsetAndOffset detected = resolveCharsetByBom(bytes);
+            return new String(
+                    bytes, detected.offset, bytes.length - detected.offset, detected.charset);
+        } catch (Exception e) {
+            throw new SQLException(
+                    "Failed to decode Tibero " + getTypeNameForError() + " binary value", e);
+        }
+    }
+
+    protected String tryGetString(ResultSet rs, String colName) {
+        try {
+            return rs.getString(colName);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+
+    protected String buildReadErrorMessage(String colName) {
+        return "Failed to read Tibero " + getTypeNameForError() + " value: " + colName;
+    }
+
+    protected CharsetAndOffset resolveCharsetByBom(byte[] bytes) {
+        if (bytes.length >= 3
+                && bytes[0] == (byte) 0xEF
+                && bytes[1] == (byte) 0xBB
+                && bytes[2] == (byte) 0xBF) {
+            return new CharsetAndOffset(StandardCharsets.UTF_8, 3);
+        }
+        if (bytes.length >= 2 && bytes[0] == (byte) 0xFE && bytes[1] == (byte) 0xFF) {
+            return new CharsetAndOffset(StandardCharsets.UTF_16BE, 2);
+        }
+        if (bytes.length >= 2 && bytes[0] == (byte) 0xFF && bytes[1] == (byte) 0xFE) {
+            return new CharsetAndOffset(StandardCharsets.UTF_16LE, 2);
+        }
+        return new CharsetAndOffset(StandardCharsets.UTF_8, 0);
+    }
+
+    protected static final class CharsetAndOffset {
+        private final Charset charset;
+        private final int offset;
+
+        protected CharsetAndOffset(Charset charset, int offset) {
+            this.charset = charset;
+            this.offset = offset;
+        }
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalDSTypeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalDSTypeHandler.java
@@ -29,18 +29,13 @@
  */
 package com.cubrid.cubridmigration.tibero.export.handler;
 
-import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.dbobject.Column;
 import com.cubrid.cubridmigration.core.export.IExportDataHandler;
-
-import org.slf4j.Logger;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class TiberoIntervalDSTypeHandler implements IExportDataHandler {
-    private static final Logger LOG = LogUtil.getLogger(TiberoIntervalDSTypeHandler.class);
-
     /**
      * Retrieves the value object of INTERVALDS column.
      *
@@ -51,11 +46,12 @@ public class TiberoIntervalDSTypeHandler implements IExportDataHandler {
      */
     public Object getJdbcObject(ResultSet rs, Column column) throws SQLException {
         try {
-            String value = rs.getString(column.getName());
-            return value;
+            return rs.getString(column.getName());
+        } catch (SQLException e) {
+            throw e;
         } catch (Exception e) {
-            LOG.error("", e);
-            return null;
+            throw new SQLException(
+                    "Failed to read Tibero INTERVAL DAY TO SECOND value: " + column.getName(), e);
         }
     }
 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalDSTypeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalDSTypeHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.tibero.export.handler;
+
+import com.cubrid.common.log.LogUtil;
+import com.cubrid.cubridmigration.core.dbobject.Column;
+import com.cubrid.cubridmigration.core.export.IExportDataHandler;
+
+import org.slf4j.Logger;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class TiberoIntervalDSTypeHandler implements IExportDataHandler {
+    private static final Logger LOG = LogUtil.getLogger(TiberoIntervalDSTypeHandler.class);
+
+    /**
+     * Retrieves the value object of INTERVALDS column.
+     *
+     * @param rs the result set
+     * @param column column description
+     * @return value of column
+     * @throws SQLException e
+     */
+    public Object getJdbcObject(ResultSet rs, Column column) throws SQLException {
+        try {
+            String value = rs.getString(column.getName());
+            return value;
+        } catch (Exception e) {
+            LOG.error("", e);
+            return null;
+        }
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalYMTypeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalYMTypeHandler.java
@@ -29,18 +29,13 @@
  */
 package com.cubrid.cubridmigration.tibero.export.handler;
 
-import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.dbobject.Column;
 import com.cubrid.cubridmigration.core.export.IExportDataHandler;
-
-import org.slf4j.Logger;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class TiberoIntervalYMTypeHandler implements IExportDataHandler {
-    private static final Logger LOG = LogUtil.getLogger(TiberoIntervalYMTypeHandler.class);
-
     /**
      * Retrieves the value object of INTERVALYM column.
      *
@@ -51,11 +46,12 @@ public class TiberoIntervalYMTypeHandler implements IExportDataHandler {
      */
     public Object getJdbcObject(ResultSet rs, Column column) throws SQLException {
         try {
-            String value = rs.getString(column.getName());
-            return value;
+            return rs.getString(column.getName());
+        } catch (SQLException e) {
+            throw e;
         } catch (Exception e) {
-            LOG.error("", e);
-            return null;
+            throw new SQLException(
+                    "Failed to read Tibero INTERVAL YEAR TO MONTH value: " + column.getName(), e);
         }
     }
 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalYMTypeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalYMTypeHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.tibero.export.handler;
+
+import com.cubrid.common.log.LogUtil;
+import com.cubrid.cubridmigration.core.dbobject.Column;
+import com.cubrid.cubridmigration.core.export.IExportDataHandler;
+
+import org.slf4j.Logger;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class TiberoIntervalYMTypeHandler implements IExportDataHandler {
+    private static final Logger LOG = LogUtil.getLogger(TiberoIntervalYMTypeHandler.class);
+
+    /**
+     * Retrieves the value object of INTERVALYM column.
+     *
+     * @param rs the result set
+     * @param column column description
+     * @return value of column
+     * @throws SQLException e
+     */
+    public Object getJdbcObject(ResultSet rs, Column column) throws SQLException {
+        try {
+            String value = rs.getString(column.getName());
+            return value;
+        } catch (Exception e) {
+            LOG.error("", e);
+            return null;
+        }
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoJsonTypeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoJsonTypeHandler.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.tibero.export.handler;
+
+import com.cubrid.cubridmigration.core.dbobject.Column;
+import com.cubrid.cubridmigration.core.export.handler.ClobTypeHandler;
+
+import java.sql.Clob;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLXML;
+
+/** Reads Tibero JSON values as String for stable downstream conversion. */
+public class TiberoJsonTypeHandler extends ClobTypeHandler {
+
+    /**
+     * Retrieves the value object of JSON column.
+     *
+     * @param rs the result set
+     * @param column column description
+     * @return value of column
+     * @throws SQLException e
+     */
+    public Object getJdbcObject(ResultSet rs, Column column) throws SQLException {
+        final String colName = column.getName();
+        try {
+            Object value = rs.getObject(colName);
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof String) {
+                return value;
+            }
+            if (value instanceof SQLXML) {
+                return getStringFromSQLXML((SQLXML) value);
+            }
+            if (value instanceof Clob) {
+                return getCharObject(((Clob) value).getCharacterStream());
+            }
+            return rs.getString(colName);
+        } catch (SQLException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SQLException("Failed to read Tibero JSON value: " + colName, e);
+        }
+    }
+
+    private String getStringFromSQLXML(SQLXML sqlxml) throws SQLException {
+        try {
+            return sqlxml.getString();
+        } finally {
+            try {
+                sqlxml.free();
+            } catch (Exception ignored) {
+                // ignore SQLXML cleanup failure
+            }
+        }
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoJsonTypeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoJsonTypeHandler.java
@@ -29,9 +29,14 @@
  */
 package com.cubrid.cubridmigration.tibero.export.handler;
 
+import com.cubrid.cubridmigration.core.common.Closer;
 import com.cubrid.cubridmigration.core.dbobject.Column;
 import com.cubrid.cubridmigration.core.export.handler.ClobTypeHandler;
 
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -48,6 +53,7 @@ public class TiberoJsonTypeHandler extends ClobTypeHandler {
      * @return value of column
      * @throws SQLException e
      */
+    @Override
     public Object getJdbcObject(ResultSet rs, Column column) throws SQLException {
         final String colName = column.getName();
         try {
@@ -63,6 +69,15 @@ public class TiberoJsonTypeHandler extends ClobTypeHandler {
             }
             if (value instanceof Clob) {
                 return getCharObject(((Clob) value).getCharacterStream());
+            }
+            if (value instanceof Blob) {
+                return getStringFromBlob((Blob) value);
+            }
+            if (value instanceof byte[]) {
+                return new String((byte[]) value, StandardCharsets.UTF_8);
+            }
+            if (value instanceof InputStream) {
+                return getStringFromBinaryStream((InputStream) value);
             }
             return rs.getString(colName);
         } catch (SQLException e) {
@@ -81,6 +96,40 @@ public class TiberoJsonTypeHandler extends ClobTypeHandler {
             } catch (Exception ignored) {
                 // ignore SQLXML cleanup failure
             }
+        }
+    }
+
+    private String getStringFromBlob(Blob blob) throws SQLException {
+        try {
+            return getStringFromBinaryStream(blob.getBinaryStream());
+        } finally {
+            try {
+                blob.free();
+            } catch (Exception ignored) {
+                // ignore BLOB cleanup failure
+            }
+        }
+    }
+
+    private String getStringFromBinaryStream(InputStream inputStream) throws SQLException {
+        if (inputStream == null) {
+            return null;
+        }
+        ByteArrayOutputStream out = null;
+        try {
+            out = new ByteArrayOutputStream();
+            byte[] buf = new byte[2048];
+            int len = inputStream.read(buf);
+            while (len != -1) {
+                out.write(buf, 0, len);
+                len = inputStream.read(buf);
+            }
+            return new String(out.toByteArray(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new SQLException("Failed to decode Tibero JSON binary value as UTF-8", e);
+        } finally {
+            Closer.close(inputStream);
+            Closer.close(out);
         }
     }
 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoJsonTypeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoJsonTypeHandler.java
@@ -31,19 +31,14 @@ package com.cubrid.cubridmigration.tibero.export.handler;
 
 import com.cubrid.cubridmigration.core.common.Closer;
 import com.cubrid.cubridmigration.core.dbobject.Column;
-import com.cubrid.cubridmigration.core.export.handler.ClobTypeHandler;
 
-import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
-import java.sql.Clob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.SQLXML;
 
 /** Reads Tibero JSON values as String for stable downstream conversion. */
-public class TiberoJsonTypeHandler extends ClobTypeHandler {
+public class TiberoJsonTypeHandler extends AbstractTiberoTextTypeHandler {
 
     /**
      * Retrieves the value object of JSON column.
@@ -61,75 +56,37 @@ public class TiberoJsonTypeHandler extends ClobTypeHandler {
             if (value == null) {
                 return null;
             }
-            if (value instanceof String) {
-                return value;
-            }
-            if (value instanceof SQLXML) {
-                return getStringFromSQLXML((SQLXML) value);
-            }
-            if (value instanceof Clob) {
-                return getCharObject(((Clob) value).getCharacterStream());
-            }
             if (value instanceof Blob) {
-                return getStringFromBlob((Blob) value);
+                return readFromBlob((Blob) value, rs, colName);
             }
             if (value instanceof byte[]) {
-                return new String((byte[]) value, StandardCharsets.UTF_8);
+                String str = tryGetString(rs, colName);
+                return str == null ? decodeBinary((byte[]) value) : str;
             }
             if (value instanceof InputStream) {
-                return getStringFromBinaryStream((InputStream) value);
+                return readFromInputStreamValue((InputStream) value, rs, colName);
             }
-            return rs.getString(colName);
-        } catch (SQLException e) {
-            throw e;
+            return readTextValue(value, rs, colName);
         } catch (Exception e) {
-            throw new SQLException("Failed to read Tibero JSON value: " + colName, e);
+            if (e instanceof SQLException) {
+                throw (SQLException) e;
+            }
+            throw new SQLException(buildReadErrorMessage(colName), e);
         }
     }
 
-    private String getStringFromSQLXML(SQLXML sqlxml) throws SQLException {
-        try {
-            return sqlxml.getString();
-        } finally {
-            try {
-                sqlxml.free();
-            } catch (Exception ignored) {
-                // ignore SQLXML cleanup failure
-            }
-        }
+    @Override
+    protected String getTypeNameForError() {
+        return "JSON";
     }
 
-    private String getStringFromBlob(Blob blob) throws SQLException {
-        try {
-            return getStringFromBinaryStream(blob.getBinaryStream());
-        } finally {
-            try {
-                blob.free();
-            } catch (Exception ignored) {
-                // ignore BLOB cleanup failure
-            }
-        }
-    }
-
-    private String getStringFromBinaryStream(InputStream inputStream) throws SQLException {
-        if (inputStream == null) {
-            return null;
-        }
-        ByteArrayOutputStream out = null;
-        try {
-            out = new ByteArrayOutputStream();
-            byte[] buf = new byte[2048];
-            int len = inputStream.read(buf);
-            while (len != -1) {
-                out.write(buf, 0, len);
-                len = inputStream.read(buf);
-            }
-            return new String(out.toByteArray(), StandardCharsets.UTF_8);
-        } catch (Exception e) {
-            throw new SQLException("Failed to decode Tibero JSON binary value as UTF-8", e);
-        } finally {
+    private String readFromInputStreamValue(InputStream inputStream, ResultSet rs, String colName)
+            throws SQLException {
+        String value = tryGetString(rs, colName);
+        if (value != null) {
             Closer.close(inputStream);
-            Closer.close(out);
+            return value;
         }
+        return readFromInputStream(inputStream);
     }
 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoXmlTypeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoXmlTypeHandler.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.tibero.export.handler;
+
+import com.cubrid.cubridmigration.core.dbobject.Column;
+import com.cubrid.cubridmigration.core.export.handler.ClobTypeHandler;
+
+import java.sql.Clob;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLXML;
+
+/** Reads Tibero XMLTYPE values as plain text for target-side transformation. */
+public class TiberoXmlTypeHandler extends ClobTypeHandler {
+
+    /**
+     * Retrieves the value object of XMLTYPE column.
+     *
+     * @param rs the result set
+     * @param column column description
+     * @return value of column
+     * @throws SQLException e
+     */
+    public Object getJdbcObject(ResultSet rs, Column column) throws SQLException {
+        final String colName = column.getName();
+        try {
+            Object value = rs.getObject(colName);
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof SQLXML) {
+                return getStringFromSQLXML((SQLXML) value);
+            }
+            if (value instanceof Clob) {
+                return getCharObject(((Clob) value).getCharacterStream());
+            }
+            if (value instanceof String) {
+                return value;
+            }
+            return rs.getString(colName);
+        } catch (SQLException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SQLException("Failed to read Tibero XMLTYPE value: " + colName, e);
+        }
+    }
+
+    private String getStringFromSQLXML(SQLXML sqlxml) throws SQLException {
+        try {
+            return sqlxml.getString();
+        } finally {
+            try {
+                sqlxml.free();
+            } catch (Exception ignored) {
+                // ignore SQLXML cleanup failure
+            }
+        }
+    }
+}

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoXmlTypeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/tibero/export/handler/TiberoXmlTypeHandler.java
@@ -30,15 +30,12 @@
 package com.cubrid.cubridmigration.tibero.export.handler;
 
 import com.cubrid.cubridmigration.core.dbobject.Column;
-import com.cubrid.cubridmigration.core.export.handler.ClobTypeHandler;
 
-import java.sql.Clob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.SQLXML;
 
 /** Reads Tibero XMLTYPE values as plain text for target-side transformation. */
-public class TiberoXmlTypeHandler extends ClobTypeHandler {
+public class TiberoXmlTypeHandler extends AbstractTiberoTextTypeHandler {
 
     /**
      * Retrieves the value object of XMLTYPE column.
@@ -48,39 +45,13 @@ public class TiberoXmlTypeHandler extends ClobTypeHandler {
      * @return value of column
      * @throws SQLException e
      */
+    @Override
     public Object getJdbcObject(ResultSet rs, Column column) throws SQLException {
-        final String colName = column.getName();
-        try {
-            Object value = rs.getObject(colName);
-            if (value == null) {
-                return null;
-            }
-            if (value instanceof SQLXML) {
-                return getStringFromSQLXML((SQLXML) value);
-            }
-            if (value instanceof Clob) {
-                return getCharObject(((Clob) value).getCharacterStream());
-            }
-            if (value instanceof String) {
-                return value;
-            }
-            return rs.getString(colName);
-        } catch (SQLException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new SQLException("Failed to read Tibero XMLTYPE value: " + colName, e);
-        }
+        return readTextValue(rs, column);
     }
 
-    private String getStringFromSQLXML(SQLXML sqlxml) throws SQLException {
-        try {
-            return sqlxml.getString();
-        } finally {
-            try {
-                sqlxml.free();
-            } catch (Exception ignored) {
-                // ignore SQLXML cleanup failure
-            }
-        }
+    @Override
+    protected String getTypeNameForError() {
+        return "XMLTYPE";
     }
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4840>

### Purpose
Tibero 소스 데이터를 CMT 코어 Export 경로에 안정적으로 연동하기 위해 특수 타입 처리 (JSON/XMLTYPE/INTERVAL)를 보강하고, JDBC가 반환하는 다양한 값 형태(문자/LOB/바이너리)를 일관된 값으로 정규화해 변환 파이프라인의 안정성을 높입니다. Tibero Export 동작을 코어 엔진의 일반 처리 흐름과 정합되게 맞춥니다.

### Implementation
- TiberoExportHelper: handlerMap2에 `INTERVAL DAY TO SECOND`, `INTERVAL YEAR TO MONTH`, `JSON`, `XMLTYPE` 핸들러 연결
- TiberoDataTypeHelper 확장: JSON, XMLTYPE 키 정규화 추가
- SQLXML/CLOB/String 공통 텍스트 추출 로직 통합
- JSON 바이너리(Blob, byte[], InpuStream) 처리 추가

### Remarks
N/A
