### PR TITLE
[TOOLS-4868] Exclude test code from code style check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -87,14 +87,16 @@ jobs:
       - id: changed
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62
         with:
-          files: "**/*.java"
+          files: |
+            **/*.java
+            !tests/**/*.java
           write_output_files: true
       - uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd
         if: steps.changed.outputs.any_changed == 'true'
         with:
           release-name: v1.32.0
           args: "--aosp --replace --set-exit-if-changed @.github/outputs/all_changed_files.txt"
-          files-excluded: "**/*"
+          files-excluded: "**/tests/**/*.java"
           skip-commit: true
       - name: Suggest code changes
         if: failure()


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4868>

### Purpose
GitHub Actions의 코드 스타일 검사에서 테스트 코드를 제외하도록 수정했습니다.
테스트 코드는 일반 코드와 성격이 다르기도 하고, 굳이 스타일 검사까지 엄격하게 적용할 필요는 없다고 봐서 제외하기로 했습니다.

### Implementation
N/A

### Remarks
N/A
