### PR TITLE
[TOOLS-4866] Set up unit test environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,5 +158,15 @@
                 <module>product</module>
             </modules>
         </profile>
+
+        <profile>
+            <id>unit-test</id>
+            <modules>
+                <module>plugins/com.cubrid.common.log</module>
+                <module>plugins/com.cubrid.common.configuration</module>
+                <module>plugins/com.cubrid.cubridmigration.core</module>
+                <module>tests/unit-test</module>
+            </modules>
+        </profile>
     </profiles>
 </project>

--- a/tests/unit-test/pom.xml
+++ b/tests/unit-test/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.cubrid.cubridmigration</groupId>
+    <artifactId>unit-test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <junit-jupiter.version>6.0.3</junit-jupiter.version>
+        <mockito.version>5.22.0</mockito.version>
+        <assertj.version>3.27.7</assertj.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.cubrid.cubridmigration</groupId>
+            <artifactId>com.cubrid.cubridmigration.core</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.cubrid.cubridmigration</groupId>
+            <artifactId>com.cubrid.common.log</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.cubrid.cubridmigration</groupId>
+            <artifactId>com.cubrid.common.configuration</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4866>

### Purpose
테스트 코드를 OSGi 프래그먼트 번들 방식의 구조에서 벗어나고, 순수 비즈니스 로직에 대한 빠르고 가벼운 유닛 테스트를 실행할 수 있는 독립형 Maven 테스트 모듈을 구성하고자 합니다.

### Implementation
- root pom.xml에 `unit-test` 프로파일 추가
- OSGi 설정이 필요 없는 순수 Maven 테스트 모듈 생성 (`tests/unit-test`)

### Remarks
N/A
