### PR TITLE
[TOOLS-4903] Fix NPE on wizard back navigation to Object Mapping page

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -1037,9 +1037,10 @@ public class MigrationConfiguration {
                 }
 
                 if (tprocedure == null
-                        || !sourceDBSchema
-                                .getTargetSchemaName()
-                                .equals(tprocedure.getTargetOwner())) {
+                        || (nonNull(sourceDBSchema.getTargetSchemaName())
+                                && !sourceDBSchema
+                                        .getTargetSchemaName()
+                                        .equals(tprocedure.getTargetOwner()))) {
                     tprocedure = new PlcsqlProcedure();
                     tprocedure.setOwner(sc.getOwner());
                     tprocedure.setTargetOwner(sc.getTargetOwner());
@@ -1112,9 +1113,10 @@ public class MigrationConfiguration {
                 }
 
                 if (tfunction == null
-                        || !sourceDBSchema
-                                .getTargetSchemaName()
-                                .equals(tfunction.getTargetOwner())) {
+                        || (nonNull(sourceDBSchema.getTargetSchemaName())
+                                && !sourceDBSchema
+                                        .getTargetSchemaName()
+                                        .equals(tfunction.getTargetOwner()))) {
                     tfunction = new PlcsqlFunction();
                     tfunction.setOwner(sc.getOwner());
                     tfunction.setTargetOwner(sc.getTargetOwner());


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4903>

### Purpose
마이그레이션 마법사에서 Object Mapping 페이지를 한 번 통과한 뒤 Back 버튼으로 다시 진입할 때 NPE가 발생하여 다음 단계로 진행할 수 없는 문제를 해결합니다.

### Implementation
- `MigrationConfiguration.buildPlcsqlProcedureCfg`와 `buildPlcsqlFunctionCfg`의
`tprocedure` / `tfunction` 비교 분기에 null 가드를 추가

### Remarks
N/A
