### PR TITLE
[TOOLS-4868] Exclude tests/ from Codacy analysis

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+  - "tests/**"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -89,14 +89,12 @@ jobs:
         with:
           files: |
             **/*.java
-            !tests/**/*.java
           write_output_files: true
       - uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd
         if: steps.changed.outputs.any_changed == 'true'
         with:
           release-name: v1.32.0
           args: "--aosp --replace --set-exit-if-changed @.github/outputs/all_changed_files.txt"
-          files-excluded: "**/tests/**/*.java"
           skip-commit: true
       - name: Suggest code changes
         if: failure()


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4868>

### Purpose
Codacy에서도 `tests/`는 검사 대상에서 제외하도록 설정합니다.
Git Action에 있는 Code Stype 체크를 다시 설정합니다.

### Implementation
- `.codacy.yml` 파일을 저장소 root에 생성해 Codacy에서 설정을 적용할 수 있도록 합니다.

### Remarks
- #379 에서 테스트 코드는 코드 스타일 검사에서 제외 시켰지만, 팀 회의 후 테스트 코드도 동일하게 google-java-format을 적용하는 것으로 결정.
