### PR TITLE
[TOOLS-4922] Fix missing <schemas> in exported migration script

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -801,12 +801,27 @@ public class MigrationConfiguration {
      * @param isReset
      */
     private void buildSchemaCfg(boolean isReset) {
-        for (String schemaName : newTargetSchema) {
-            Schema dummySchema = new Schema();
-            dummySchema.setName(schemaName);
-            dummySchema.setNewTargetSchema(true);
+        if (!targetIsOnline()) {
+            return;
+        }
+        if (!scriptSchemaMapping.isEmpty()) {
+            return;
+        }
+        rebuildTargetSchemaListFromSource(srcCatalog);
+    }
 
-            targetSchemaList.add(dummySchema);
+    public void rebuildTargetSchemaListFromSource(Catalog sourceCatalog) {
+        removeTargetSchemaList();
+        for (Schema sourceSchema : sourceCatalog.getSchemas()) {
+            String target = sourceSchema.getTargetSchemaName();
+            if (StringUtils.isBlank(target)) {
+                continue;
+            }
+            Schema entry = new Schema();
+            entry.setName(sourceSchema.getName());
+            entry.setTargetSchemaName(target);
+            entry.setNewTargetSchema(newTargetSchema.contains(target));
+            targetSchemaList.add(entry);
         }
     }
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
@@ -361,6 +361,9 @@ public class MigrationTasksScheduler {
 
     protected void createSchema() {
         MigrationConfiguration config = context.getConfig();
+        if (config.targetIsOnline() && !config.isAddUserSchema()) {
+            return;
+        }
         List<Schema> dummySchemaList = config.getTargetSchemaList();
 
         dummySchemaList.stream()

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/scheduler/MigrationTasksScheduler.java
@@ -367,6 +367,7 @@ public class MigrationTasksScheduler {
         List<Schema> dummySchemaList = config.getTargetSchemaList();
 
         dummySchemaList.stream()
+                .filter(Schema::isNewTargetSchema)
                 .distinct()
                 .forEach(
                         schema -> {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/UpdateStatisticsTask.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/UpdateStatisticsTask.java
@@ -140,6 +140,9 @@ public class UpdateStatisticsTask extends ImportTask {
     /** Execute import */
     protected void executeImport() {
         if (config.targetIsOnline() && config.isUpdateStatistics()) {
+            if (!config.isAddUserSchema()) {
+                return;
+            }
             List<Schema> schemaList = config.getTargetSchemaList();
             for (Schema schema : schemaList) {
                 LOG.debug("Execute update statistics for " + schema.getTargetSchemaName());

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/UpdateStatisticsTask.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/task/imp/UpdateStatisticsTask.java
@@ -71,13 +71,17 @@ public class UpdateStatisticsTask extends ImportTask {
      * @return UPDATE STATISTICS ON SQLs
      */
     private List<String> getUpdateStatisticsSQLs(String schemaName) {
+        return getUpdateStatisticsSQLs(schemaName, config.getSourceDBType().isSupportMultiSchema());
+    }
+
+    private List<String> getUpdateStatisticsSQLs(String schemaName, boolean qualifyBySchema) {
         List<String> result = new ArrayList<String>();
         if (config.sourceIsSQL()) {
             return result;
         }
         List<String> objectsToBeUpdated = new ArrayList<String>();
 
-        if (config.getSourceDBType().isSupportMultiSchema()) {
+        if (qualifyBySchema) {
             if (config.sourceIsCSV()) {
                 List<SourceCSVConfig> csvConfigs = config.getCSVConfigs();
                 for (SourceCSVConfig csvf : csvConfigs) {
@@ -141,6 +145,7 @@ public class UpdateStatisticsTask extends ImportTask {
     protected void executeImport() {
         if (config.targetIsOnline() && config.isUpdateStatistics()) {
             if (!config.isAddUserSchema()) {
+                execSQLList(getUpdateStatisticsSQLs(null, false));
                 return;
             }
             List<Schema> schemaList = config.getTargetSchemaList();

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/TemplateTags.java
@@ -95,6 +95,7 @@ public final class TemplateTags {
     public static final String ATTR_MIGRATE_DATA = "migrate_data";
     public static final String ATTR_MIN = "min";
     public static final String ATTR_NAME = "name";
+    public static final String ATTR_NEW = "new";
     public static final String ATTR_NO_LOGGING = "no_logging";
     public static final String ATTR_NO_MAX = "no_max";
     public static final String ATTR_NO_MIN = "no_min";

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/SchemasNodeHandler.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/reader/node/SchemasNodeHandler.java
@@ -50,12 +50,14 @@ public class SchemasNodeHandler extends DefaultHandler {
         if (TAG_SCHEMA.equals(qName)) {
             String src = attributes.getValue(ATTR_SOURCE);
             String trg = attributes.getValue(ATTR_TARGET);
+            String isNew = attributes.getValue(ATTR_NEW);
 
             if (src != null && trg != null) {
                 Schema schema = new Schema();
                 schema.setName(src);
                 schema.setTargetSchemaName(trg);
                 schema.setMigration(true);
+                schema.setNewTargetSchema(isNew == null ? true : Boolean.parseBoolean(isNew));
 
                 config.addScriptSchemaMapping(src, schema);
                 config.addTargetSchemaList(schema);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/SchemasNodeWriter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/template/writer/node/SchemasNodeWriter.java
@@ -49,11 +49,15 @@ public class SchemasNodeWriter {
             return;
         }
 
+        boolean online = config.targetIsOnline();
         writer.writeStartElement(TAG_SCHEMAS);
         for (Schema schema : schemas) {
             writer.writeEmptyElement(TAG_SCHEMA);
             writer.writeAttribute(ATTR_SOURCE, schema.getName());
             writer.writeAttribute(ATTR_TARGET, schema.getTargetSchemaName());
+            if (online) {
+                writer.writeAttribute(ATTR_NEW, String.valueOf(schema.isNewTargetSchema()));
+            }
         }
         writer.writeEndElement(); // </schemas>
     }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/cubrid/CUBRIDSQLHelper.java
@@ -792,7 +792,7 @@ public class CUBRIDSQLHelper extends SQLHelper {
         StringBuffer bf = new StringBuffer();
 
         bf.append("CREATE USER ");
-        bf.append(dummySchema.getName());
+        bf.append(dummySchema.getTargetSchemaName());
 
         return bf.toString();
     }

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -394,6 +394,11 @@ public class SchemaMappingPage extends MigrationWizardPage {
             return false;
         }
 
+        config.clearNewTargetShemaList();
+        for (Schema srcSchema : srcCatalog.getSchemas()) {
+            srcSchema.setTargetSchemaName(null);
+        }
+
         List<String> checkNewSchemaDuplicate = new ArrayList<>();
         config.setTarSchemaDuplicate(false);
 
@@ -406,9 +411,7 @@ public class SchemaMappingPage extends MigrationWizardPage {
             }
         }
 
-        if (!tarCatalog.isDbHasUserSchema()) {
-            buildNonUserSchemaTargetList(currentSrcTables);
-        }
+        config.rebuildTargetSchemaListFromSource(srcCatalog);
 
         wizard.setSourceDBNode(srcCatalog);
         return true;
@@ -418,6 +421,10 @@ public class SchemaMappingPage extends MigrationWizardPage {
             SrcTable srcTable, Catalog tarCatalog, List<String> checkNewSchemaDuplicate) {
         if (!(tarCatalog.isDbHasUserSchema())) {
             srcTable.setTarSchema(null);
+            Schema srcSchema = srcCatalog.getSchemaByName(srcTable.getSrcSchema());
+            if (srcSchema != null) {
+                srcSchema.setTargetSchemaName(srcSchema.getName());
+            }
             return true;
         }
 
@@ -450,27 +457,6 @@ public class SchemaMappingPage extends MigrationWizardPage {
             checkNewSchemaDuplicate.add(newSchema.getName());
             config.setNewTargetSchema(newSchema.getName());
         }
-    }
-
-    private void buildNonUserSchemaTargetList(List<SrcTable> currentSrcTables) {
-        List<Schema> targetSchemaList = new ArrayList<>();
-        List<String> addedSchemas = new ArrayList<>();
-        for (SrcTable srcTable : currentSrcTables) {
-            if (!srcTable.isSelected()) {
-                continue;
-            }
-            Schema srcSchema = srcCatalog.getSchemaByName(srcTable.getSrcSchema());
-            if (srcSchema == null || addedSchemas.contains(srcSchema.getName())) {
-                continue;
-            }
-            srcSchema.setTargetSchemaName(srcSchema.getName());
-            targetSchemaList.add(srcSchema);
-            addedSchemas.add(srcSchema.getName());
-        }
-        if (!config.getTargetSchemaList().isEmpty()) {
-            config.removeTargetSchemaList();
-        }
-        config.setTargetSchemaList(targetSchemaList);
     }
 
     /**

--- a/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
+++ b/plugins/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/page/SchemaMappingPage.java
@@ -405,6 +405,11 @@ public class SchemaMappingPage extends MigrationWizardPage {
                 return false;
             }
         }
+
+        if (!tarCatalog.isDbHasUserSchema()) {
+            buildNonUserSchemaTargetList(currentSrcTables);
+        }
+
         wizard.setSourceDBNode(srcCatalog);
         return true;
     }
@@ -445,6 +450,27 @@ public class SchemaMappingPage extends MigrationWizardPage {
             checkNewSchemaDuplicate.add(newSchema.getName());
             config.setNewTargetSchema(newSchema.getName());
         }
+    }
+
+    private void buildNonUserSchemaTargetList(List<SrcTable> currentSrcTables) {
+        List<Schema> targetSchemaList = new ArrayList<>();
+        List<String> addedSchemas = new ArrayList<>();
+        for (SrcTable srcTable : currentSrcTables) {
+            if (!srcTable.isSelected()) {
+                continue;
+            }
+            Schema srcSchema = srcCatalog.getSchemaByName(srcTable.getSrcSchema());
+            if (srcSchema == null || addedSchemas.contains(srcSchema.getName())) {
+                continue;
+            }
+            srcSchema.setTargetSchemaName(srcSchema.getName());
+            targetSchemaList.add(srcSchema);
+            addedSchemas.add(srcSchema.getName());
+        }
+        if (!config.getTargetSchemaList().isEmpty()) {
+            config.removeTargetSchemaList();
+        }
+        config.setTargetSchemaList(targetSchemaList);
     }
 
     /**


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4922>

### Purpose
Export Script로 생성한 스크립트에서 일부 케이스에 `<schemas>` 태그가 누락되는 문제를 해결합니다.
- 누락 케이스: 온라인 -> CUBRID 11.2 미만, 11.2 이상에서 이미 존재하는 스키마로 매핑하는 경우
- `<schemas>`는 원본의 어떤 스키마를 읽을지를 지정하는 핵심 정보입니다. 누락되면 콘솔 마이그레이션이 실패하고, 스크립트로 마법사를 재시작할 때 스키마 선택/매핑 정보 유실됩니다.

### Implementation
 - 스키마 목록 구성을 한 곳으로 통일하여, 선택된 모든 원본 스키마의 source -> target 매핑을 출력하도록 변경. 타겟 버전이나 신규/기존 여부와 무관하게 `<schemas>`가 생성
 - 스키마 목록은 export뿐 아니라 실제 스키마 생성(CREATE USER)에서도 사용
 - `<schema new="true|false">`로 신규/기존을 구분하고, `new=true`인 스키마만 생성
 - 스키마 생성은 온라인 전용 개념이므로 오프라인 `<schema>`에는 `new`를 출력하지 않음

### Remarks
N/A
