### PR TITLE
[TOOLS-4907] Fix Linux package configuration layout

### DIFF
--- a/product/com.cubrid.cubridmigration.desktop/linux.xml
+++ b/product/com.cubrid.cubridmigration.desktop/linux.xml
@@ -7,7 +7,7 @@
     </formats>
     <fileSets>
         <fileSet>
-            <directory>${basedir}/target/products/com.cubrid.cubridmigration.desktop/linux/gtk/x86_64/cubridmigration/</directory>
+            <directory>${basedir}/target/products/com.cubrid.cubridmigration.desktop/linux/gtk/x86_64/cubridmigration/configuration</directory>
             <outputDirectory>configuration</outputDirectory>
         </fileSet>
         <fileSet>


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4907>

### Purpose
Linux 배포 패키지에서 제품 루트 전체가 `configuration/` 아래에 중첩되어 RCP 애플리케이션 실행이 실패하는 문제가 있습니다.
이로 인해 `configuration/config.ini`와 `bundles.info`가 기대 위치에 없어서 `org.eclipse.core.runtime` 번들이 정상적으로 resolve/start되지 않았습니다.

### Implementation
`linux.xml`의 `configuration` fileSet source 경로를 제품 루트가 아닌 실제 `configuration` 디렉터리로 수정했습니다.

수정 후 Linux tarball에서 `configuration/plugins`, `configuration/features`, `configuration/p2`, `configuration/configuration` 중첩이 사라지고, `configuration/config.ini`와 `configuration/org.eclipse.equinox.simpleconfigurator/bundles.info`가 정상 위치에 포함되는 것을 확인했습니다.
### Remarks
N/A