### PR TITLE
[TOOLS-4894] Skip unparseable PL/CSQL routines and report them as Failed

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/PlcsqlFunction.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/PlcsqlFunction.java
@@ -40,6 +40,8 @@ public class PlcsqlFunction extends Function {
     private String headerDDL;
     private String bodyDDL;
 
+    private String parseError;
+
     public String getHeaderDDL() {
         return headerDDL;
     }
@@ -54,6 +56,14 @@ public class PlcsqlFunction extends Function {
 
     public void setBodyDDL(String bodyDDL) {
         this.bodyDDL = bodyDDL;
+    }
+
+    public String getParseError() {
+        return parseError;
+    }
+
+    public void setParseError(String parseError) {
+        this.parseError = parseError;
     }
 
     /**

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/PlcsqlProcedure.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/dbobject/PlcsqlProcedure.java
@@ -40,6 +40,8 @@ public class PlcsqlProcedure extends Procedure {
     private String headerDDL;
     private String bodyDDL;
 
+    private String parseError;
+
     public String getHeaderDDL() {
         return headerDDL;
     }
@@ -54,6 +56,14 @@ public class PlcsqlProcedure extends Procedure {
 
     public void setBodyDDL(String bodyDDL) {
         this.bodyDDL = bodyDDL;
+    }
+
+    public String getParseError() {
+        return parseError;
+    }
+
+    public void setParseError(String parseError) {
+        this.parseError = parseError;
     }
 
     /**

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -2361,10 +2361,17 @@ public class MigrationConfiguration {
         for (SourcePlcsqlProcedureConfig spc : spcs) {
             PlcsqlProcedure targetProc =
                     getTargetPlcsqlProcedureSchema(spc.getOwner(), spc.getName());
+            if (targetProc.getParseError() != null) {
+                continue;
+            }
             if (StringUtils.isBlank(targetProc.getHeaderDDL())
                     || StringUtils.isBlank(targetProc.getBodyDDL())) {
                 ProcedureDDL procedureDDL =
                         PlConvOracleToCubrid.getProcedureDDL(spc.getSourceDDL(), changeDataType);
+                if (procedureDDL.hasSyntaxError()) {
+                    targetProc.setParseError(procedureDDL.getSyntaxErrorMessage());
+                    continue;
+                }
                 targetProc.setHeaderDDL(procedureDDL.getHeader());
                 targetProc.setBodyDDL(procedureDDL.getBody());
             }
@@ -2374,10 +2381,17 @@ public class MigrationConfiguration {
         for (SourcePlcsqlFunctionConfig fpc : fpcs) {
             PlcsqlFunction targetFunc =
                     getTargetPlcsqlFunctionSchema(fpc.getOwner(), fpc.getName());
+            if (targetFunc.getParseError() != null) {
+                continue;
+            }
             if (StringUtils.isBlank(targetFunc.getHeaderDDL())
                     || StringUtils.isBlank(targetFunc.getBodyDDL())) {
                 ProcedureDDL procedureDDL =
                         PlConvOracleToCubrid.getProcedureDDL(fpc.getSourceDDL(), changeDataType);
+                if (procedureDDL.hasSyntaxError()) {
+                    targetFunc.setParseError(procedureDDL.getSyntaxErrorMessage());
+                    continue;
+                }
                 targetFunc.setHeaderDDL(procedureDDL.getHeader());
                 targetFunc.setBodyDDL(procedureDDL.getBody());
             }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/JDBCImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/JDBCImporter.java
@@ -287,6 +287,12 @@ public class JDBCImporter extends Importer {
      */
     @Override
     public void createPlcsqlProcedureHeader(PlcsqlProcedure pd) {
+        if (pd.getParseError() != null) {
+            createObjectFailed(
+                    pd,
+                    new NormalMigrationException("PL/CSQL syntax error: " + pd.getParseError()));
+            return;
+        }
         String ddl =
                 CUBRIDSQLHelper.getInstance(null)
                         .getPlcsqlProcedureHeaderDDL(pd, config.isAddUserSchema());
@@ -305,6 +311,9 @@ public class JDBCImporter extends Importer {
      */
     @Override
     public void createPlcsqlProcedureBody(PlcsqlProcedure pd) {
+        if (pd.getParseError() != null) {
+            return;
+        }
         String ddl =
                 CUBRIDSQLHelper.getInstance(null)
                         .getPlcsqlProcedureDDL(pd, config.isAddUserSchema());
@@ -323,6 +332,12 @@ public class JDBCImporter extends Importer {
      */
     @Override
     public void createPlcsqlFunctionHeader(PlcsqlFunction ft) {
+        if (ft.getParseError() != null) {
+            createObjectFailed(
+                    ft,
+                    new NormalMigrationException("PL/CSQL syntax error: " + ft.getParseError()));
+            return;
+        }
         String ddl =
                 CUBRIDSQLHelper.getInstance(null)
                         .getPlcsqlFunctionHeaderDDL(ft, config.isAddUserSchema());
@@ -341,6 +356,9 @@ public class JDBCImporter extends Importer {
      */
     @Override
     public void createPlcsqlFunctionBody(PlcsqlFunction ft) {
+        if (ft.getParseError() != null) {
+            return;
+        }
         String ddl =
                 CUBRIDSQLHelper.getInstance(null)
                         .getPlcsqlFunctionDDL(ft, config.isAddUserSchema());

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -893,6 +893,12 @@ public abstract class OfflineImporter extends Importer {
      */
     @Override
     public void createPlcsqlProcedureHeader(PlcsqlProcedure pd) {
+        if (pd.getParseError() != null) {
+            createObjectFailed(
+                    pd,
+                    new NormalMigrationException("PL/CSQL syntax error: " + pd.getParseError()));
+            return;
+        }
         String ddl =
                 CUBRIDSQLHelper.getInstance(null)
                         .getPlcsqlProcedureHeaderDDL(pd, config.isAddUserSchema());
@@ -914,6 +920,9 @@ public abstract class OfflineImporter extends Importer {
      */
     @Override
     public void createPlcsqlProcedureBody(PlcsqlProcedure pd) {
+        if (pd.getParseError() != null) {
+            return;
+        }
         String ddl =
                 CUBRIDSQLHelper.getInstance(null)
                         .getPlcsqlProcedureDDL(pd, config.isAddUserSchema());
@@ -935,6 +944,12 @@ public abstract class OfflineImporter extends Importer {
      */
     @Override
     public void createPlcsqlFunctionHeader(PlcsqlFunction ft) {
+        if (ft.getParseError() != null) {
+            createObjectFailed(
+                    ft,
+                    new NormalMigrationException("PL/CSQL syntax error: " + ft.getParseError()));
+            return;
+        }
         String ddl =
                 CUBRIDSQLHelper.getInstance(null)
                         .getPlcsqlFunctionHeaderDDL(ft, config.isAddUserSchema());
@@ -956,6 +971,9 @@ public abstract class OfflineImporter extends Importer {
      */
     @Override
     public void createPlcsqlFunctionBody(PlcsqlFunction ft) {
+        if (ft.getParseError() != null) {
+            return;
+        }
         String ddl =
                 CUBRIDSQLHelper.getInstance(null)
                         .getPlcsqlFunctionDDL(ft, config.isAddUserSchema());

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlFunctionDDLTask.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlFunctionDDLTask.java
@@ -63,6 +63,9 @@ public class AllPlcsqlFunctionDDLTask extends ImportTask {
         Map<String, String> functionFiles = config.getTargetAllPlcsqlFunctionFileName();
 
         for (PlcsqlFunction function : targetFunctions) {
+            if (function.getParseError() != null) {
+                continue;
+            }
             String owner = function.getOwner();
 
             CUBRIDSQLHelper sqlHelper = CUBRIDSQLHelper.getInstance(null);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlFunctionHeaderDDLTask.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlFunctionHeaderDDLTask.java
@@ -63,6 +63,9 @@ public class AllPlcsqlFunctionHeaderDDLTask extends ImportTask {
         Map<String, String> functionFiles = config.getTargetAllPlcsqlFunctionHeaderFileName();
 
         for (PlcsqlFunction function : targetFunctions) {
+            if (function.getParseError() != null) {
+                continue;
+            }
             String owner = function.getOwner();
 
             CUBRIDSQLHelper sqlHelper = CUBRIDSQLHelper.getInstance(null);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlProcedureDDLTask.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlProcedureDDLTask.java
@@ -63,6 +63,9 @@ public class AllPlcsqlProcedureDDLTask extends ImportTask {
         Map<String, String> procedureFiles = config.getTargetAllPlcsqlProcedureFileName();
 
         for (PlcsqlProcedure procedure : targetProcedures) {
+            if (procedure.getParseError() != null) {
+                continue;
+            }
             String owner = procedure.getOwner();
 
             CUBRIDSQLHelper sqlHelper = CUBRIDSQLHelper.getInstance(null);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlProcedureHeaderDDLTask.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/AllPlcsqlProcedureHeaderDDLTask.java
@@ -63,6 +63,9 @@ public class AllPlcsqlProcedureHeaderDDLTask extends ImportTask {
         Map<String, String> procedureFiles = config.getTargetAllPlcsqlProcedureHeaderFileName();
 
         for (PlcsqlProcedure procedure : targetProcedures) {
+            if (procedure.getParseError() != null) {
+                continue;
+            }
             String owner = procedure.getOwner();
 
             CUBRIDSQLHelper sqlHelper = CUBRIDSQLHelper.getInstance(null);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/PlcsqlFunctionSourceAndDropDDLTask.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/PlcsqlFunctionSourceAndDropDDLTask.java
@@ -63,6 +63,9 @@ public class PlcsqlFunctionSourceAndDropDDLTask extends ImportTask {
         Map<String, Map<String, String>> functionFiles = config.getTargetPlcsqlFunctionFileName();
 
         for (PlcsqlFunction function : targetFunctions) {
+            if (function.getParseError() != null) {
+                continue;
+            }
             String owner = function.getOwner();
             String name = function.getName();
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/PlcsqlProcedureSourceAndDropDDLTask.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/PlcsqlProcedureSourceAndDropDDLTask.java
@@ -63,6 +63,9 @@ public class PlcsqlProcedureSourceAndDropDDLTask extends ImportTask {
         Map<String, Map<String, String>> procedureFiles = config.getTargetPlcsqlProcedureFileName();
 
         for (PlcsqlProcedure procedure : targetProcedures) {
+            if (procedure.getParseError() != null) {
+                continue;
+            }
             String owner = procedure.getOwner();
             String name = procedure.getName();
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/parser/OffsetCollector.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/parser/OffsetCollector.java
@@ -75,11 +75,12 @@ public class OffsetCollector extends PloParserBaseListener {
             // interested in.
 
             Token isOrAs;
-            if (ctx.IS() == null) {
-                assert ctx.AS() != null;
+            if (ctx.IS() != null) {
+                isOrAs = ctx.IS().getSymbol();
+            } else if (ctx.AS() != null) {
                 isOrAs = ctx.AS().getSymbol();
             } else {
-                isOrAs = ctx.IS().getSymbol();
+                return;
             }
             bodyStartOffset = isOrAs.getStartIndex();
             assert bodyStartOffset > 0;

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/parser/PlConvOracleToCubrid.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/parser/PlConvOracleToCubrid.java
@@ -55,12 +55,18 @@ public class PlConvOracleToCubrid {
         parser.addErrorListener(sei);
 
         ParseTree tree = parser.sql_script();
+        SyntaxError syntaxError = null;
         if (sei.hasError) {
-            log.error("PL/CSQL syntax error", new SyntaxError(sei.line, sei.column, sei.msg));
+            syntaxError = new SyntaxError(sei.line, sei.column, sei.msg);
+            log.error("PL/CSQL syntax error", syntaxError);
         }
 
         OffsetCollector oc = new OffsetCollector();
         ParseTreeWalker.DEFAULT.walk(oc, tree);
+
+        if (syntaxError != null && oc.bodyStartOffset == 0) {
+            return new ProcedureDDL("", "", false, true, syntaxError.getMessage());
+        }
 
         String header = text.substring(0, oc.bodyStartOffset);
         assert header != null;

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/parser/ProcedureDDL.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/oracle/parser/ProcedureDDL.java
@@ -37,11 +37,24 @@ public class ProcedureDDL {
     private final String header;
     private final String body;
     private final boolean hasUnsupportedType;
+    private final boolean hasSyntaxError;
+    private final String syntaxErrorMessage;
 
     public ProcedureDDL(String header, String body, boolean hasUnsupportedType) {
+        this(header, body, hasUnsupportedType, false, null);
+    }
+
+    public ProcedureDDL(
+            String header,
+            String body,
+            boolean hasUnsupportedType,
+            boolean hasSyntaxError,
+            String syntaxErrorMessage) {
         this.header = header;
         this.body = body;
         this.hasUnsupportedType = hasUnsupportedType;
+        this.hasSyntaxError = hasSyntaxError;
+        this.syntaxErrorMessage = syntaxErrorMessage;
     }
 
     public String getHeader() {
@@ -56,6 +69,14 @@ public class ProcedureDDL {
         return hasUnsupportedType;
     }
 
+    public boolean hasSyntaxError() {
+        return hasSyntaxError;
+    }
+
+    public String getSyntaxErrorMessage() {
+        return syntaxErrorMessage;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -63,11 +84,13 @@ public class ProcedureDDL {
         ProcedureDDL that = (ProcedureDDL) o;
         return Objects.equals(header, that.header)
                 && Objects.equals(body, that.body)
-                && hasUnsupportedType == that.hasUnsupportedType;
+                && hasUnsupportedType == that.hasUnsupportedType
+                && hasSyntaxError == that.hasSyntaxError
+                && Objects.equals(syntaxErrorMessage, that.syntaxErrorMessage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(header, body, hasUnsupportedType);
+        return Objects.hash(header, body, hasUnsupportedType, hasSyntaxError, syntaxErrorMessage);
     }
 }

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/FunctionMappingView.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/FunctionMappingView.java
@@ -162,13 +162,27 @@ public class FunctionMappingView extends AbstractMappingView {
 
         // Perform parsing when displaying on the screen. Skip parsing during migration.
         final CUBRIDSQLHelper ddlUtils = CUBRIDSQLHelper.getInstance(null);
-        if (targetFunc.getHeaderDDL() == null && targetFunc.getBodyDDL() == null) {
+        if (targetFunc.getParseError() == null
+                && targetFunc.getHeaderDDL() == null
+                && targetFunc.getBodyDDL() == null) {
             ProcedureDDL functionDDL =
                     PlConvOracleToCubrid.getProcedureDDL(targetFunc.getSourceDDL(), true);
-            targetFunc.setHeaderDDL(functionDDL.getHeader());
-            targetFunc.setBodyDDL(functionDDL.getBody());
+            if (functionDDL.hasSyntaxError()) {
+                targetFunc.setParseError(functionDDL.getSyntaxErrorMessage());
+            } else {
+                targetFunc.setHeaderDDL(functionDDL.getHeader());
+                targetFunc.setBodyDDL(functionDDL.getBody());
+            }
         }
-        String funcDDL = ddlUtils.getPlcsqlFunctionDDL(targetFunc, config.isAddUserSchema());
+        String funcDDL;
+        if (targetFunc.getParseError() != null) {
+            funcDDL =
+                    "-- PL/CSQL syntax error: "
+                            + targetFunc.getParseError()
+                            + "\n-- This routine will be skipped during migration.\n";
+        } else {
+            funcDDL = ddlUtils.getPlcsqlFunctionDDL(targetFunc, config.isAddUserSchema());
+        }
         txtTargetSQL.setText(funcDDL);
         // Set controls status
         btnCreate.setEnabled(true);

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/ProcedureMappingView.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/view/ProcedureMappingView.java
@@ -162,13 +162,27 @@ public class ProcedureMappingView extends AbstractMappingView {
 
         // Perform parsing when displaying on the screen. Skip parsing during migration.
         final CUBRIDSQLHelper ddlUtils = CUBRIDSQLHelper.getInstance(null);
-        if (targetProc.getHeaderDDL() == null && targetProc.getBodyDDL() == null) {
+        if (targetProc.getParseError() == null
+                && targetProc.getHeaderDDL() == null
+                && targetProc.getBodyDDL() == null) {
             ProcedureDDL procedureDDL =
                     PlConvOracleToCubrid.getProcedureDDL(targetProc.getSourceDDL(), true);
-            targetProc.setHeaderDDL(procedureDDL.getHeader());
-            targetProc.setBodyDDL(procedureDDL.getBody());
+            if (procedureDDL.hasSyntaxError()) {
+                targetProc.setParseError(procedureDDL.getSyntaxErrorMessage());
+            } else {
+                targetProc.setHeaderDDL(procedureDDL.getHeader());
+                targetProc.setBodyDDL(procedureDDL.getBody());
+            }
         }
-        String procDDL = ddlUtils.getPlcsqlProcedureDDL(targetProc, config.isAddUserSchema());
+        String procDDL;
+        if (targetProc.getParseError() != null) {
+            procDDL =
+                    "-- PL/CSQL syntax error: "
+                            + targetProc.getParseError()
+                            + "\n-- This routine will be skipped during migration.\n";
+        } else {
+            procDDL = ddlUtils.getPlcsqlProcedureDDL(targetProc, config.isAddUserSchema());
+        }
         txtTargetSQL.setText(procDDL);
         // Set controls status
         btnCreate.setEnabled(true);

--- a/tests/unit-test/src/test/java/com/cubrid/cubridmigration/oracle/parser/PlConvOracleToCubridTest.java
+++ b/tests/unit-test/src/test/java/com/cubrid/cubridmigration/oracle/parser/PlConvOracleToCubridTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+package com.cubrid.cubridmigration.oracle.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PlConvOracleToCubrid")
+public class PlConvOracleToCubridTest {
+
+    @Nested
+    @DisplayName("getProcedureDDL()")
+    class GetProcedureDDL {
+
+        @Test
+        @DisplayName("valid procedure parses and splits header/body around IS")
+        void validProcedure_splitsHeaderAndBody() {
+            String text = "CREATE OR REPLACE PROCEDURE HELLO IS BEGIN NULL; END;";
+
+            ProcedureDDL result = PlConvOracleToCubrid.getProcedureDDL(text, false);
+
+            assertThat(result.getHeader()).contains("PROCEDURE HELLO");
+            assertThat(result.getBody()).startsWith("IS");
+            assertThat(result.getBody()).contains("END;");
+            assertThat(result.hasUnsupportedType()).isFalse();
+            assertThat(result.hasSyntaxError()).isFalse();
+            assertThat(result.getSyntaxErrorMessage()).isNull();
+        }
+
+        @Test
+        @DisplayName("valid function parses and splits header/body around IS")
+        void validFunction_splitsHeaderAndBody() {
+            String text =
+                    "CREATE OR REPLACE FUNCTION ADD_ONE (P NUMBER) RETURN NUMBER IS "
+                            + "BEGIN RETURN P + 1; END;";
+
+            ProcedureDDL result = PlConvOracleToCubrid.getProcedureDDL(text, false);
+
+            assertThat(result.getHeader()).contains("FUNCTION ADD_ONE");
+            assertThat(result.getHeader()).contains("RETURN NUMBER");
+            assertThat(result.getBody()).startsWith("IS");
+            assertThat(result.getBody()).contains("RETURN P + 1;");
+            assertThat(result.hasSyntaxError()).isFalse();
+        }
+
+        @Test
+        @DisplayName("wrapped routine flags syntax error and returns empty DDL")
+        void wrappedRoutine_flagsSyntaxError() {
+            String text =
+                    "FUNCTION SYS_INTERNAL_FUNC wrapped\n"
+                            + "abcd\n"
+                            + "0123456789abcdef0123456789abcdef\n";
+
+            ProcedureDDL[] holder = new ProcedureDDL[1];
+            assertThatCode(() -> holder[0] = PlConvOracleToCubrid.getProcedureDDL(text, false))
+                    .doesNotThrowAnyException();
+
+            assertThat(holder[0]).isNotNull();
+            assertThat(holder[0].getHeader()).isEmpty();
+            assertThat(holder[0].getBody()).isEmpty();
+            assertThat(holder[0].hasUnsupportedType()).isFalse();
+            assertThat(holder[0].hasSyntaxError()).isTrue();
+            assertThat(holder[0].getSyntaxErrorMessage()).contains("wrapped");
+        }
+
+        @Test
+        @DisplayName("unsupported syntax after AS keyword returns best-effort header and body")
+        void unsupportedSyntaxAfterAs_returnsBestEffortOutput() {
+            String text =
+                    "CREATE OR REPLACE PROCEDURE EXCEPTION_TEST AS\n"
+                            + "    e_zero_div EXCEPTION;\n"
+                            + "    PRAGMA EXCEPTION_INIT(e_zero_div, -1476);\n"
+                            + "BEGIN\n"
+                            + "    NULL;\n"
+                            + "END;";
+
+            ProcedureDDL result = PlConvOracleToCubrid.getProcedureDDL(text, false);
+
+            assertThat(result.hasSyntaxError()).isFalse();
+            assertThat(result.getHeader()).contains("PROCEDURE EXCEPTION_TEST");
+            assertThat(result.getBody()).startsWith("AS");
+            assertThat(result.getBody()).contains("PRAGMA EXCEPTION_INIT");
+        }
+    }
+}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4894>

### Purpose
마이그레이션 소스에서 PL/CSQL 파서가 처리할 수 없는 문법을 만나면 NPE가 발생하여 마이그레이션 마법사 진행이 중단됩니다.
파싱이 불가능한 Procedure 또는 Function을 마이그레이션 대상에서 제외하고, 마이그레이션 리포트의 Failed 컬럼에 집계되도록 합니다.

### Implementation
- ProcedureDDL에 `hasSyntaxError`, `syntaxErrorMessage` 필드 추가
- PlcsqlFunction, PlcsqlProcedure에 `parseError` 필드 추가
- PlConvOracleToCubrid.getProcedureDDL: syntax error 시 tree walk 생략 후 flag가 설정된 빈 결과 반환
- JDBCImporter / OfflineImporter의 Header 메서드: `parseError` 시 `createObjectFailed` 호출하여 리포트 Failed + 1 처리
- JDBCImporter / OfflineImporter의 Body 메서드: `parseError` 시 아무런 작업하지 않고 return

### Tests
PlConvOracleToCubridTest 추가
- 정상 procedure가 `IS` 기준으로 header/body 분리, syntax error flag 미설정
- 정상 function이 `RETURN` 절 포함 header와 body 분리
- `IS`, `AS`를 인식할 수 없는 경우 빈 DDL + error flag 설정
- `IS`, `AS` 이후 미지원 문법의 경우 에러 처리 없이 header/body 반환, error falg 미설정

### Remarks
마이그레이션이 진행되면서 기록되는 로그에서 마이그레이션 성공 시 Header + Body로 나눠서 실행되고 있어 로그가 2줄이 출력되지만, parse 실패의 경우 실패 로그 1줄만 출력됩니다.
