### PR TITLE
[TOOLS-4893] Fix sequence migration failure in specific cases

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -843,20 +843,20 @@ public class MigrationConfiguration {
                     }
                 }
                 tempList.add(sc);
-                Sequence tseq = null;
-                if (sc.getOwner() == null) {
-                    tseq = getTargetSerialSchema(sc.getTarget());
-                } else {
-                    tseq = getTargetSerialSchema(sc.getTargetOwner(), sc.getTarget());
-                }
+                String sourceOwner =
+                        StringUtils.defaultIfBlank(
+                                sc.getOwner(),
+                                StringUtils.defaultIfBlank(
+                                        seq.getOwner(), sourceDBSchema.getName()));
+                Sequence tseq = getTargetSerialSchema(sc.getTargetOwner(), sc.getTarget());
                 if (tseq == null) {
                     tseq = (Sequence) seq.clone();
                     tseq.setName(sc.getTarget());
-                    tseq.setOwner(sc.getTargetOwner());
-                    tseq.setSourceOwner(sc.getOwner());
-                    tseq.setDDL(cubridddlUtil.getSequenceDDL(tseq, this.addUserSchema));
-                    tseq.setComment(seq.getComment());
                 }
+                tseq.setOwner(sc.getTargetOwner());
+                tseq.setSourceOwner(sourceOwner);
+                tseq.setDDL(cubridddlUtil.getSequenceDDL(tseq, this.addUserSchema));
+                tseq.setComment(seq.getComment());
                 tempSerials.add(tseq);
             }
         }
@@ -3875,7 +3875,8 @@ public class MigrationConfiguration {
         }
 
         for (Sequence seq : this.targetSequences) {
-            if (seq.getName().equalsIgnoreCase(target) && seq.getOwner().equalsIgnoreCase(owner)) {
+            if (seq.getName().equalsIgnoreCase(target)
+                    && StringUtils.equalsIgnoreCase(seq.getOwner(), owner)) {
                 return seq;
             }
         }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4893>

### Purpose
CUBRID 11.2 미만 버전에서 dump 파일로 이관할 때 5페이지 진입 후 4페이지로 돌아가서 target schema 이름 변경 후 이관하면 serial이 이관되지 않는 문제를 수정

### Implementation
- Target sequence 조회 시 `sc.getTargetOwner()`와 `sc.getTarget()`을 사용하도록 변경
- Target sequence의 특정 정보를 항시 갱신하도록 수정

### Remarks
N/A
