### PR TITLE
[TOOLS-4868] Add Tibero Unit-Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ target/
 ## test
 
 testd
+tests/unit-test/logs/

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/testutil/TestColumnFactory.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/testutil/TestColumnFactory.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.testutil;
 
 import com.cubrid.cubridmigration.core.dbobject.Column;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/testutil/TestColumnFactory.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/testutil/TestColumnFactory.java
@@ -1,0 +1,44 @@
+package com.cubrid.cubridmigration.testutil;
+
+import com.cubrid.cubridmigration.core.dbobject.Column;
+
+/**
+ * Test Column Factory.
+ *
+ * <p>Usage: {@code import static com.cubrid.cubridmigration.testutil.TestColumnFactory.*;}
+ */
+public final class TestColumnFactory {
+
+    private TestColumnFactory() {}
+
+    public static Column createColumn(String dataType) {
+        return createColumn("TEST_COL", dataType, null, null);
+    }
+
+    public static Column createColumn(String dataType, Integer precision, Integer scale) {
+        return createColumn("TEST_COL", dataType, precision, scale);
+    }
+
+    public static Column createColumnWithDefault(String dataType, String defaultValue) {
+        Column col = createColumn(dataType);
+        col.setDefaultValue(defaultValue);
+        return col;
+    }
+
+    /** charUsed: "C" -> CHAR semantics, "B" -> BYTE semantics */
+    public static Column createCharColumn(String dataType, Integer precision, String charUsed) {
+        Column col = createColumn(dataType, precision, null);
+        col.setCharUsed(charUsed);
+        return col;
+    }
+
+    public static Column createColumn(
+            String name, String dataType, Integer precision, Integer scale) {
+        Column col = new Column();
+        col.setName(name);
+        col.setDataType(dataType);
+        col.setPrecision(precision);
+        col.setScale(scale);
+        return col;
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoDataTypeHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoDataTypeHelperTest.java
@@ -1,12 +1,22 @@
 package com.cubrid.cubridmigration.tibero;
 
+import com.cubrid.cubridmigration.core.datatype.DataType;
+import com.cubrid.cubridmigration.core.dbobject.Catalog;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("TiberoDataTypeHelper")
 public class TiberoDataTypeHelperTest {
@@ -139,6 +149,90 @@ public class TiberoDataTypeHelperTest {
         void singleton_returnSameInstance() {
             assertThat(TiberoDataTypeHelper.getInstance(null))
                     .isSameAs(TiberoDataTypeHelper.getInstance("1.0"));
+        }
+    }
+
+    @Nested
+    @DisplayName("getJdbcDataTypeID()")
+    class GetJdbcDataTypeID {
+
+        @Test
+        @DisplayName("NUMBER -> delegates to number type mapper")
+        void number_returnsJdbcTypeFromPrecisionAndScale() {
+            Integer jdbcType =
+                    TiberoDataTypeHelper.getInstance(null)
+                            .getJdbcDataTypeID(new Catalog(), "NUMBER", 10, 0);
+
+            assertThat(jdbcType).isEqualTo(Types.INTEGER);
+        }
+
+        @Test
+        @DisplayName("unsupported ROWID -> null")
+        void unsupportedRowid_returnsNull() {
+            Integer jdbcType =
+                    TiberoDataTypeHelper.getInstance(null)
+                            .getJdbcDataTypeID(new Catalog(), "ROWID", null, null);
+
+            assertThat(jdbcType).isNull();
+        }
+
+        @Test
+        @DisplayName("fixed type BINARY_FLOAT -> FLOAT")
+        void fixedType_returnsFixedJdbcType() {
+            Integer jdbcType =
+                    TiberoDataTypeHelper.getInstance(null)
+                            .getJdbcDataTypeID(new Catalog(), "BINARY_FLOAT", null, null);
+
+            assertThat(jdbcType).isEqualTo(Types.FLOAT);
+        }
+
+        @Test
+        @DisplayName("dynamic VARCHAR2 -> jdbc type from supported data types")
+        void dynamicType_returnsJdbcTypeFromCatalogMap() {
+            Catalog catalog = createCatalogWithSupportedType("VARCHAR2", Types.VARCHAR);
+
+            Integer jdbcType =
+                    TiberoDataTypeHelper.getInstance(null)
+                            .getJdbcDataTypeID(catalog, "VARCHAR2", 20, null);
+
+            assertThat(jdbcType).isEqualTo(Types.VARCHAR);
+        }
+
+        @Test
+        @DisplayName("normalized TIMESTAMP(6) -> jdbc type from TIMESTAMP key")
+        void normalizedDynamicType_usesNormalizedLookupKey() {
+            Catalog catalog = createCatalogWithSupportedType("TIMESTAMP", Types.TIMESTAMP);
+
+            Integer jdbcType =
+                    TiberoDataTypeHelper.getInstance(null)
+                            .getJdbcDataTypeID(catalog, "TIMESTAMP(6)", null, 6);
+
+            assertThat(jdbcType).isEqualTo(Types.TIMESTAMP);
+        }
+
+        @Test
+        @DisplayName("missing supported type -> IllegalArgumentException")
+        void missingSupportedType_throwsIllegalArgumentException() {
+            Catalog catalog = new Catalog();
+
+            assertThatThrownBy(
+                            () ->
+                                    TiberoDataTypeHelper.getInstance(null)
+                                            .getJdbcDataTypeID(catalog, "VARCHAR2", 10, null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Not supported Tibero data type(VARCHAR2)");
+        }
+
+        private Catalog createCatalogWithSupportedType(String key, int jdbcTypeId) {
+            Catalog catalog = new Catalog();
+            DataType dataType = new DataType();
+            dataType.setTypeName(key);
+            dataType.setJdbcDataTypeID(jdbcTypeId);
+
+            Map<String, List<DataType>> supported = new HashMap<String, List<DataType>>();
+            supported.put(key, Arrays.asList(dataType));
+            catalog.setSupportedDataType(supported);
+            return catalog;
         }
     }
 }

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoDataTypeHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoDataTypeHelperTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero;
 
 import com.cubrid.cubridmigration.core.datatype.DataType;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoDataTypeHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoDataTypeHelperTest.java
@@ -1,0 +1,144 @@
+package com.cubrid.cubridmigration.tibero;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TiberoDataTypeHelper")
+public class TiberoDataTypeHelperTest {
+
+    @Nested
+    @DisplayName("getTiberoDataTypeKey()")
+    class GetTiberoDataTypeKey {
+
+        @Test
+        @DisplayName("null -> emply String")
+        void null_returnEmptyString() {
+            assertThat(TiberoDataTypeHelper.getTiberoDataTypeKey(null)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("empty string -> empty string")
+        void emptyString_returnEmptyString() {
+            assertThat(TiberoDataTypeHelper.getTiberoDataTypeKey("")).isEmpty();
+        }
+
+        @ParameterizedTest(name = "[{index}] \"{0}\" → \"{1}\"")
+        @CsvSource({
+            // No pattern: keep as is with uppercase normalization.
+            "VARCHAR2,             VARCHAR2",
+            "NUMBER,               NUMBER",
+            "CLOB,                 CLOB",
+            "BLOB,                 BLOB",
+            "CHAR,                 CHAR",
+            "NCHAR,                NCHAR",
+            "NVARCHAR2,            NVARCHAR2",
+            "DATE,                 DATE",
+            "ROWID,                ROWID",
+            "RAW,                  RAW",
+            "LONG,                 LONG",
+            "LONG RAW,             LONG RAW",
+            "BINARY_FLOAT,         BINARY_FLOAT",
+            "BINARY_DOUBLE,        BINARY_DOUBLE",
+
+            // TIMESTAMP: strip precision.
+            "TIMESTAMP,            TIMESTAMP",
+            "TIMESTAMP(0),         TIMESTAMP",
+            "TIMESTAMP(6),         TIMESTAMP",
+            "TIMESTAMP(9),         TIMESTAMP",
+
+            // TIME: strip precision.
+            "TIME,                 TIME",
+            "TIME(0),              TIME",
+            "TIME(6),              TIME",
+
+            // TIMESTAMP WITH TIME ZONE pattern.
+            "TIMESTAMP WITH TIME ZONE,              TIMESTAMP WITH TIME ZONE",
+            "TIMESTAMP(6) WITH TIME ZONE,           TIMESTAMP WITH TIME ZONE",
+            "TIMESTAMP(0) WITH TIME ZONE,           TIMESTAMP WITH TIME ZONE",
+
+            // TIMESTAMP WITH LOCAL TIME ZONE pattern.
+            "TIMESTAMP WITH LOCAL TIME ZONE,        TIMESTAMP WITH LOCAL TIME ZONE",
+            "TIMESTAMP(6) WITH LOCAL TIME ZONE,     TIMESTAMP WITH LOCAL TIME ZONE",
+            "TIMESTAMP(3) WITH LOCAL TIME ZONE,     TIMESTAMP WITH LOCAL TIME ZONE",
+
+            // INTERVAL DAY TO SECOND pattern.
+            "INTERVAL DAY TO SECOND,                INTERVAL DAY TO SECOND",
+            "INTERVAL DAY(2) TO SECOND(6),          INTERVAL DAY TO SECOND",
+            "INTERVAL DAY(5) TO SECOND(9),          INTERVAL DAY TO SECOND",
+            "INTERVAL DAY(0) TO SECOND(0),          INTERVAL DAY TO SECOND",
+
+            // INTERVAL YEAR TO MONTH pattern.
+            "INTERVAL YEAR TO MONTH,                INTERVAL YEAR TO MONTH",
+            "INTERVAL YEAR(4) TO MONTH,             INTERVAL YEAR TO MONTH",
+            "INTERVAL YEAR(2) TO MONTH,             INTERVAL YEAR TO MONTH",
+
+            // Special cases.
+            "JSON,                 JSON",
+            "XMLTYPE,              XMLTYPE",
+        })
+        void variousTypes_returnsNormalizedKey(String input, String expected) {
+            assertThat(TiberoDataTypeHelper.getTiberoDataTypeKey(input.trim()))
+                    .isEqualTo(expected.trim());
+        }
+
+        @Test
+        @DisplayName("lowercase input -> uppercase")
+        void lowercaseInput_returnUppercase() {
+            assertThat(TiberoDataTypeHelper.getTiberoDataTypeKey("varchar2"))
+                    .isEqualTo("VARCHAR2");
+        }
+
+        @Test
+        @DisplayName("extra spaces -> single space")
+        void extraWhitespace_normalizedToSingleSpace() {
+            assertThat(TiberoDataTypeHelper.getTiberoDataTypeKey("TIMESTAMP  WITH  TIME  ZONE"))
+                    .isEqualTo("TIMESTAMP WITH TIME ZONE");
+        }
+    }
+
+    @Nested
+    @DisplayName("isBinary()")
+    class IsBianry {
+
+        @Test
+        @DisplayName("blob lowercase -> true")
+        void blob_lowercase_returnsTrue() {
+            assertThat(TiberoDataTypeHelper.getInstance(null).isBinary("blob")).isTrue();
+        }
+
+        @Test
+        @DisplayName("BLOB uppercase -> true")
+        void blob_uppercase_returnTrue() {
+            assertThat(TiberoDataTypeHelper.getInstance(null).isBinary("BLOB")).isTrue();
+        }
+
+        @Test
+        @DisplayName("CLOB -> false for text type")
+        void clob_returnFalse() {
+            assertThat(TiberoDataTypeHelper.getInstance(null).isBinary("CLOB")).isFalse();
+        }
+
+        @Test
+        @DisplayName("RAW -> false in Tibero")
+        void raw_returnsFalse() {
+            assertThat(TiberoDataTypeHelper.getInstance(null).isBinary("RAW")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("getInstance()")
+    class GetInstance {
+
+        @Test
+        @DisplayName("singleton returns same instance")
+        void singleton_returnSameInstance() {
+            assertThat(TiberoDataTypeHelper.getInstance(null))
+                    .isSameAs(TiberoDataTypeHelper.getInstance("1.0"));
+        }
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoJdbcTypeMapperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoJdbcTypeMapperTest.java
@@ -1,0 +1,130 @@
+package com.cubrid.cubridmigration.tibero;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+import java.util.stream.Stream;
+
+@DisplayName("TiberoJdbcTypeMapper")
+public class TiberoJdbcTypeMapperTest {
+
+
+    @Nested
+    @DisplayName("isUnsupportedJdbcType()")
+    class IsUnsupportedJdbcType {
+
+        @Test
+        @DisplayName("ROWID -> true for unsupported type")
+        void rowid_returnTrue() {
+            assertThat(TiberoJdbcTypeMapper.isUnsupportedJdbcType("ROWID")).isTrue();
+        }
+
+        @Test
+        @DisplayName("rowid lowercase -> true")
+        void rowid_lowercase_returnTrue() {
+            assertThat(TiberoJdbcTypeMapper.isUnsupportedJdbcType("rowid")).isTrue();
+        }
+
+        @ParameterizedTest(name = "[{index}] \"{0}\" -> false for supported type")
+        @ValueSource(strings = {"VARCHAR2", "NUMBER", "CLOB", "BLOB", "DATE", "TIMESTAMP",
+                "BINARY_FLOAT", "BINARY_DOUBLE", "CHAR", "NCHAR"})
+        void supportedTypes_returnsFalse(String dataType) {
+            assertThat(TiberoJdbcTypeMapper.isUnsupportedJdbcType(dataType)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("getFixedJdbcTypeId()")
+    class GetFixedJdbcTypeId {
+
+        @Test
+        @DisplayName("BINARY_FLOAT -> Types.FLOAT")
+        void binaryFloat_returnFloat() {
+            assertThat(TiberoJdbcTypeMapper.getFixedJdbcTypeId("BINARY_FLOAT"))
+                    .isEqualTo(Types.FLOAT);
+        }
+
+        @Test
+        @DisplayName("BINARY_DOUBLE -> Types.DOUBLE")
+        void binaryDouble_returnDouble() {
+            assertThat(TiberoJdbcTypeMapper.getFixedJdbcTypeId("BINARY_DOUBLE"))
+                    .isEqualTo(Types.DOUBLE);
+        }
+
+        @ParameterizedTest(name = "[{index}] \"{0}\" -> null for non-fixed type")
+        @ValueSource(strings = {"VARCHAR2", "NUMBER", "CLOB", "BLOB", "DATE", "TIMESTAMP", "ROWID"})
+        void nonFixedTypes_returnsNull(String dataType) {
+            assertThat(TiberoJdbcTypeMapper.getFixedJdbcTypeId(dataType)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("getNumberType")
+    class GetNumberType {
+
+        @Test
+        @DisplayName("precision=null, scale=null -> NUMERIC")
+        void nullPrecisionNullScale_returnsNumeric() {
+            assertThat(TiberoJdbcTypeMapper.getNumberType(null, null))
+                    .isEqualTo(Types.NUMERIC);
+        }
+
+        @Test
+        @DisplayName("precision=null, scale=0 -> BIGINT")
+        void nullPrecisionScale0_returnBigint() {
+            assertThat(TiberoJdbcTypeMapper.getNumberType(null, 0))
+                    .isEqualTo(Types.BIGINT);
+        }
+
+        @ParameterizedTest(name = "[{index}] NUMBER({0},{1}) → JDBC {2}")
+        @MethodSource("com.cubrid.cubridmigration.tibero.TiberoJdbcTypeMapperTest#precisionScaleToJdbcType")
+        void precisionScale_mapsToCorrectJdbcType(
+                Integer precision, Integer scale, int expectedJdbcType) {
+            assertThat(TiberoJdbcTypeMapper.getNumberType(precision, scale))
+                    .isEqualTo(expectedJdbcType);
+        }
+    }
+
+    static Stream<Arguments> precisionScaleToJdbcType() {
+        return Stream.of(
+                // precision1 -> BIT
+                Arguments.of(1, 0, Types.BIT),
+                Arguments.of(1, null, Types.BIT),
+
+                // precision=3 → TINYINT
+                Arguments.of(3, 0, Types.TINYINT),
+                Arguments.of(3, null, Types.TINYINT),
+
+                // precision=5 → SMALLINT
+                Arguments.of(5, 0, Types.SMALLINT),
+                Arguments.of(5, null, Types.SMALLINT),
+
+                // precision 2, 4, 6~10 -> INTEGER
+                Arguments.of(2, 0, Types.INTEGER),
+                Arguments.of(4, 0, Types.INTEGER),
+                Arguments.of(6, 0, Types.INTEGER),
+                Arguments.of(9, 0, Types.INTEGER),
+                Arguments.of(10, 0, Types.INTEGER),
+
+                // precision 11~38 → BIGINT
+                Arguments.of(11, 0, Types.BIGINT),
+                Arguments.of(18, 0, Types.BIGINT),
+                Arguments.of(38, 0, Types.BIGINT),
+
+                // precision > 38 -> NUMERIC
+                Arguments.of(39, 0, Types.NUMERIC),
+
+                // scale set -> NUMERIC
+                Arguments.of(10, 2, Types.NUMERIC),
+                Arguments.of(38, 15, Types.NUMERIC)
+        );
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoJdbcTypeMapperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoJdbcTypeMapperTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero;
 
 import org.junit.jupiter.api.DisplayName;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoSQLHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoSQLHelperTest.java
@@ -1,0 +1,93 @@
+package com.cubrid.cubridmigration.tibero;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TiberoSQLHelper")
+public class TiberoSQLHelperTest {
+
+    private static final TiberoSQLHelper HELPER = TiberoSQLHelper.getInstance(null);
+
+    @Nested
+    @DisplayName("getTestSelectSQL()")
+    class GetTestSelectSQL {
+
+        @Test
+        @DisplayName("SELECT * FROM T -> wrapped with WHERE 1<>1")
+        void simpleSelect_wrapsWithWhereClause() {
+            String sql = "SELECT * FROM EMP";
+
+            String result = HELPER.getTestSelectSQL(sql);
+
+            assertThat(result).isEqualTo("SELECT * FROM ( SELECT * FROM EMP ) WHERE 1<>1");
+        }
+
+        @Test
+        @DisplayName("result contains original SQL")
+        void result_containsOriginalSql() {
+            String sql = "SELECT ID, NAME FROM ACCOUNTS WHERE STATUS = 'ACTIVE'";
+
+            String result = HELPER.getTestSelectSQL(sql);
+
+            assertThat(result).contains(sql);
+            assertThat(result).startsWith("SELECT * FROM (");
+            assertThat(result).endsWith("WHERE 1<>1");
+        }
+
+        @Test
+        @DisplayName("result is a zero-row query")
+        void result_hasZeroRowCondition() {
+            String result = HELPER.getTestSelectSQL("SELECT 1 FROM DUAL");
+
+            assertThat(result).contains("WHERE 1<>1");
+        }
+    }
+
+    @Nested
+    @DisplayName("getQuotedObjName()")
+    class GetQuotedObjName {
+
+        @Test
+        @DisplayName("normal table name -> double quotes")
+        void tableName_wrapsInDoubleQoutes() {
+            assertThat(HELPER.getQuotedObjName("MY_TABLE"))
+                    .isEqualTo("\"MY_TABLE\"");
+        }
+
+        @Test
+        @DisplayName("lowercase object name -> keep case")
+        void lowercase_wrapsWithoutCaseChange() {
+            assertThat(HELPER.getQuotedObjName("my_view"))
+                    .isEqualTo("\"my_view\"");
+        }
+
+        @Test
+        @DisplayName("reserved word -> double quotes")
+        void reservedWord_wrapsInDoubleQuotes() {
+            assertThat(HELPER.getQuotedObjName("SELECT"))
+                    .isEqualTo("\"SELECT\"");
+        }
+
+        @Test
+        @DisplayName("empty string -> two double quotes")
+        void emptyString_returnsEmptyQuotes() {
+            assertThat(HELPER.getQuotedObjName(""))
+                    .isEqualTo("\"\"");
+        }
+    }
+
+    @Nested
+    @DisplayName("getInstance()")
+    class GetInstance {
+
+        @Test
+        @DisplayName("singleton returns same instance")
+        void singleton_returnsSameInstance() {
+            assertThat(TiberoSQLHelper.getInstance(null))
+                    .isSameAs(TiberoSQLHelper.getInstance("7.0"));
+        }
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoSQLHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoSQLHelperTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero;
 
 import org.junit.jupiter.api.DisplayName;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoTypeFormatterTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoTypeFormatterTest.java
@@ -1,0 +1,161 @@
+package com.cubrid.cubridmigration.tibero;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static com.cubrid.cubridmigration.testutil.TestColumnFactory.*;
+
+@DisplayName("TiberoTypeFormatter")
+public class TiberoTypeFormatterTest {
+
+    private static final TiberoDataTypeHelper HELPER = TiberoDataTypeHelper.getInstance(null);
+
+    @Nested
+    @DisplayName("NUMBER format")
+    class NumberFormat {
+
+        @Test
+        @DisplayName("NUMBER (precision=null) -> \"NUMBER\"")
+        void numberNoPrecision_returnsNumber() {
+            assertThat(TiberoTypeFormatter.format(createColumn("NUMBER"), HELPER))
+                    .isEqualTo("NUMBER");
+        }
+
+        @Test
+        @DisplayName("NUMBER (precision=0) -> \"NUMBER\"")
+        void numberPrecision0_returnNumber() {
+            assertThat(TiberoTypeFormatter.format(createColumn("NUMBER", 0, null), HELPER))
+                    .isEqualTo("NUMBER");
+        }
+
+        @Test
+        @DisplayName("NUMBER(10) -> \"NUMBER(10,0)\"")
+        void numberPrecisionOnly_returnsNumberWithPrecision() {
+            assertThat(TiberoTypeFormatter.format(createColumn("NUMBER", 10, null), HELPER))
+                    .isEqualTo("NUMBER(10,0)");
+        }
+
+        @Test
+        @DisplayName("NUMBER(10,2) → \"NUMBER(10,2)\"")
+        void numberPrecisionAndScale_returnsNumberWithBoth() {
+            assertThat(TiberoTypeFormatter.format(createColumn("NUMBER", 10, 2), HELPER))
+                    .isEqualTo("NUMBER(10,2)");
+        }
+
+        @Test
+        @DisplayName("NUMBER(38,15) -> \"NUMBER(38,15)\"")
+        void numberMaxPrecision_returnsFormattedNumber() {
+            assertThat(TiberoTypeFormatter.format(createColumn("NUMBER", 38, 15), HELPER))
+                    .isEqualTo("NUMBER(38,15)");
+        }
+    }
+
+    @Nested
+    @DisplayName("string type format")
+    class StringTypeFormat {
+
+        @ParameterizedTest(name = "[{index}] {0}{1} -> \"{0}({1})\"")
+        @CsvSource({
+            "VARCHAR, 100",
+            "VARCHAR, 4000",
+            "VARCHAR2, 100",
+            "VARCHAR2, 4000",
+            "CHAR,     10",
+            "NCHAR,    10",
+            "NVARCHAR2,200",
+        })
+        void stringTypesWithPrecision_returnsTypeWithPrecision(String dataType, int precision) {
+            assertThat(TiberoTypeFormatter.format(createColumn(dataType, precision, null), HELPER))
+                    .isEqualTo(dataType + "(" + precision + ")");
+        }
+
+        @Test
+        @DisplayName("VARCHAR with precision=null -> \"VARCHAR\"")
+        void varcharNoPrecision_returnTypeOnly() {
+            assertThat(TiberoTypeFormatter.format(createColumn("VARCHAR"), HELPER))
+                    .isEqualTo("VARCHAR");
+        }
+
+        @Test
+        @DisplayName("VARCHAR with precision=0 -> \"VARCHAR\"")
+        void varcharPrecision0_returnsTypeOnly() {
+            assertThat(TiberoTypeFormatter.format(createColumn("VARCHAR", 0, null), HELPER))
+                    .isEqualTo("VARCHAR");
+        }
+
+        @Test
+        @DisplayName("CHAR(10 CHAR) when charUsed='C")
+        void charWithCharSemantics_appendsCharSuffix() {
+            assertThat(TiberoTypeFormatter.format(createCharColumn("CHAR", 10, "C"), HELPER))
+                    .isEqualTo("CHAR(10 CHAR)");
+        }
+
+        @Test
+        @DisplayName("CHAR(10) when charUsed='B'")
+        void charWithByteSemantics_noCHARSuffix() {
+            assertThat(TiberoTypeFormatter.format(createCharColumn("CHAR", 10, "B"), HELPER))
+                    .isEqualTo("CHAR(10)");
+        }
+    }
+
+    @Nested
+    @DisplayName("RAW format")
+    class RawTypeFormat {
+
+        @Test
+        @DisplayName("RAW(100) -> \"RAW(100)\"")
+        void rawWithPrecision_returnWithPrecision() {
+            assertThat(TiberoTypeFormatter.format(createColumn("RAW", 100, null), HELPER))
+                    .isEqualTo("RAW(100)");
+        }
+
+        @Test
+        @DisplayName("RAW (precision=null) → \"RAW\"")
+        void rawNoPrecision_returnsTypeOnly() {
+            assertThat(TiberoTypeFormatter.format(createColumn("RAW"), HELPER))
+                    .isEqualTo("RAW");
+        }
+    }
+
+    @Nested
+    @DisplayName("pass-through types")
+    class PassThroughTypes {
+
+        @ParameterizedTest(name = "[{index}] {0} → {0}")
+        @CsvSource({
+            "TIMESTAMP",
+            "DATE",
+            "CLOB",
+            "BLOB",
+            "XMLTYPE",
+            "JSON",
+            "ROWID",
+            "INTERVAL DAY TO SECOND",
+            "INTERVAL YEAR TO MONTH",
+            "TIMESTAMP WITH TIME ZONE",
+            "TIMESTAMP WITH LOCAL TIME ZONE",
+            "BINARY_FLOAT",
+            "BINARY_DOUBLE",
+        })
+        void passThroughTypes_returnedUnchanged(String dataType) {
+            assertThat(TiberoTypeFormatter.format(createColumn(dataType), HELPER))
+                    .isEqualTo(dataType);
+        }
+    }
+
+    @Nested
+    @DisplayName("edge cases")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("dataType=null -> empty string")
+        void nullDataType_returnsEmptyString() {
+            assertThat(TiberoTypeFormatter.format(createColumn(null), HELPER))
+                    .isEmpty();
+        }
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoTypeFormatterTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/TiberoTypeFormatterTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero;
 
 import org.junit.jupiter.api.DisplayName;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/TiberoExportHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/TiberoExportHelperTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero.export;
 
 import com.cubrid.cubridmigration.core.dbtype.DatabaseType;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/TiberoExportHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/TiberoExportHelperTest.java
@@ -1,0 +1,85 @@
+package com.cubrid.cubridmigration.tibero.export;
+
+import com.cubrid.cubridmigration.core.dbtype.DatabaseType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TiberoExportHelper")
+public class TiberoExportHelperTest {
+
+    private static final TiberoExportHelper HELPER = new TiberoExportHelper();
+
+    @Nested
+    @DisplayName("getDBType()")
+    class GetDBType {
+
+        @Test
+        @DisplayName("returns DatabaseType.TIBERO")
+        void returnsTypeTibero() {
+            assertThat(HELPER.getDBType()).isEqualTo(DatabaseType.TIBERO);
+        }
+    }
+
+    @Nested
+    @DisplayName("getPagedSelectSQL")
+    class GetPagedSelectSQL {
+
+        @Test
+        @DisplayName("first page -> ROWNUM <= 100 and CMT_ROWNUM > 0")
+        void firstPage_correctRownumBounds() {
+            String sql = "SELECT * FROM EMP";
+            String result = HELPER.getPagedSelectSQL(sql, 100, 0, null);
+
+            assertThat(result).startsWith("SELECT * FROM (SELECT CMT_PAGED_.*, ROWNUM CMT_ROWNUM FROM (");
+            assertThat(result).contains("SELECT * FROM EMP");
+            assertThat(result).contains(") CMT_PAGED_ WHERE ROWNUM <= 100");
+            assertThat(result).contains(") WHERE CMT_ROWNUM > 0");
+        }
+
+        @Test
+        @DisplayName("second page -> ROWNUM <= 200 and CMT_ROWNUM > 100")
+        void secondPage_correctRownumBounds() {
+            String result = HELPER.getPagedSelectSQL("SLECT * FROM EMP", 100, 100, null);
+
+            assertThat(result).contains("ROWNUM <= 200");
+            assertThat(result).contains("CMT_ROWNUM > 100");
+        }
+
+        @ParameterizedTest(name = "[{index}] rows={0}, exported={1} → endRow={2}, start={3}")
+        @CsvSource({
+            "50,   0,   50,  0",
+            "50,  50,  100, 50",
+            "200,  0,  200,  0",
+            "1,    0,    1,  0",
+        })
+        @DisplayName("checks endRow for rows/exportedRecords")
+        void rownumBounds_variousCombinations(long rows, long exported, long expectedEnd, long expectedStart) {
+            String result = HELPER.getPagedSelectSQL("SELECT 1 FROM DUAL", rows, exported, null);
+
+            assertThat(result).contains("ROWNUM <= " + expectedEnd);
+            assertThat(result).contains("CMT_ROWNUM > " + expectedStart);
+        }
+
+        @Test
+        @DisplayName("trims sql")
+        void sql_trimmed() {
+            String result = HELPER.getPagedSelectSQL("  SELECT * FROM EMP  ", 10, 0, null);
+
+            assertThat(result).contains("SELECT * FROM EMP");
+        }
+
+        @Test
+        @DisplayName("works with null pk")
+        void nullPk_works() {
+            String result = HELPER.getPagedSelectSQL("SELECT * FROM T", 10, 0, null);
+
+            assertThat(result).isNotNull().isNotEmpty();
+        }
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/AbstractTiberoTextTypeHandlerTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/AbstractTiberoTextTypeHandlerTest.java
@@ -1,0 +1,215 @@
+package com.cubrid.cubridmigration.tibero.export.handler;
+
+import com.cubrid.cubridmigration.core.dbobject.Column;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests internal logic of AbstractTiberoTextTypeHandler via TestTextTypeHandler.
+ */
+@DisplayName("AbstractTiberoTextTypeHandler")
+public class AbstractTiberoTextTypeHandlerTest {
+
+    static class TestTextTypeHandler extends AbstractTiberoTextTypeHandler {
+        @Override
+        protected String getTypeNameForError() {
+            return "TEST";
+        }
+    }
+
+    private static final TestTextTypeHandler HANDLER = new TestTextTypeHandler();
+
+    @Nested
+    @DisplayName("buildReadErrorMessage()")
+    class BuildReadErrorMessage {
+
+        @Test
+        @DisplayName("returns \"Failed to read Tibero TEST value: COL\"")
+        void returnsFormattedMessage() {
+            assertThat(HANDLER.buildReadErrorMessage("MY_COL"))
+                    .isEqualTo("Failed to read Tibero TEST value: MY_COL");
+        }
+
+        @Test
+        @DisplayName("message contains column name")
+        void colNameIncludedMessage() {
+            assertThat(HANDLER.buildReadErrorMessage("JSON_DATA"))
+                    .contains("JSON_DATA");
+        }
+    }
+
+    @Nested
+    @DisplayName("resolveCharsetByBom")
+    class ResolveCharsetByBom {
+
+        @Test
+        @DisplayName("UTF-8 BOM (EF BB BF) -> UTF-8, offset=3")
+        void utf8Bom_returnsUtf8Offset3() throws SQLException {
+            byte[] bytes = new byte[] {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF, 'H', 'i'};
+
+            String result = HANDLER.decodeBinary(bytes);
+
+            assertThat(result).isEqualTo("Hi");
+        }
+
+        @Test
+        @DisplayName("UTF-16BE BOM (FE FF) → UTF-16BE, offset=2")
+        void utf16BeBom_returnsUtf16Be() throws SQLException {
+            // "A" in UTF-16BE is 0x00 0x41
+            byte[] bytes = new byte[]{(byte) 0xFE, (byte) 0xFF, 0x00, 0x41};
+
+            String result = HANDLER.decodeBinary(bytes);
+
+            assertThat(result).isEqualTo("A");
+        }
+
+        @Test
+        @DisplayName("UTF-16LE BOM (FF FE) → UTF-16LE, offset=2")
+        void utf16LeBom_returnsUtf16Le() throws SQLException {
+            // "A" in UTF-16LE is 0x41 0x00
+            byte[] bytes = new byte[]{(byte) 0xFF, (byte) 0xFE, 0x41, 0x00};
+
+            String result = HANDLER.decodeBinary(bytes);
+
+            assertThat(result).isEqualTo("A");
+        }
+
+        @Test
+        @DisplayName("no BOM -> UTF-8 default, offset=0")
+        void noBom_defaultsToUtf8() throws SQLException {
+            byte[] bytes = "Hello".getBytes(StandardCharsets.UTF_8);
+
+            String result = HANDLER.decodeBinary(bytes);
+
+            assertThat(result).isEqualTo("Hello");
+        }
+    }
+
+    @Nested
+    @DisplayName("decodeBinary()")
+    class DecodeBinary {
+
+        @Test
+        @DisplayName("null -> null")
+        void nullBytes_returnsNull() throws SQLException {
+            assertThat(HANDLER.decodeBinary(null)).isNull();
+        }
+
+        @Test
+        @DisplayName("empty array -> empty string")
+        void emptyBytes_returnsEmptyString() throws SQLException {
+            assertThat(HANDLER.decodeBinary(new byte[0])).isEmpty();
+        }
+
+        @Test
+        @DisplayName("decodes UTF-8 Korean text")
+        void koreanUtf8_decodedCorrectly() throws SQLException {
+            byte[] bytes = "안녕".getBytes(StandardCharsets.UTF_8);
+
+            assertThat(HANDLER.decodeBinary(bytes)).isEqualTo("안녕");
+        }
+    }
+
+    @Nested
+    @DisplayName("readFromInputStream")
+    class ReadFromInputStream {
+
+        @Test
+        @DisplayName("null InputStream -> null")
+        void nullInputStream_returnsNull() throws SQLException {
+            assertThat(HANDLER.readFromInputStream(null)).isNull();
+        }
+
+        @Test
+        @DisplayName("reads text from InputStream")
+        void inputStream_readsText() throws SQLException {
+            byte[] data = "test data".getBytes(StandardCharsets.UTF_8);
+
+            String result = HANDLER.readFromInputStream(new ByteArrayInputStream(data));
+
+            assertThat(result).isEqualTo("test data");
+        }
+
+        @Test
+        @DisplayName("reads all data over 2048 bytes")
+        void largeInputStream_readsAll() throws SQLException {
+            String longStr = "X".repeat(5000);
+            byte[] data = longStr.getBytes(StandardCharsets.UTF_8);
+
+            String result = HANDLER.readFromInputStream(new ByteArrayInputStream(data));
+
+            assertThat(result).hasSize(5000);
+        }
+    }
+
+    @Nested
+    @DisplayName("readTextValue(Object, ResultSet, String)")
+    class ReadTextValueObjectDispatch {
+
+        @Test
+        @DisplayName("null -> null")
+        void nullValue_returnsNull() throws SQLException {
+            ResultSet rs = mock(ResultSet.class);
+            assertThat(HANDLER.readTextValue(null, rs, "COL")).isNull();
+        }
+
+        @Test
+        @DisplayName("String -> return as is")
+        void stringValue_returnedAsIs() throws SQLException {
+            ResultSet rs = mock(ResultSet.class);
+            assertThat(HANDLER.readTextValue("hello", rs, "COL")).isEqualTo("hello");
+        }
+
+        @Test
+        @DisplayName("other object -> delegate to rs.getString()")
+        void otherObject_delegatesToGetString() throws SQLException {
+            ResultSet rs = mock(ResultSet.class);
+            when(rs.getString("COL")).thenReturn("from_rs");
+
+            assertThat(HANDLER.readTextValue(new Object(), rs, "COL")).isEqualTo("from_rs");
+        }
+    }
+
+    @Nested
+    @DisplayName("readTextValue(ResultSet, Column) exception handling")
+    class ReadTextValueExceptionHandling {
+
+        @Test
+        @DisplayName("SQLException -> rethrow")
+        void sqlException_rethrown() throws SQLException {
+            ResultSet rs = mock(ResultSet.class);
+            Column col = new Column();
+            col.setName("COL");
+            when(rs.getObject("COL")).thenThrow(new SQLException("DB error"));
+
+            assertThatThrownBy(() -> HANDLER.readTextValue(rs, col))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessage("DB error");
+        }
+
+        @Test
+        @DisplayName("non-SQL exception -> wrap to SQLException with column name")
+        void nonSqlException_wrappedWithColName() throws SQLException {
+            ResultSet rs = mock(ResultSet.class);
+            Column col = new Column();
+            col.setName("MY_COL");
+            when(rs.getObject("MY_COL")).thenThrow(new RuntimeException("unexpected"));
+
+            assertThatThrownBy(() -> HANDLER.readTextValue(rs, col))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("MY_COL");
+        }
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/AbstractTiberoTextTypeHandlerTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/AbstractTiberoTextTypeHandlerTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero.export.handler;
 
 import com.cubrid.cubridmigration.core.dbobject.Column;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalDSTypeHandlerTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalDSTypeHandlerTest.java
@@ -1,0 +1,70 @@
+package com.cubrid.cubridmigration.tibero.export.handler;
+
+import com.cubrid.cubridmigration.core.dbobject.Column;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("TiberoIntervalDSTypeHandler")
+public class TiberoIntervalDSTypeHandlerTest {
+
+    private static final TiberoIntervalDSTypeHandler HANDLER = new TiberoIntervalDSTypeHandler();
+
+    private ResultSet rs;
+    private Column column;
+
+    @BeforeEach
+    void setUp() {
+        rs = mock(ResultSet.class);
+        column = new Column();
+        column.setName("DURATION_COL");
+    }
+
+    @Test
+    @DisplayName("normal value -> return getString() result")
+    void normal_returnsStringValue() throws SQLException {
+        when(rs.getString("DURATION_COL")).thenReturn("1 2:03:04.5");
+
+        Object result = HANDLER.getJdbcObject(rs, column);
+
+        assertThat(result).isEqualTo("1 2:03:04.5");
+    }
+
+    @Test
+    @DisplayName("null value -> null")
+    void nullValue_returnsNull() throws SQLException {
+        when(rs.getString("DURATION_COL")).thenReturn(null);
+
+        assertThat(HANDLER.getJdbcObject(rs, column)).isNull();
+    }
+
+    @Test
+    @DisplayName("SQLException -> rethrow")
+    void sqlException_rethrown() throws SQLException {
+        when(rs.getString("DURATION_COL")).thenThrow(new SQLException("DB error"));
+
+        assertThatThrownBy(() -> HANDLER.getJdbcObject(rs, column))
+                .isInstanceOf(SQLException.class)
+                .hasMessage("DB error");
+    }
+
+    @Test
+    @DisplayName("non-SQL RuntimeException -> wrap to SQLException with column name")
+    void runtimeException_wrappedInSqlException() throws SQLException {
+        when(rs.getString("DURATION_COL")).thenThrow(new RuntimeException("unexpected"));
+
+        assertThatThrownBy(() -> HANDLER.getJdbcObject(rs, column))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("INTERVAL DAY TO SECOND")
+                .hasMessageContaining("DURATION_COL");
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalDSTypeHandlerTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalDSTypeHandlerTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero.export.handler;
 
 import com.cubrid.cubridmigration.core.dbobject.Column;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalYMTypeHandlerTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalYMTypeHandlerTest.java
@@ -1,0 +1,68 @@
+package com.cubrid.cubridmigration.tibero.export.handler;
+
+import com.cubrid.cubridmigration.core.dbobject.Column;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("TiberoIntervalYMTypeHandler")
+public class TiberoIntervalYMTypeHandlerTest {
+
+    private TiberoIntervalYMTypeHandler HANDLER = new TiberoIntervalYMTypeHandler();
+
+    private ResultSet rs;
+    private Column column;
+
+    @BeforeEach
+    void setUp() {
+        rs = mock(ResultSet.class);
+        column = new Column();
+        column.setName("TENURE_COL");
+    }
+
+    @Test
+    @DisplayName("normal value -> return getString() result")
+    void normal_returnsStringValue() throws SQLException {
+        when(rs.getString("TENURE_COL")).thenReturn("2-3");
+
+        assertThat(HANDLER.getJdbcObject(rs, column)).isEqualTo("2-3");
+    }
+
+    @Test
+    @DisplayName("null value -> null")
+    void nullValue_returnsNull() throws SQLException {
+        when(rs.getString("TENURE_COL")).thenReturn(null);
+
+        assertThat(HANDLER.getJdbcObject(rs, column)).isNull();
+    }
+
+    @Test
+    @DisplayName("SQLException -> rethrow")
+    void sqlException_rethrown() throws SQLException {
+        when(rs.getString("TENURE_COL")).thenThrow(new SQLException("DB error"));
+
+        assertThatThrownBy(() -> HANDLER.getJdbcObject(rs, column))
+                .isInstanceOf(SQLException.class)
+                .hasMessage("DB error");
+    }
+
+    @Test
+    @DisplayName("non-SQL RuntimeException -> wrap to SQLException with column name")
+    void runtimeException_wrappedInSqlException() throws SQLException {
+        when(rs.getString("TENURE_COL")).thenThrow(new RuntimeException("unexpected"));
+
+        assertThatThrownBy(() -> HANDLER.getJdbcObject(rs, column))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("INTERVAL YEAR TO MONTH")
+                .hasMessageContaining("TENURE_COL");
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalYMTypeHandlerTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoIntervalYMTypeHandlerTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero.export.handler;
 
 import com.cubrid.cubridmigration.core.dbobject.Column;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoJsonTypeHandlerTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoJsonTypeHandlerTest.java
@@ -1,0 +1,139 @@
+package com.cubrid.cubridmigration.tibero.export.handler;
+
+import com.cubrid.cubridmigration.core.dbobject.Column;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Blob;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("TiberoJsonTypeHandler")
+public class TiberoJsonTypeHandlerTest {
+
+    private static final TiberoJsonTypeHandler HANDLER = new TiberoJsonTypeHandler();
+
+    private ResultSet rs;
+    private Column column;
+
+    @BeforeEach
+    void setUp() {
+        rs = mock(ResultSet.class);
+        column = new Column();
+        column.setName("JSON_COL");
+    }
+
+    @Test
+    @DisplayName("getTypeNameForError() → \"JSON\"")
+    void getTypeNameForError_returnsJson() {
+        assertThat(HANDLER.getTypeNameForError()).isEqualTo("JSON");
+    }
+
+    @Test
+    @DisplayName("null value -> null")
+    void nullValue_returnsNull() throws SQLException {
+        when(rs.getObject("JSON_COL")).thenReturn(null);
+
+        assertThat(HANDLER.getJdbcObject(rs, column)).isNull();
+    }
+
+    @Test
+    @DisplayName("String object -> return as is via readTextValue")
+    void stringValue_returnedAsIs() throws SQLException {
+        when(rs.getObject("JSON_COL")).thenReturn("{\"key\":\"value\"}");
+
+        assertThat(HANDLER.getJdbcObject(rs, column)).isEqualTo("{\"key\":\"value\"}");
+    }
+
+    @Nested
+    @DisplayName("byte[] handling")
+    class ByteArrayDispatch {
+
+        @Test
+        @DisplayName("byte[] with getString -> prefer getString")
+        void byteArray_getStringSucceeds_returnsString() throws SQLException {
+            when(rs.getObject("JSON_COL")).thenReturn("{\"a\":1}".getBytes(StandardCharsets.UTF_8));
+            when(rs.getString("JSON_COL")).thenReturn("{\"a\":1}");
+
+            assertThat(HANDLER.getJdbcObject(rs, column)).isEqualTo("{\"a\":1}");
+        }
+
+        @Test
+        @DisplayName("byte[] with null getString -> decodeBinary as UTF-8")
+        void byteArray_getStringNull_decodesBytes() throws SQLException {
+            byte[] bytes = "{\"b\":2}".getBytes(StandardCharsets.UTF_8);
+            when(rs.getObject("JSON_COL")).thenReturn(bytes);
+            when(rs.getString("JSON_COL")).thenReturn(null);
+
+            assertThat(HANDLER.getJdbcObject(rs, column)).isEqualTo("{\"b\":2}");
+        }
+    }
+
+    @Nested
+    @DisplayName("InputStream handling")
+    class InputStreamDispatch {
+
+        @Test
+        @DisplayName("InputStream with getString -> prefer getString")
+        void inputStream_getStringSucceeds_returnsString() throws SQLException {
+            ByteArrayInputStream stream = new ByteArrayInputStream("{\"c\":3}".getBytes(StandardCharsets.UTF_8));
+            when(rs.getObject("JSON_COL")).thenReturn(stream);
+            when(rs.getString("JSON_COL")).thenReturn("{\"c\":3}");
+
+            assertThat(HANDLER.getJdbcObject(rs, column)).isEqualTo("{\"c\":3}");
+        }
+
+        @Test
+        @DisplayName("InputStream with null getString -> read from stream")
+        void inputStream_getStringNull_readsStream() throws SQLException {
+            byte[] data = "{\"d\":4}".getBytes(StandardCharsets.UTF_8);
+            ByteArrayInputStream stream = new ByteArrayInputStream(data);
+            when(rs.getObject("JSON_COL")).thenReturn(stream);
+            when(rs.getString("JSON_COL")).thenReturn(null);
+
+            assertThat(HANDLER.getJdbcObject(rs, column)).isEqualTo("{\"d\":4}");
+        }
+    }
+
+    @Test
+    @DisplayName("Blob with null getString -> read from binaryStream")
+    void blobValue_readFromBlobStream() throws Exception {
+        Blob blob = mock(Blob.class);
+        byte[] data = "{\"e\":5}".getBytes(StandardCharsets.UTF_8);
+        when(rs.getObject("JSON_COL")).thenReturn(blob);
+        when(rs.getString("JSON_COL")).thenReturn(null);
+        when(blob.getBinaryStream()).thenReturn(new ByteArrayInputStream(data));
+
+        assertThat(HANDLER.getJdbcObject(rs, column)).isEqualTo("{\"e\":5}");
+    }
+
+    @Test
+    @DisplayName("SQLException -> rethrow")
+    void sqlException_rethrown() throws SQLException {
+        when(rs.getObject("JSON_COL")).thenThrow(new SQLException("json error"));
+
+        assertThatThrownBy(() -> HANDLER.getJdbcObject(rs, column))
+                .isInstanceOf(SQLException.class)
+                .hasMessage("json error");
+    }
+
+    @Test
+    @DisplayName("non-SQL exception -> wrap to SQLException with column name")
+    void runtimeException_wrappedWithColName() throws SQLException {
+        when(rs.getObject("JSON_COL")).thenThrow(new RuntimeException("unexpected"));
+
+        assertThatThrownBy(() -> HANDLER.getJdbcObject(rs, column))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("JSON_COL");
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoJsonTypeHandlerTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoJsonTypeHandlerTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero.export.handler;
 
 import com.cubrid.cubridmigration.core.dbobject.Column;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoXmlTypeHandlerText.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoXmlTypeHandlerText.java
@@ -1,0 +1,84 @@
+package com.cubrid.cubridmigration.tibero.export.handler;
+
+import com.cubrid.cubridmigration.core.dbobject.Column;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("TiberoXmlTypeHandler")
+public class TiberoXmlTypeHandlerText {
+
+    private static final TiberoXmlTypeHandler HANDLER = new TiberoXmlTypeHandler();
+
+    private ResultSet rs = mock(ResultSet.class);
+    private Column column = new Column();
+
+    @BeforeEach
+    void setUp() {
+        rs = mock(ResultSet.class);
+        column = new Column();
+        column.setName("XML_COL");
+    }
+
+    @Test
+    @DisplayName("getTypeNameForError() → \"XMLTYPE\"")
+    void getTypeNameForError_returnsXmlType() {
+        assertThat(HANDLER.getTypeNameForError()).isEqualTo("XMLTYPE");
+    }
+
+    @Test
+    @DisplayName("String value -> return as is")
+    void stringValue_returnedAsIs() throws SQLException {
+        when(rs.getObject("XML_COL")).thenReturn("<root><id>1</id></root>");
+
+        Object result = HANDLER.getJdbcObject(rs, column);
+
+        assertThat(result).isEqualTo("<root><id>1</id></root>");
+    }
+
+    @Test
+    @DisplayName("null value -> null")
+    void nullValue_returnsNull() throws SQLException {
+        when(rs.getObject("XML_COL")).thenReturn(null);
+
+        assertThat(HANDLER.getJdbcObject(rs, column)).isNull();
+    }
+
+    @Test
+    @DisplayName("other object -> delegate to rs.getString()")
+    void otherObject_delegatesToGetString() throws SQLException {
+        when(rs.getObject("XML_COL")).thenReturn(new Object());
+        when(rs.getString("XML_COL")).thenReturn("<data/>");
+
+        assertThat(HANDLER.getJdbcObject(rs, column)).isEqualTo("<data/>");
+    }
+
+    @Test
+    @DisplayName("SQLException -> rethrow")
+    void sqlException_rethrown() throws SQLException {
+        when(rs.getObject("XML_COL")).thenThrow(new SQLException("xml read error"));
+
+        assertThatThrownBy(() -> HANDLER.getJdbcObject(rs, column))
+                .isInstanceOf(SQLException.class)
+                .hasMessage("xml read error");
+    }
+
+    @Test
+    @DisplayName("non-SQL exception -> wrap to SQLException")
+    void runtimeException_wrappedWithTypeName() throws SQLException {
+        when(rs.getObject("XML_COL")).thenThrow(new RuntimeException("unexpected"));
+
+        assertThatThrownBy(() -> HANDLER.getJdbcObject(rs, column))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("XML_COL");
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoXmlTypeHandlerText.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/export/handler/TiberoXmlTypeHandlerText.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero.export.handler;
 
 import com.cubrid.cubridmigration.core.dbobject.Column;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/meta/TiberoConstraintIndexMetadataLoaderTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/meta/TiberoConstraintIndexMetadataLoaderTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero.meta;
 
 import com.cubrid.cubridmigration.core.dbobject.Column;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/meta/TiberoConstraintIndexMetadataLoaderTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/meta/TiberoConstraintIndexMetadataLoaderTest.java
@@ -12,22 +12,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @DisplayName("TiberoConstraintIndexMetadataLoader")
 class TiberoConstraintIndexMetadataLoaderTest {
@@ -44,12 +37,14 @@ class TiberoConstraintIndexMetadataLoaderTest {
         @Test
         @DisplayName("composite PK is built and same-name index is removed")
         void compositePk_builtAndSameNameIndexRemoved() throws Exception {
-            Connection conn =
-                    connectionOf(
-                            preparedStatementOf(
-                                    resultSetOf(
-                                            row("PK_NAME", "PK_EMP", "COLUMN_NAME", "ID"),
-                                            row("PK_NAME", "PK_EMP", "COLUMN_NAME", "CODE"))));
+            Connection conn = mock(Connection.class);
+            PreparedStatement stmt = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(stmt);
+            when(stmt.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(true, true, false);
+            when(rs.getString("PK_NAME")).thenReturn("PK_EMP", "PK_EMP");
+            when(rs.getString("COLUMN_NAME")).thenReturn("ID", "CODE");
 
             Schema schema = createSchema("HR");
             Table table = createTable("EMP", "ID", "CODE");
@@ -77,22 +72,17 @@ class TiberoConstraintIndexMetadataLoaderTest {
         @Test
         @DisplayName("composite FK rows are grouped into one FK")
         void compositeFk_rowsGroupedIntoSingleFk() throws Exception {
-            Connection conn =
-                    connectionOf(
-                            preparedStatementOf(
-                                    resultSetOf(
-                                            row(
-                                                    "FK_NAME", "FK_EMP_DEPT",
-                                                    "DELETE_RULE", "CASCADE",
-                                                    "PK_TABLE_NAME", "DEPT",
-                                                    "FK_COLUMN_NAME", "DEPT_ID",
-                                                    "PK_COLUMN_NAME", "ID"),
-                                            row(
-                                                    "FK_NAME", "FK_EMP_DEPT",
-                                                    "DELETE_RULE", "CASCADE",
-                                                    "PK_TABLE_NAME", "DEPT",
-                                                    "FK_COLUMN_NAME", "DEPT_CODE",
-                                                    "PK_COLUMN_NAME", "CODE"))));
+            Connection conn = mock(Connection.class);
+            PreparedStatement stmt = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(stmt);
+            when(stmt.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(true, true, false);
+            when(rs.getString("FK_NAME")).thenReturn("FK_EMP_DEPT", "FK_EMP_DEPT");
+            when(rs.getString("DELETE_RULE")).thenReturn("CASCADE", "CASCADE");
+            when(rs.getString("PK_TABLE_NAME")).thenReturn("DEPT", "DEPT");
+            when(rs.getString("FK_COLUMN_NAME")).thenReturn("DEPT_ID", "DEPT_CODE");
+            when(rs.getString("PK_COLUMN_NAME")).thenReturn("ID", "CODE");
 
             Schema schema = createSchema("HR");
             Table table = createTable("EMP", "DEPT_ID", "DEPT_CODE");
@@ -113,16 +103,17 @@ class TiberoConstraintIndexMetadataLoaderTest {
         @Test
         @DisplayName("unsupported delete rule -> NO ACTION")
         void unsupportedDeleteRule_defaultsToNoAction() throws Exception {
-            Connection conn =
-                    connectionOf(
-                            preparedStatementOf(
-                                    resultSetOf(
-                                            row(
-                                                    "FK_NAME", "FK_EMP_DEPT",
-                                                    "DELETE_RULE", "RESTRICT",
-                                                    "PK_TABLE_NAME", "DEPT",
-                                                    "FK_COLUMN_NAME", "DEPT_ID",
-                                                    "PK_COLUMN_NAME", "ID"))));
+            Connection conn = mock(Connection.class);
+            PreparedStatement stmt = mock(PreparedStatement.class);
+            ResultSet rs = mock(ResultSet.class);
+            when(conn.prepareStatement(anyString())).thenReturn(stmt);
+            when(stmt.executeQuery()).thenReturn(rs);
+            when(rs.next()).thenReturn(true, false);
+            when(rs.getString("FK_NAME")).thenReturn("FK_EMP_DEPT");
+            when(rs.getString("DELETE_RULE")).thenReturn("RESTRICT");
+            when(rs.getString("PK_TABLE_NAME")).thenReturn("DEPT");
+            when(rs.getString("FK_COLUMN_NAME")).thenReturn("DEPT_ID");
+            when(rs.getString("PK_COLUMN_NAME")).thenReturn("ID");
 
             Schema schema = createSchema("HR");
             Table table = createTable("EMP", "DEPT_ID");
@@ -141,47 +132,47 @@ class TiberoConstraintIndexMetadataLoaderTest {
         @Test
         @DisplayName("indexes are built with reverse flag, expression columns, and empty indexes removed")
         void indexes_builtAndEmptyIndexesRemoved() throws Exception {
-            Connection conn =
-                    connectionOf(
-                            preparedStatementOf(
-                                    resultSetOf(
-                                            row(
-                                                    "INDEX_NAME", "IDX_NAME",
-                                                    "INDEX_TYPE", "NORMAL",
-                                                    "UNIQUENESS", "UNIQUE"),
-                                            row(
-                                                    "INDEX_NAME", "IDX_REV",
-                                                    "INDEX_TYPE", "NORMAL/REV",
-                                                    "UNIQUENESS", "NONUNIQUE"),
-                                            row(
-                                                    "INDEX_NAME", "IDX_EXPR",
-                                                    "INDEX_TYPE", "BITMAP",
-                                                    "UNIQUENESS", "NONUNIQUE"),
-                                            row(
-                                                    "INDEX_NAME", "IDX_EMPTY",
-                                                    "INDEX_TYPE", "NORMAL",
-                                                    "UNIQUENESS", "NONUNIQUE"))),
-                            preparedStatementOf(
-                                    resultSetOf(
-                                            row(
-                                                    "COLUMN_NAME", "NAME",
-                                                    "COLUMN_EXPRESSION", null,
-                                                    "DESCEND", "A")),
-                                    resultSetOf(
-                                            row(
-                                                    "COLUMN_NAME", "AGE",
-                                                    "COLUMN_EXPRESSION", null,
-                                                    "DESCEND", "D")),
-                                    resultSetOf(
-                                            row(
-                                                    "COLUMN_NAME", null,
-                                                    "COLUMN_EXPRESSION", "\"LOWER(NAME)\"",
-                                                    "DESCEND", null)),
-                                    resultSetOf(
-                                            row(
-                                                    "COLUMN_NAME", null,
-                                                    "COLUMN_EXPRESSION", null,
-                                                    "DESCEND", null))));
+            Connection conn = mock(Connection.class);
+            PreparedStatement indexStmt = mock(PreparedStatement.class);
+            PreparedStatement columnStmt = mock(PreparedStatement.class);
+            ResultSet indexRs = mock(ResultSet.class);
+            ResultSet nameColumnsRs = mock(ResultSet.class);
+            ResultSet reverseColumnsRs = mock(ResultSet.class);
+            ResultSet expressionColumnsRs = mock(ResultSet.class);
+            ResultSet emptyColumnsRs = mock(ResultSet.class);
+
+            when(conn.prepareStatement(anyString())).thenReturn(indexStmt, columnStmt);
+            when(indexStmt.executeQuery()).thenReturn(indexRs);
+            when(columnStmt.executeQuery())
+                    .thenReturn(nameColumnsRs, reverseColumnsRs, expressionColumnsRs, emptyColumnsRs);
+
+            when(indexRs.next()).thenReturn(true, true, true, true, false);
+            when(indexRs.getString("INDEX_NAME"))
+                    .thenReturn("IDX_NAME", "IDX_REV", "IDX_EXPR", "IDX_EMPTY");
+            when(indexRs.getString("INDEX_TYPE"))
+                    .thenReturn("NORMAL", "NORMAL/REV", "BITMAP", "NORMAL");
+            when(indexRs.getString("UNIQUENESS"))
+                    .thenReturn("UNIQUE", "NONUNIQUE", "NONUNIQUE", "NONUNIQUE");
+
+            when(nameColumnsRs.next()).thenReturn(true, false);
+            when(nameColumnsRs.getString("COLUMN_NAME")).thenReturn("NAME");
+            when(nameColumnsRs.getString("COLUMN_EXPRESSION")).thenReturn(null);
+            when(nameColumnsRs.getString("DESCEND")).thenReturn("A");
+
+            when(reverseColumnsRs.next()).thenReturn(true, false);
+            when(reverseColumnsRs.getString("COLUMN_NAME")).thenReturn("AGE");
+            when(reverseColumnsRs.getString("COLUMN_EXPRESSION")).thenReturn(null);
+            when(reverseColumnsRs.getString("DESCEND")).thenReturn("D");
+
+            when(expressionColumnsRs.next()).thenReturn(true, false);
+            when(expressionColumnsRs.getString("COLUMN_NAME")).thenReturn(null);
+            when(expressionColumnsRs.getString("COLUMN_EXPRESSION")).thenReturn("\"LOWER(NAME)\"");
+            when(expressionColumnsRs.getString("DESCEND")).thenReturn(null);
+
+            when(emptyColumnsRs.next()).thenReturn(true, false);
+            when(emptyColumnsRs.getString("COLUMN_NAME")).thenReturn(null);
+            when(emptyColumnsRs.getString("COLUMN_EXPRESSION")).thenReturn(null);
+            when(emptyColumnsRs.getString("DESCEND")).thenReturn(null);
 
             Schema schema = createSchema("HR");
             Table table = createTable("EMP", "NAME", "AGE");
@@ -226,108 +217,5 @@ class TiberoConstraintIndexMetadataLoaderTest {
             table.addColumn(column);
         }
         return table;
-    }
-
-    private Connection connectionOf(PreparedStatement... statements) {
-        final Deque<PreparedStatement> queue = new ArrayDeque<PreparedStatement>(Arrays.asList(statements));
-        return (Connection)
-                Proxy.newProxyInstance(
-                        getClass().getClassLoader(),
-                        new Class[] {Connection.class},
-                        new InvocationHandler() {
-                            public Object invoke(Object proxy, Method method, Object[] args) {
-                                if ("prepareStatement".equals(method.getName())) {
-                                    return queue.removeFirst();
-                                }
-                                if ("close".equals(method.getName())) {
-                                    return null;
-                                }
-                                return defaultValue(method.getReturnType());
-                            }
-                        });
-    }
-
-    private PreparedStatement preparedStatementOf(ResultSet... resultSets) {
-        final Deque<ResultSet> queue = new ArrayDeque<ResultSet>(Arrays.asList(resultSets));
-        return (PreparedStatement)
-                Proxy.newProxyInstance(
-                        getClass().getClassLoader(),
-                        new Class[] {PreparedStatement.class},
-                        new InvocationHandler() {
-                            public Object invoke(Object proxy, Method method, Object[] args) {
-                                if ("executeQuery".equals(method.getName())) {
-                                    return queue.removeFirst();
-                                }
-                                if ("setString".equals(method.getName()) || "close".equals(method.getName())) {
-                                    return null;
-                                }
-                                return defaultValue(method.getReturnType());
-                            }
-                        });
-    }
-
-    private ResultSet resultSetOf(Map<String, Object>... rows) {
-        final List<Map<String, Object>> data = new ArrayList<Map<String, Object>>(Arrays.asList(rows));
-        return (ResultSet)
-                Proxy.newProxyInstance(
-                        getClass().getClassLoader(),
-                        new Class[] {ResultSet.class},
-                        new InvocationHandler() {
-                            private int index = -1;
-
-                            public Object invoke(Object proxy, Method method, Object[] args) {
-                                if ("next".equals(method.getName())) {
-                                    index++;
-                                    return index < data.size();
-                                }
-                                if ("getString".equals(method.getName())) {
-                                    return currentRow().get(args[0]);
-                                }
-                                if ("close".equals(method.getName())) {
-                                    return null;
-                                }
-                                return defaultValue(method.getReturnType());
-                            }
-
-                            private Map<String, Object> currentRow() {
-                                return data.get(index);
-                            }
-                        });
-    }
-
-    private Map<String, Object> row(Object... values) {
-        Map<String, Object> row = new HashMap<String, Object>();
-        for (int i = 0; i < values.length; i += 2) {
-            row.put((String) values[i], values[i + 1]);
-        }
-        return row;
-    }
-
-    private Object defaultValue(Class<?> returnType) {
-        if (Boolean.TYPE.equals(returnType)) {
-            return false;
-        }
-        if (Integer.TYPE.equals(returnType)) {
-            return 0;
-        }
-        if (Long.TYPE.equals(returnType)) {
-            return 0L;
-        }
-        if (Double.TYPE.equals(returnType)) {
-            return 0d;
-        }
-        if (Float.TYPE.equals(returnType)) {
-            return 0f;
-        }
-        if (Short.TYPE.equals(returnType)) {
-            return (short) 0;
-        }
-        if (Byte.TYPE.equals(returnType)) {
-            return (byte) 0;
-        }
-        if (Character.TYPE.equals(returnType)) {
-            return '\0';
-        }
-        return null;
     }
 }

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/meta/TiberoConstraintIndexMetadataLoaderTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/meta/TiberoConstraintIndexMetadataLoaderTest.java
@@ -1,0 +1,333 @@
+package com.cubrid.cubridmigration.tibero.meta;
+
+import com.cubrid.cubridmigration.core.dbobject.Column;
+import com.cubrid.cubridmigration.core.dbobject.DBObjectFactory;
+import com.cubrid.cubridmigration.core.dbobject.FK;
+import com.cubrid.cubridmigration.core.dbobject.Index;
+import com.cubrid.cubridmigration.core.dbobject.PK;
+import com.cubrid.cubridmigration.core.dbobject.Schema;
+import com.cubrid.cubridmigration.core.dbobject.Table;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TiberoConstraintIndexMetadataLoader")
+class TiberoConstraintIndexMetadataLoaderTest {
+
+    private static final TiberoConstraintIndexMetadataLoader LOADER =
+            new TiberoConstraintIndexMetadataLoader();
+
+    private static final DBObjectFactory FACTORY = new DBObjectFactory();
+
+    @Nested
+    @DisplayName("buildTablePK()")
+    class BuildTablePK {
+
+        @Test
+        @DisplayName("composite PK is built and same-name index is removed")
+        void compositePk_builtAndSameNameIndexRemoved() throws Exception {
+            Connection conn =
+                    connectionOf(
+                            preparedStatementOf(
+                                    resultSetOf(
+                                            row("PK_NAME", "PK_EMP", "COLUMN_NAME", "ID"),
+                                            row("PK_NAME", "PK_EMP", "COLUMN_NAME", "CODE"))));
+
+            Schema schema = createSchema("HR");
+            Table table = createTable("EMP", "ID", "CODE");
+            Index sameNameIndex = FACTORY.createIndex(table);
+            sameNameIndex.setName("PK_EMP");
+            table.addIndex(sameNameIndex);
+            Index keepIndex = FACTORY.createIndex(table);
+            keepIndex.setName("IDX_CODE");
+            table.addIndex(keepIndex);
+
+            LOADER.buildTablePK(conn, schema, table, FACTORY);
+
+            PK pk = table.getPk();
+            assertThat(pk).isNotNull();
+            assertThat(pk.getName()).isEqualTo("PK_EMP");
+            assertThat(pk.getPkColumns()).containsExactly("ID", "CODE");
+            assertThat(table.getIndexes()).extracting(Index::getName).containsExactly("IDX_CODE");
+        }
+    }
+
+    @Nested
+    @DisplayName("buildTableFKs()")
+    class BuildTableFKs {
+
+        @Test
+        @DisplayName("composite FK rows are grouped into one FK")
+        void compositeFk_rowsGroupedIntoSingleFk() throws Exception {
+            Connection conn =
+                    connectionOf(
+                            preparedStatementOf(
+                                    resultSetOf(
+                                            row(
+                                                    "FK_NAME", "FK_EMP_DEPT",
+                                                    "DELETE_RULE", "CASCADE",
+                                                    "PK_TABLE_NAME", "DEPT",
+                                                    "FK_COLUMN_NAME", "DEPT_ID",
+                                                    "PK_COLUMN_NAME", "ID"),
+                                            row(
+                                                    "FK_NAME", "FK_EMP_DEPT",
+                                                    "DELETE_RULE", "CASCADE",
+                                                    "PK_TABLE_NAME", "DEPT",
+                                                    "FK_COLUMN_NAME", "DEPT_CODE",
+                                                    "PK_COLUMN_NAME", "CODE"))));
+
+            Schema schema = createSchema("HR");
+            Table table = createTable("EMP", "DEPT_ID", "DEPT_CODE");
+
+            LOADER.buildTableFKs(conn, schema, table, FACTORY);
+
+            assertThat(table.getFks()).hasSize(1);
+            FK fk = table.getFks().get(0);
+            assertThat(fk.getName()).isEqualTo("FK_EMP_DEPT");
+            assertThat(fk.getReferencedTableName()).isEqualTo("DEPT");
+            assertThat(fk.getDeleteRule()).isEqualTo(FK.ON_DELETE_CASCADE);
+            assertThat(fk.getUpdateRule()).isEqualTo(FK.ON_UPDATE_NO_ACTION);
+            assertThat(fk.getColumns())
+                    .containsEntry("DEPT_ID", "ID")
+                    .containsEntry("DEPT_CODE", "CODE");
+        }
+
+        @Test
+        @DisplayName("unsupported delete rule -> NO ACTION")
+        void unsupportedDeleteRule_defaultsToNoAction() throws Exception {
+            Connection conn =
+                    connectionOf(
+                            preparedStatementOf(
+                                    resultSetOf(
+                                            row(
+                                                    "FK_NAME", "FK_EMP_DEPT",
+                                                    "DELETE_RULE", "RESTRICT",
+                                                    "PK_TABLE_NAME", "DEPT",
+                                                    "FK_COLUMN_NAME", "DEPT_ID",
+                                                    "PK_COLUMN_NAME", "ID"))));
+
+            Schema schema = createSchema("HR");
+            Table table = createTable("EMP", "DEPT_ID");
+
+            LOADER.buildTableFKs(conn, schema, table, FACTORY);
+
+            assertThat(table.getFks()).hasSize(1);
+            assertThat(table.getFks().get(0).getDeleteRule()).isEqualTo(FK.ON_DELETE_NO_ACTION);
+        }
+    }
+
+    @Nested
+    @DisplayName("buildTableIndexes()")
+    class BuildTableIndexes {
+
+        @Test
+        @DisplayName("indexes are built with reverse flag, expression columns, and empty indexes removed")
+        void indexes_builtAndEmptyIndexesRemoved() throws Exception {
+            Connection conn =
+                    connectionOf(
+                            preparedStatementOf(
+                                    resultSetOf(
+                                            row(
+                                                    "INDEX_NAME", "IDX_NAME",
+                                                    "INDEX_TYPE", "NORMAL",
+                                                    "UNIQUENESS", "UNIQUE"),
+                                            row(
+                                                    "INDEX_NAME", "IDX_REV",
+                                                    "INDEX_TYPE", "NORMAL/REV",
+                                                    "UNIQUENESS", "NONUNIQUE"),
+                                            row(
+                                                    "INDEX_NAME", "IDX_EXPR",
+                                                    "INDEX_TYPE", "BITMAP",
+                                                    "UNIQUENESS", "NONUNIQUE"),
+                                            row(
+                                                    "INDEX_NAME", "IDX_EMPTY",
+                                                    "INDEX_TYPE", "NORMAL",
+                                                    "UNIQUENESS", "NONUNIQUE"))),
+                            preparedStatementOf(
+                                    resultSetOf(
+                                            row(
+                                                    "COLUMN_NAME", "NAME",
+                                                    "COLUMN_EXPRESSION", null,
+                                                    "DESCEND", "A")),
+                                    resultSetOf(
+                                            row(
+                                                    "COLUMN_NAME", "AGE",
+                                                    "COLUMN_EXPRESSION", null,
+                                                    "DESCEND", "D")),
+                                    resultSetOf(
+                                            row(
+                                                    "COLUMN_NAME", null,
+                                                    "COLUMN_EXPRESSION", "\"LOWER(NAME)\"",
+                                                    "DESCEND", null)),
+                                    resultSetOf(
+                                            row(
+                                                    "COLUMN_NAME", null,
+                                                    "COLUMN_EXPRESSION", null,
+                                                    "DESCEND", null))));
+
+            Schema schema = createSchema("HR");
+            Table table = createTable("EMP", "NAME", "AGE");
+
+            LOADER.buildTableIndexes(conn, schema, table, FACTORY);
+
+            assertThat(table.getIndexes()).hasSize(3);
+            assertThat(table.getIndexes()).extracting(Index::getName)
+                    .containsExactly("IDX_NAME", "IDX_REV", "IDX_EXPR");
+
+            Index nameIndex = table.getIndexByName("IDX_NAME");
+            assertThat(nameIndex.isUnique()).isTrue();
+            assertThat(nameIndex.getIndexType()).isEqualTo(DatabaseMetaData.tableIndexClustered);
+            assertThat(nameIndex.getColumnNames()).containsExactly("NAME");
+            assertThat(nameIndex.getColumnOrderRules()).containsExactly(true);
+
+            Index reverseIndex = table.getIndexByName("IDX_REV");
+            assertThat(reverseIndex.isReverse()).isTrue();
+            assertThat(reverseIndex.getIndexType()).isEqualTo(DatabaseMetaData.tableIndexClustered);
+            assertThat(reverseIndex.getColumnNames()).containsExactly("AGE");
+            assertThat(reverseIndex.getColumnOrderRules()).containsExactly(false);
+
+            Index expressionIndex = table.getIndexByName("IDX_EXPR");
+            assertThat(expressionIndex.getIndexType()).isEqualTo(DatabaseMetaData.tableIndexOther);
+            assertThat(expressionIndex.getColumnNames()).containsExactly("LOWER(NAME)");
+            assertThat(expressionIndex.getColumnOrderRules()).containsExactly(true);
+        }
+    }
+
+    private Schema createSchema(String name) {
+        Schema schema = new Schema();
+        schema.setName(name);
+        return schema;
+    }
+
+    private Table createTable(String name, String... columnNames) {
+        Table table = new Table();
+        table.setName(name);
+        for (String columnName : columnNames) {
+            Column column = FACTORY.createColumn();
+            column.setName(columnName);
+            table.addColumn(column);
+        }
+        return table;
+    }
+
+    private Connection connectionOf(PreparedStatement... statements) {
+        final Deque<PreparedStatement> queue = new ArrayDeque<PreparedStatement>(Arrays.asList(statements));
+        return (Connection)
+                Proxy.newProxyInstance(
+                        getClass().getClassLoader(),
+                        new Class[] {Connection.class},
+                        new InvocationHandler() {
+                            public Object invoke(Object proxy, Method method, Object[] args) {
+                                if ("prepareStatement".equals(method.getName())) {
+                                    return queue.removeFirst();
+                                }
+                                if ("close".equals(method.getName())) {
+                                    return null;
+                                }
+                                return defaultValue(method.getReturnType());
+                            }
+                        });
+    }
+
+    private PreparedStatement preparedStatementOf(ResultSet... resultSets) {
+        final Deque<ResultSet> queue = new ArrayDeque<ResultSet>(Arrays.asList(resultSets));
+        return (PreparedStatement)
+                Proxy.newProxyInstance(
+                        getClass().getClassLoader(),
+                        new Class[] {PreparedStatement.class},
+                        new InvocationHandler() {
+                            public Object invoke(Object proxy, Method method, Object[] args) {
+                                if ("executeQuery".equals(method.getName())) {
+                                    return queue.removeFirst();
+                                }
+                                if ("setString".equals(method.getName()) || "close".equals(method.getName())) {
+                                    return null;
+                                }
+                                return defaultValue(method.getReturnType());
+                            }
+                        });
+    }
+
+    private ResultSet resultSetOf(Map<String, Object>... rows) {
+        final List<Map<String, Object>> data = new ArrayList<Map<String, Object>>(Arrays.asList(rows));
+        return (ResultSet)
+                Proxy.newProxyInstance(
+                        getClass().getClassLoader(),
+                        new Class[] {ResultSet.class},
+                        new InvocationHandler() {
+                            private int index = -1;
+
+                            public Object invoke(Object proxy, Method method, Object[] args) {
+                                if ("next".equals(method.getName())) {
+                                    index++;
+                                    return index < data.size();
+                                }
+                                if ("getString".equals(method.getName())) {
+                                    return currentRow().get(args[0]);
+                                }
+                                if ("close".equals(method.getName())) {
+                                    return null;
+                                }
+                                return defaultValue(method.getReturnType());
+                            }
+
+                            private Map<String, Object> currentRow() {
+                                return data.get(index);
+                            }
+                        });
+    }
+
+    private Map<String, Object> row(Object... values) {
+        Map<String, Object> row = new HashMap<String, Object>();
+        for (int i = 0; i < values.length; i += 2) {
+            row.put((String) values[i], values[i + 1]);
+        }
+        return row;
+    }
+
+    private Object defaultValue(Class<?> returnType) {
+        if (Boolean.TYPE.equals(returnType)) {
+            return false;
+        }
+        if (Integer.TYPE.equals(returnType)) {
+            return 0;
+        }
+        if (Long.TYPE.equals(returnType)) {
+            return 0L;
+        }
+        if (Double.TYPE.equals(returnType)) {
+            return 0d;
+        }
+        if (Float.TYPE.equals(returnType)) {
+            return 0f;
+        }
+        if (Short.TYPE.equals(returnType)) {
+            return (short) 0;
+        }
+        if (Byte.TYPE.equals(returnType)) {
+            return (byte) 0;
+        }
+        if (Character.TYPE.equals(returnType)) {
+            return '\0';
+        }
+        return null;
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/trans/Tibero2CUBRIDTransformHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/trans/Tibero2CUBRIDTransformHelperTest.java
@@ -1,0 +1,346 @@
+package com.cubrid.cubridmigration.tibero.trans;
+
+import com.cubrid.cubridmigration.core.dbobject.Column;
+import com.cubrid.cubridmigration.core.dbobject.PartitionInfo;
+import com.cubrid.cubridmigration.core.dbobject.PartitionTable;
+import com.cubrid.cubridmigration.core.dbobject.Table;
+import com.cubrid.cubridmigration.core.dbobject.View;
+import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+import com.cubrid.cubridmigration.cubrid.trans.ToCUBRIDDataConverterFacade;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.cubrid.cubridmigration.testutil.TestColumnFactory.createColumn;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Tiber2CUBRIDTransformHelper")
+public class Tibero2CUBRIDTransformHelperTest {
+
+    private static final Tibero2CUBRIDTransformHelper HELPER =
+            new Tibero2CUBRIDTransformHelper(
+                    new TiberoDataTypeMappingHelper(),
+                    ToCUBRIDDataConverterFacade.getIntance());
+
+    @Nested
+    @DisplayName("adjustDefaultValue()")
+    class AdjustDefaultValue {
+
+        @Test
+        @DisplayName("null default -> no change")
+        void nullDefault_noChange() {
+            Column src = createColumn("DATE");
+            Column cub = createColumn("DATETIME");
+
+            HELPER.adjustDefaultValue(src, cub);
+
+            assertThat(cub.getDefaultValue()).isNull();
+            assertThat(cub.isDefaultIsExpression()).isFalse();
+        }
+
+        @ParameterizedTest(name = "[{index}] {0} column | {1} -> {3}")
+        @CsvSource({
+            "DATE,      SYSDATE,      DATETIME, SYS_DATETIME",
+            "DATE,      SYSTIME,      DATETIME, SYS_TIME",
+            "TIMESTAMP, SYSTIMESTAMP, DATETIME, SYS_TIMESTAMP",
+            "DATE,      CURRENT_DATE, DATETIME, CURRENT_DATETIME",
+        })
+        @DisplayName("datetime column Tibero date function -> CUBRID function")
+        void datetimeColumn_dateTimeFunction_converted(
+                String srcType, String tiberoFn, String cubType, String cubridFn) {
+            Column src = createColumn(srcType);
+            src.setDefaultValue(tiberoFn);
+            Column cub = createColumn(cubType);
+
+            HELPER.adjustDefaultValue(src, cub);
+
+            assertThat(cub.getDefaultValue()).isEqualTo(cubridFn);
+            assertThat(cub.isDefaultIsExpression()).isFalse();
+        }
+
+        @ParameterizedTest(name = "[{index}] {0} column | {1} -> {3}")
+        @CsvSource({
+            "DATE, sysdate, DATETIME, SYS_DATETIME",
+        })
+        @DisplayName("datetime column date function is converted case-insensitively")
+        void datetimeColumn_dateTimeFunctionConvertedCaseInsensitively(
+                String srcType, String tiberoFn, String cubType, String cubridFn) {
+            Column src = createColumn(srcType);
+            src.setDefaultValue(tiberoFn);
+            Column cub = createColumn(cubType);
+
+            HELPER.adjustDefaultValue(src, cub);
+
+            assertThat(cub.getDefaultValue()).isEqualTo(cubridFn);
+            assertThat(cub.isDefaultIsExpression()).isFalse();
+        }
+
+        @ParameterizedTest(name = "[{index}] {0} column | {1} remains as is")
+        @CsvSource({
+            "TIMESTAMP, LOCALTIMESTAMP,   DATETIME, LOCALTIMESTAMP",
+            "DATE,      CURRENT_TIMESTAMP, DATETIME, CURRENT_TIMESTAMP",
+        })
+        @DisplayName("datetime column recognized date function without mapping remains unchanged")
+        void datetimeColumn_recognizedDateFunctionWithoutMapping_remainsUnchanged(
+                String srcType, String tiberoFn, String cubType, String expected) {
+            Column src = createColumn(srcType);
+            src.setDefaultValue(tiberoFn);
+            Column cub = createColumn(cubType);
+
+            HELPER.adjustDefaultValue(src, cub);
+
+            assertThat(cub.getDefaultValue()).isEqualTo(expected);
+            assertThat(cub.isDefaultIsExpression()).isFalse();
+        }
+
+        @ParameterizedTest(name = "[{index}] {0} column | {1} -> {2}")
+        @CsvSource({
+            "DATE,      SYSDATE, true",
+            "TIMESTAMP, SYSDATE, true",
+            "VARCHAR2,  SYSDATE, false",
+        })
+        @DisplayName("date function conversion depends on source column type")
+        void dateFunctionConversion_dependsOnSourceColumnType(
+                String srcType, String tiberoFn, boolean converted) {
+            Column src = createColumn(srcType);
+            src.setDefaultValue(tiberoFn);
+            Column cub = createColumn("DATETIME");
+
+            HELPER.adjustDefaultValue(src, cub);
+
+            if (converted) {
+                assertThat(cub.getDefaultValue()).isEqualTo("SYS_DATETIME");
+            } else {
+                assertThat(cub.getDefaultValue()).isNull();
+            }
+            assertThat(cub.isDefaultIsExpression()).isFalse();
+        }
+
+        @ParameterizedTest(name = "[{index}] expression \"{0}\" -> isExpression=true")
+        @ValueSource(strings = {
+                "(SELECT 1 FROM DUAL)",
+                "TO_CHAR(SYSDATE,'YYYY-MM-DD')",
+                "CAST('2024-01-01' AS DATE)",
+        })
+        @DisplayName("expression default -> set isDefaultIsExpression=true")
+        void expressionDefault_markedAsExpression(String expr) {
+            Column src = createColumn("VARCHAR2");
+            src.setDefaultValue(expr);
+            Column cub = createColumn("VARCHAR");
+
+            HELPER.adjustDefaultValue(src, cub);
+
+            assertThat(cub.isDefaultIsExpression()).isTrue();
+        }
+
+        @ParameterizedTest(name = "[{index}] DATETIME column | TO_DATE/TO_TIMESTAMP conversion")
+        @MethodSource("com.cubrid.cubridmigration.tibero.trans.Tibero2CUBRIDTransformHelperTest#toDateConversionCases")
+        @DisplayName("DATETIME type converts TO_DATE/TO_TIMESTAMP to TO_DATETIME")
+        void dateTimeColumn_toDateConverted(String input, String expected) {
+            Column src = createColumn("DATE");
+            src.setDefaultValue(input);
+            Column cub = createColumn("DATETIME");
+
+            HELPER.adjustDefaultValue(src, cub);
+
+            assertThat(cub.getDefaultValue()).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("non-date literal default -> cub stays unchanged")
+        void nonDateLiteralDefault_cubridColumnUnchanged() {
+            Column src = createColumn("NUMBER");
+            src.setDefaultValue("42");
+            Column cub = createColumn("INT");
+
+            HELPER.adjustDefaultValue(src, cub);
+
+            assertThat(cub.getDefaultValue()).isNull();
+            assertThat(cub.isDefaultIsExpression()).isFalse();
+        }
+
+    }
+
+    @Nested
+    @DisplayName("getColumnView()")
+    class GetColunView {
+
+        private final MigrationConfiguration config = new MigrationConfiguration();
+
+        @Test
+        @DisplayName("removes uppercase WITH READ ONLY")
+        void uppercase_withReadOnly_removed() {
+            View view = new View();
+            view.setName("V_EMP");
+            view.setQuerySpec("SELECT * FROM EMP WITH READ ONLY");
+
+            View result = HELPER.getCloneView(view, config);
+
+            assertThat(result.getQuerySpec()).doesNotContainIgnoringCase("with read only");
+            assertThat(result.getQuerySpec()).contains("SELECT * FROM EMP");
+        }
+
+        @Test
+        @DisplayName("removes lowercase with read only")
+        void lowercase_withReadOnly_removed() {
+            View view = new View();
+            view.setName("V_EMP");
+            view.setQuerySpec("SELECT * FROM EMP with read only");
+
+            View result = HELPER.getCloneView(view, config);
+
+            assertThat(result.getQuerySpec()).doesNotContainIgnoringCase("with read only");
+        }
+
+        @Test
+        @DisplayName("view without WITH READ ONLY -> keep querySpec")
+        void noWithReadOnly_querySpecUnchanged() {
+            View view = new View();
+            view.setName("V_EMP");
+            view.setQuerySpec("SELECT ID, NAME FROM EMP WHERE ACTIVE = 1");
+
+            View result = HELPER.getCloneView(view, config);
+
+            assertThat(result.getQuerySpec()).isEqualTo("SELECT ID, NAME FROM EMP WHERE ACTIVE = 1");
+        }
+    }
+
+    @Nested
+    @DisplayName("getToCUBRIDPartitionDDL()")
+    class GetToCUBRIDPartitionDDL {
+
+        @Test
+        @DisplayName("table=null -> null")
+        void nullTable_returnNull() {
+            assertThat(HELPER.getToCUBRIDPartitionDDL(null)).isNull();
+        }
+
+        @Test
+        @DisplayName("partitionInfo=null -> null")
+        void nullPartitionInfo_returnNull() {
+            assertThat(HELPER.getToCUBRIDPartitionDDL(new Table())).isNull();
+        }
+
+        @Test
+        @DisplayName("partitionColumnCount=0 -> return source DDL")
+        void zeroPartitionColumns_returnsSrcDDL() {
+            Table table = new Table();
+            PartitionInfo info = new PartitionInfo();
+            info.setDDL("ORIGINAL_DDL");
+            info.setPartitionColumnCount(0);
+            info.setPartitionCount(2);
+            table.setPartitionInfo(info);
+
+            assertThat(HELPER.getToCUBRIDPartitionDDL(table)).isEqualTo("ORIGINAL_DDL");
+        }
+
+        @Test
+        @DisplayName("HASH partition -> PARTITION BY HASH(COL) PARTITION N")
+        void hashPartition_generatesHashDDL() {
+            Table table = new Table();
+            PartitionInfo info = new PartitionInfo();
+            info.setPartitionMethod("HASH");
+            info.setPartitionColumnCount(1);
+            info.setPartitionCount(4);
+            Column col = new Column();
+            col.setName("ID");
+            info.setPartitionColumns(List.of(col));
+            info.setPartitions(List.of());
+            table.setPartitionInfo(info);
+
+            String ddl = HELPER.getToCUBRIDPartitionDDL(table);
+
+            assertThat(ddl).contains("PARTITION BY");
+            assertThat(ddl).contains("HASH");
+            assertThat(ddl).contains("(ID)");
+            assertThat(ddl).contains("PARTITIONS 4");
+        }
+
+        @Test
+        @DisplayName("RANGE partition -> handles VALUES LESS THAN and MAXVALUE")
+        void rangePartition_generatesRangeDDL() {
+            Table table = new Table();
+            PartitionInfo info = new PartitionInfo();
+            info.setPartitionMethod("RANGE");
+            info.setPartitionColumnCount(1);
+            info.setPartitionCount(2);
+            Column col = new Column();
+            col.setName("SALARY");
+            info.setPartitionColumns(List.of(col));
+            PartitionTable p1 = new PartitionTable();
+            p1.setPartitionName("P_LOW");
+            p1.setPartitionDesc("1000");
+            PartitionTable p2 = new PartitionTable();
+            p2.setPartitionName("P_HIGH");
+            p2.setPartitionDesc("MAXVALUE");
+            info.setPartitions(List.of(p1, p2));
+            table.setPartitionInfo(info);
+
+            String ddl = HELPER.getToCUBRIDPartitionDDL(table);
+
+            assertThat(ddl).contains("PARTITION BY");
+            assertThat(ddl).contains("RANGE");
+            assertThat(ddl).contains("PARTITION P_LOW VALUES LESS THAN (1000)");
+            assertThat(ddl).contains("PARTITION P_HIGH VALUES LESS THAN MAXVALUE");
+        }
+
+        @Test
+        @DisplayName("LIST partition -> VALUES IN format")
+        void listPartition_generatesListDDL() {
+            Table table = new Table();
+            PartitionInfo info = new PartitionInfo();
+            info.setPartitionMethod("LIST");
+            info.setPartitionColumnCount(1);
+            info.setPartitionCount(1);
+            Column col = new Column();
+            col.setName("REGION");
+            info.setPartitionColumns(List.of(col));
+            PartitionTable p1 = new PartitionTable();
+            p1.setPartitionName("P_SEOUL");
+            p1.setPartitionDesc("'SEOUL','BUSAN'");
+            info.setPartitions(List.of(p1));
+            table.setPartitionInfo(info);
+
+            String ddl = HELPER.getToCUBRIDPartitionDDL(table);
+
+            assertThat(ddl).contains("LIST");
+            assertThat(ddl).contains("PARTITION P_SEOUL VALUES IN ('SEOUL','BUSAN')");
+        }
+
+        @Test
+        @DisplayName("unknown partition method -> return source DDL")
+        void unknownPartitionMethod_returnsSrcDDL() {
+            Table table = new Table();
+            PartitionInfo info = new PartitionInfo();
+            info.setDDL("ORIGINAL_DDL");
+            info.setPartitionMethod("UNKNOWN");
+            info.setPartitionColumnCount(1);
+            info.setPartitionCount(1);
+            Column col = new Column();
+            col.setName("ID");
+            info.setPartitionColumns(List.of(col));
+            info.setPartitions(List.of());
+            table.setPartitionInfo(info);
+
+            assertThat(HELPER.getToCUBRIDPartitionDDL(table)).isEqualTo("ORIGINAL_DDL");
+        }
+    }
+
+    static Stream<Arguments> toDateConversionCases() {
+        return Stream.of(
+                Arguments.of("TO_DATE('2024-01-01','YYYY-MM-DD')",
+                        "TO_DATETIME('2024-01-01','YYYY-MM-DD')"),
+                Arguments.of("TO_TIMESTAMP('2024-01-01','YYYY-MM-DD')",
+                        "TO_DATETIME('2024-01-01','YYYY-MM-DD')")
+                );
+    }
+}

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/trans/Tibero2CUBRIDTransformHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/trans/Tibero2CUBRIDTransformHelperTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero.trans;
 
 import com.cubrid.cubridmigration.core.dbobject.Column;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/trans/Tibero2CUBRIDTransformHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/trans/Tibero2CUBRIDTransformHelperTest.java
@@ -5,7 +5,9 @@ import com.cubrid.cubridmigration.core.dbobject.PartitionInfo;
 import com.cubrid.cubridmigration.core.dbobject.PartitionTable;
 import com.cubrid.cubridmigration.core.dbobject.Table;
 import com.cubrid.cubridmigration.core.dbobject.View;
+import com.cubrid.cubridmigration.core.datatype.DataTypeConstant;
 import com.cubrid.cubridmigration.core.engine.config.MigrationConfiguration;
+import com.cubrid.cubridmigration.core.mapping.model.VerifyInfo;
 import com.cubrid.cubridmigration.cubrid.trans.ToCUBRIDDataConverterFacade;
 
 import org.junit.jupiter.api.DisplayName;
@@ -168,6 +170,198 @@ public class Tibero2CUBRIDTransformHelperTest {
             assertThat(cub.isDefaultIsExpression()).isFalse();
         }
 
+    }
+
+    @Nested
+    @DisplayName("adjustPrecision()")
+    class AdjustPrecision {
+
+        private final MigrationConfiguration CONFIG = new MigrationConfiguration();
+
+        @Test
+        @DisplayName("strict numeric scale<0 -> precision grows and scale resets to zero")
+        void negativeScale_numericPrecisionAdjusted() {
+            Column src = createColumn("NUMBER", 10, -2);
+            Column cub = createColumn("numeric", 10, -2);
+
+            HELPER.adjustPrecision(src, cub, CONFIG);
+
+            assertThat(cub.getPrecision()).isEqualTo(12);
+            assertThat(cub.getScale()).isZero();
+            assertThat(cub.getDataType()).isEqualTo("numeric");
+        }
+
+        @Test
+        @DisplayName("strict numeric scale>precision -> precision follows scale")
+        void scaleGreaterThanPrecision_precisionAdjustedToScale() {
+            Column src = createColumn("NUMBER", 5, 8);
+            Column cub = createColumn("numeric", 5, 8);
+
+            HELPER.adjustPrecision(src, cub, CONFIG);
+
+            assertThat(cub.getPrecision()).isEqualTo(8);
+            assertThat(cub.getScale()).isEqualTo(8);
+        }
+
+        @Test
+        @DisplayName("strict numeric overflow -> converted to varchar")
+        void overflowNumeric_convertedToVarchar() {
+            Column src = createColumn("NUMBER", 10, 45);
+            Column cub = createColumn("numeric", 10, 45);
+
+            HELPER.adjustPrecision(src, cub, CONFIG);
+
+            assertThat(cub.getDataTypeInstance()).isNotNull();
+            assertThat(cub.getDataTypeInstance().getName()).isEqualTo(DataTypeConstant.CUBRID_VARCHAR);
+            assertThat(cub.getDataTypeInstance().getPrecision()).isEqualTo(48);
+            assertThat(cub.getJdbcIDOfDataType()).isEqualTo(DataTypeConstant.CUBRID_DT_VARCHAR);
+        }
+
+        @Test
+        @DisplayName("binary type -> precision is scaled by bytes to bits")
+        void binaryType_precisionScaledToBits() {
+            Column src = createColumn("RAW", 8, null);
+            Column cub = createColumn("bit varying", 8, null);
+
+            HELPER.adjustPrecision(src, cub, CONFIG);
+
+            assertThat(cub.getPrecision()).isEqualTo(64);
+        }
+    }
+
+    @Nested
+    @DisplayName("getCUBRIDColumn()")
+    class GetCUBRIDColumn {
+
+        @Test
+        @DisplayName("string default removes comments, wraps quotes, and preserves source comment")
+        void stringDefault_commentRemovedAndWrappedWithQuotes() {
+            Column src = createColumn("NAME", "VARCHAR", 20, null);
+            src.setDefaultValue("abc /* block */ -- line");
+            src.setComment("source comment");
+
+            Column cub = HELPER.getCUBRIDColumn(src, new MigrationConfiguration());
+
+            assertThat(cub.getDefaultValue()).isEqualTo("'abc'");
+            assertThat(cub.getComment()).isEqualTo("source comment");
+            assertThat(cub.getName()).isEqualTo("name");
+        }
+
+        @Test
+        @DisplayName("expression default starting with parenthesis -> no extra quotes")
+        void expressionDefault_notWrappedWithQuotes() {
+            Column src = createColumn("NAME", "VARCHAR", 20, null);
+            src.setDefaultValue("(USER)");
+
+            Column cub = HELPER.getCUBRIDColumn(src, new MigrationConfiguration());
+
+            assertThat(cub.getDefaultValue()).isEqualTo("(USER)");
+        }
+    }
+
+    @Nested
+    @DisplayName("validateChar()")
+    class ValidateChar {
+
+        @Test
+        @DisplayName("string target shorter than charset-adjusted precision -> no enough length")
+        void stringTargetShorterThanNeeded_returnsNoEnoughLength() {
+            MigrationConfiguration config = configWithCharsetFactor(3);
+            Column src = createColumn("VARCHAR2", 4, null);
+            Column cub = createColumn("varchar", 11, null);
+
+            VerifyInfo result = HELPER.validateChar(src, cub, config);
+
+            assertThat(result.getResult()).isEqualTo(VerifyInfo.TYPE_NOENOUGH_LENGTH);
+            assertThat(result.getMessage()).contains("12");
+        }
+
+        @Test
+        @DisplayName("string target long enough -> match")
+        void stringTargetLongEnough_returnsMatch() {
+            MigrationConfiguration config = configWithCharsetFactor(3);
+            Column src = createColumn("VARCHAR2", 4, null);
+            Column cub = createColumn("varchar", 12, null);
+
+            VerifyInfo result = HELPER.validateChar(src, cub, config);
+
+            assertThat(result.getResult()).isEqualTo(VerifyInfo.TYPE_MATCH);
+        }
+
+        @Test
+        @DisplayName("nstring target shorter than source precision -> no enough length")
+        void nstringTargetShorterThanSource_returnsNoEnoughLength() {
+            MigrationConfiguration config = new MigrationConfiguration();
+            Column src = createColumn("NVARCHAR2", 6, null);
+            Column cub = createColumn("nchar", 5, null);
+
+            VerifyInfo result = HELPER.validateChar(src, cub, config);
+
+            assertThat(result.getResult()).isEqualTo(VerifyInfo.TYPE_NOENOUGH_LENGTH);
+            assertThat(result.getMessage()).contains("6");
+        }
+
+        @Test
+        @DisplayName("nstring target long enough -> match")
+        void nstringTargetLongEnough_returnsMatch() {
+            MigrationConfiguration config = new MigrationConfiguration();
+            Column src = createColumn("NVARCHAR2", 6, null);
+            Column cub = createColumn("nchar", 6, null);
+
+            VerifyInfo result = HELPER.validateChar(src, cub, config);
+
+            assertThat(result.getResult()).isEqualTo(VerifyInfo.TYPE_MATCH);
+        }
+
+        private MigrationConfiguration configWithCharsetFactor(final int charsetFactor) {
+            return new MigrationConfiguration() {
+                @Override
+                public Integer getCharsetFactor() {
+                    return charsetFactor;
+                }
+            };
+        }
+    }
+
+    @Nested
+    @DisplayName("validateNumericToVarchar()")
+    class ValidateNumericToVarchar {
+
+        private final MigrationConfiguration CONFIG = new MigrationConfiguration();
+
+        @Test
+        @DisplayName("negative scale required precision not met -> no enough length")
+        void negativeScalePrecisionTooSmall_returnsNoEnoughLength() {
+            Column src = createColumn("NUMBER", 10, -2);
+            Column cub = createColumn("varchar", 12, null);
+
+            VerifyInfo result = HELPER.validateNumericToVarchar(src, cub, CONFIG);
+
+            assertThat(result.getResult()).isEqualTo(VerifyInfo.TYPE_NOENOUGH_LENGTH);
+            assertThat(result.getMessage()).contains("13");
+        }
+
+        @Test
+        @DisplayName("large scale overflow precision met -> match")
+        void scaleGreaterThanPrecisionAnd38_returnsMatch() {
+            Column src = createColumn("NUMBER", 10, 45);
+            Column cub = createColumn("varchar", 48, null);
+
+            VerifyInfo result = HELPER.validateNumericToVarchar(src, cub, CONFIG);
+
+            assertThat(result.getResult()).isEqualTo(VerifyInfo.TYPE_MATCH);
+        }
+
+        @Test
+        @DisplayName("normal numeric to varchar precision too small -> no enough length")
+        void normalRangePrecisionTooSmall_returnsNoEnoughLength() {
+            Column src = createColumn("NUMBER", 10, 2);
+            Column cub = createColumn("varchar", 11, null);
+
+            VerifyInfo result = HELPER.validateNumericToVarchar(src, cub, CONFIG);
+
+            assertThat(result.getResult()).isEqualTo(VerifyInfo.TYPE_NOENOUGH_LENGTH);
+        }
     }
 
     @Nested

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/trans/TiberoDataTypeMappingHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/trans/TiberoDataTypeMappingHelperTest.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
 package com.cubrid.cubridmigration.tibero.trans;
 
 import org.assertj.core.groups.Tuple;

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/trans/TiberoDataTypeMappingHelperTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/tibero/trans/TiberoDataTypeMappingHelperTest.java
@@ -1,0 +1,360 @@
+package com.cubrid.cubridmigration.tibero.trans;
+
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.cubrid.cubridmigration.core.mapping.AbstractDataTypeMappingHelper;
+import com.cubrid.cubridmigration.core.mapping.model.MapItem;
+import com.cubrid.cubridmigration.core.mapping.model.MapObject;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+@DisplayName("TiberoDataTypeMappingHelper")
+public class TiberoDataTypeMappingHelperTest {
+
+    private static final TiberoDataTypeMappingHelper HELPER = new TiberoDataTypeMappingHelper();
+
+    @Nested
+    @DisplayName("Tibero2CUBRID.xml loading")
+    class XmlLoading {
+
+        @Test
+        @DisplayName("XML load success -> xmlConfigMap is not empty")
+        void xmlLoaded_configMapIsNotEmpty() {
+            Map<String, MapItem> configMap = HELPER.getXmlConfigMap();
+
+            assertThat(configMap).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("NUMBER without precision mapping exists")
+        void numberWithoutPrecision_keyExists() {
+            assertThat(HELPER.getXmlConfigMap()).containsKey("NUMBER");
+        }
+
+        @Test
+        @DisplayName("NUMBER with precision/scale mapping exists")
+        void numberWithPrecisionScale_keyExists() {
+            assertThat(HELPER.getXmlConfigMap()).containsKey("NUMBER_p_s");
+        }
+
+        @ParameterizedTest(name = "[{index}] \"{0}\" key exists in xmlConfigMap")
+        @CsvSource({
+            "BINARY_FLOAT",
+            "BINARY_DOUBLE",
+            "BLOB",
+            "CHAR",
+            "CLOB",
+            "DATE",
+            "INTERVAL DAY TO SECOND",
+            "INTERVAL YEAR TO MONTH",
+            "JSON",
+            "LONG",
+            "LONG RAW",
+            "NCHAR",
+            "NCLOB",
+            "NVARCHAR",
+            "RAW",
+            "TIME",
+            "TIMESTAMP",
+            "TIMESTAMP WITH LOCAL TIME ZONE",
+            "TIMESTAMP WITH TIME ZONE",
+            "VARCHAR",
+            "XMLTYPE",
+            // No ROWID mapping in Tibero2CUBRID.xml.
+        })
+        void expectedKeys_existInXmlConfig(String expectedKey) {
+            assertThat(HELPER.getXmlConfigMap())
+                    .as("Tiber2CUBRID.xml has no key '%s'", expectedKey)
+                    .containsKey(expectedKey);
+        }
+    }
+
+    @Nested
+    @DisplayName("getMapKey()")
+    class GetMapKey {
+
+        @Nested
+        @DisplayName("NUMBER type")
+        class NumberType {
+
+            @Test
+            @DisplayName("NUMBER, precision=null -> \"NUMBER\"")
+            void nullPrecision_returnsNumber() {
+                assertThat(HELPER.getMapKey("NUMBER", null, null))
+                        .isEqualTo("NUMBER");
+            }
+
+            @Test
+            @DisplayName("NUMBER, empty precision -> \"NUMBER\"")
+            void emptyPrecision_returnsNumber() {
+                assertThat(HELPER.getMapKey("NUMBER", "", ""))
+                        .isEqualTo("NUMBER");
+            }
+
+            @Test
+            @DisplayName("NUMBER, precision=\"10\" -> \"NUMBER_p_s\"")
+            void numericPrecision_returnNumberPs() {
+                assertThat(HELPER.getMapKey("NUMBER", "10", "2"))
+                    .isEqualTo("NUMBER" + AbstractDataTypeMappingHelper.MAP_KEY_SEPARATOR
+                            + "p" + AbstractDataTypeMappingHelper.MAP_KEY_SEPARATOR + "s");
+            }
+
+            @Test
+            @DisplayName("NUMBER, precision=\"0\" -> \"NUMBER_p_s\"")
+            void zeroPrecision_returnsNumberPs() {
+                assertThat(HELPER.getMapKey("NUMBER", "0", "0"))
+                        .isEqualTo("NUMBER_p_s");
+            }
+
+            @Test
+            @DisplayName("NUMBER, precision=\"p\" -> \"NUMBER_p_s\"")
+            void templatePrecision_returnsNumberPs() {
+                assertThat(HELPER.getMapKey("NUMBER", "p", "s"))
+                        .isEqualTo("NUMBER_p_s");
+            }
+
+            @Test
+            @DisplayName("NUMBER, precision=\"P\" -> \"NUMBER_p_s\"")
+            void templatePrecisionUppercase_returnsNumberPs() {
+                assertThat(HELPER.getMapKey("NUMBER", "P", "S"))
+                        .isEqualTo("NUMBER_p_s");
+            }
+        }
+
+        @Nested
+        @DisplayName("non-NUMBER types")
+        class NonNumberTypes {
+
+            @ParameterizedTest(name = "[{index}] getMapKey(\"{0}\", ...) → \"{1}\"")
+            @CsvSource({
+                "VARCHAR2,                      VARCHAR2",
+                "VARCHAR,                       VARCHAR",
+                "CHAR,                          CHAR",
+                "NCHAR,                         NCHAR",
+                "TIMESTAMP,                     TIMESTAMP",
+                // TIMESTAMP(6) -> getTiberoDataTypeKey -> "TIMESTAMP"
+                "TIMESTAMP(6),                  TIMESTAMP",
+                // INTERVAL DAY TO SECOND without precision -> keep as is
+                "INTERVAL DAY TO SECOND,        INTERVAL DAY TO SECOND",
+                // INTERVAL DAY(5) TO SECOND(9) -> normalized
+                "INTERVAL DAY(5) TO SECOND(9),  INTERVAL DAY TO SECOND",
+                "INTERVAL YEAR TO MONTH,        INTERVAL YEAR TO MONTH",
+                "INTERVAL YEAR(4) TO MONTH,     INTERVAL YEAR TO MONTH",
+                "JSON,                          JSON",
+                "XMLTYPE,                       XMLTYPE",
+                "CLOB,                          CLOB",
+                "BLOB,                          BLOB",
+            })
+            void nonNumberTypes_returnsNormalizedKey(String inputType, String expectedKey) {
+                assertThat(HELPER.getMapKey(inputType.trim(), null, null))
+                        .isEqualTo(expectedKey.trim());
+            }
+            @Test
+            @DisplayName("lowercase input -> uppercase")
+            void lowercase_returnsUppercaseKey() {
+                assertThat(HELPER.getMapKey("varchar", "100", null))
+                        .isEqualTo("VARCHAR");
+            }
+
+            @Test
+            @DisplayName("null type -> empty string")
+            void nullType_returnsEmptyKey() {
+                assertThat(HELPER.getMapKey(null, null, null)).isEmpty();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("available target list")
+    class AvailableTargetList {
+
+        @Test
+        @DisplayName("BINARY_DOUBLE has double int bigint targets")
+        void binaryDouble_hasExpectedTargets() {
+            assertAvailableTargets("BINARY_DOUBLE", null, null,
+                    tuple("double", null, null),
+                    tuple("int", null, null),
+                    tuple("bigint", null, null));
+        }
+
+        @Test
+        @DisplayName("BINARY_FLOAT has float double int bigint targets")
+        void binaryFloat_hasExpectedTargets() {
+            assertAvailableTargets("BINARY_FLOAT", null, null,
+                    tuple("float", null, null),
+                    tuple("double", null, null),
+                    tuple("int", null, null),
+                    tuple("bigint", null, null));
+        }
+
+        @Test
+        @DisplayName("BLOB has bit varying blob varchar targets")
+        void blob_hasExpectedTargets() {
+            assertAvailableTargets("BLOB", null, null,
+                    tuple("bit varying", "1073741823", null),
+                    tuple("blob", null, null),
+                    tuple("varchar", "1073741823", null));
+        }
+
+        @Test
+        @DisplayName("CHAR has char and varchar targets")
+        void char_hasExpectedTargets() {
+            assertAvailableTargets("CHAR", "10", null,
+                    tuple("char", "n", null),
+                    tuple("varchar", "n", null));
+        }
+
+        @Test
+        @DisplayName("CLOB has varchar and clob targets")
+        void clob_hasExpectedTargets() {
+            assertAvailableTargets("CLOB", null, null,
+                    tuple("varchar", "1073741823", null),
+                    tuple("clob", null, null));
+        }
+
+        @Test
+        @DisplayName("DATE has datetime and timestamp targets")
+        void date_hasExpectedTargets() {
+            assertAvailableTargets("DATE", null, null,
+                    tuple("datetime", null, null),
+                    tuple("timestamp", null, null));
+        }
+
+        @Test
+        @DisplayName("INTERVAL DAY TO SECOND has varchar target")
+        void intervalDayToSecond_hasExpectedTargets() {
+            assertAvailableTargets("INTERVAL DAY TO SECOND", null, null,
+                    tuple("varchar", "255", null));
+        }
+
+        @Test
+        @DisplayName("INTERVAL YEAR TO MONTH has varchar target")
+        void intervalYearToMonth_hasExpectedTargets() {
+            assertAvailableTargets("INTERVAL YEAR TO MONTH", null, null,
+                    tuple("varchar", "255", null));
+        }
+
+        @Test
+        @DisplayName("JSON has json and blob targets")
+        void json_hasExpectedTargets() {
+            assertAvailableTargets("JSON", null, null,
+                    tuple("json", null, null),
+                    tuple("blob", null, null));
+        }
+
+        @Test
+        @DisplayName("LONG has varchar and clob targets")
+        void long_hasExpectedTargets() {
+            assertAvailableTargets("LONG", null, null,
+                    tuple("varchar", "1073741823", null),
+                    tuple("clob", null, null));
+        }
+
+        @Test
+        @DisplayName("LONG RAW has bit varying and blob targets")
+        void longRaw_hasExpectedTargets() {
+            assertAvailableTargets("LONG RAW", null, null,
+                    tuple("bit varying", "1073741823", null),
+                    tuple("blob", null, null));
+        }
+
+        @Test
+        @DisplayName("NCHAR has char and varchar targets")
+        void nchar_hasExpectedTargets() {
+            assertAvailableTargets("NCHAR", "10", null,
+                    tuple("char", "n", null),
+                    tuple("varchar", "n", null));
+        }
+
+        @Test
+        @DisplayName("NCLOB has varchar and clob targets")
+        void nclob_hasExpectedTargets() {
+            assertAvailableTargets("NCLOB", null, null,
+                    tuple("varchar", "1073741823", null),
+                    tuple("clob", null, null));
+        }
+
+        @Test
+        @DisplayName("NUMBER has numeric int bigint varchar targets")
+        void number_hasExpectedTargets() {
+            assertAvailableTargets("NUMBER", null, null,
+                    tuple("numeric", "38", "15"),
+                    tuple("int", null, null),
+                    tuple("bigint", null, null),
+                    tuple("varchar", "78", null));
+        }
+
+        @Test
+        @DisplayName("NUMBER with precision and scale has numeric int bigint varchar targets")
+        void numberWithPrecisionScale_hasExpectedTargets() {
+            assertAvailableTargets("NUMBER", "10", "2",
+                    tuple("numeric", "p", "s"),
+                    tuple("int", null, null),
+                    tuple("bigint", null, null),
+                    tuple("varchar", "78", null));
+        }
+
+        @Test
+        @DisplayName("RAW has bit varying target")
+        void raw_hasExpectedTargets() {
+            assertAvailableTargets("RAW", "10", null,
+                    tuple("bit varying", "n", null));
+        }
+
+        @Test
+        @DisplayName("TIME has varchar and time targets")
+        void time_hasExpectedTargets() {
+            assertAvailableTargets("TIME", null, null,
+                    tuple("varchar", "32", null),
+                    tuple("time", null, null));
+        }
+
+        @Test
+        @DisplayName("TIMESTAMP has datetime and timestamp targets")
+        void timestamp_hasExpectedTargets() {
+            assertAvailableTargets("TIMESTAMP", null, null,
+                    tuple("datetime", null, null),
+                    tuple("timestamp", null, null));
+        }
+
+        @Test
+        @DisplayName("TIMESTAMP WITH LOCAL TIME ZONE has varchar target")
+        void timestampWithLocalTimeZone_hasExpectedTargets() {
+            assertAvailableTargets("TIMESTAMP WITH LOCAL TIME ZONE", null, null,
+                    tuple("varchar", "100", null));
+        }
+
+        @Test
+        @DisplayName("TIMESTAMP WITH TIME ZONE has varchar target")
+        void timestampWithTimeZone_hasExpectedTargets() {
+            assertAvailableTargets("TIMESTAMP WITH TIME ZONE", null, null,
+                    tuple("varchar", "100", null));
+        }
+
+        @Test
+        @DisplayName("XMLTYPE has varchar and clob targets")
+        void xmltype_hasExpectedTargets() {
+            assertAvailableTargets("XMLTYPE", null, null,
+                    tuple("varchar", "1073741823", null),
+                    tuple("clob", null, null));
+        }
+
+        private void assertAvailableTargets(
+                String dataType, String precision, String scale, Tuple... expectedTargets) {
+            MapItem mapItem = HELPER.getXmlConfigMapItem(dataType, precision, scale);
+
+            assertThat(mapItem).isNotNull();
+            assertThat(mapItem.getAvailableTargetList())
+                    .extracting(MapObject::getDatatype, MapObject::getPrecision, MapObject::getScale)
+                    .containsExactly(expectedTargets);
+        }
+    }
+}

--- a/tests/unit-test/src/test/resources/mockito-extensions/org.mockito.plugins.MemberAccessor
+++ b/tests/unit-test/src/test/resources/mockito-extensions/org.mockito.plugins.MemberAccessor
@@ -1,0 +1,1 @@
+member-accessor-reflection

--- a/tests/unit-test/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/tests/unit-test/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4868>

### Purpose
정규화 및 메타데이터 로딩 경로를 중심으로 Tibero 마이그레이션 단위 테스트 케이스를 추가합니다.
특히 Tibero 특화 변환 로직, JDBC 타입 해석, 제약조건/인덱스 메타데이터 로딩에 대한 회귀 테스트를 추가하고, 단위 테스트 모듈에서 사용하는 Mockito 실행 환경을 안정화하는 데 중점을 두었습니다.

### Implementation
TiberoDataTypeHelperTest를 확장하여 다음과 같은 getJdbcDataTypeID() 분기 케이스를 검증하도록 보완

- NUMBER 타입 위임 처리
- 고정 타입 조회
- 정규화 키 기반 조회
- 지원되지 않는 타입 처리
- 타입 누락 시 실패 케이스

Tibero2CUBRIDTransformHelperTest를 확장하여 다음과 같은 주요 변환 로직을 검증하도록 추가

- 정밀도(precision) 보정
- CUBRID 컬럼 정규화
- 문자 길이 유효성 검증
- 숫자 → VARCHAR 변환 검증

TiberoConstraintIndexMetadataLoaderTest를 추가하여 Tibero의 PK/FK/인덱스 메타데이터 로딩 동작 검증

- 복합 키 그룹핑
- 삭제 규칙(delete rule) 변환
- 역방향 인덱스 처리
- 표현식 인덱스(expression index)
- 빈 인덱스 필터링

현재 JDK 환경에서의 안정적인 mocking을 위해, 단위 테스트 모듈에 Mockito 실행 설정 적용


### Remarks
N/A
