### PR TITLE
[TOOLS-4945] Fix console online migration not creating target schema

### DIFF
--- a/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
+++ b/plugins/com.cubrid.cubridmigration.command/src/com/cubrid/cubridmigration/command/handler/ScriptCommandHandler.java
@@ -325,6 +325,9 @@ public class ScriptCommandHandler implements ConsoleCommandHandler {
                 mappingSchema.setName(schemaName);
                 mappingSchema.setTargetSchemaName(schemaName);
                 schemaMappingList.add(mappingSchema);
+                if (config.targetIsOnline()) {
+                    config.setNewTargetSchema(schemaName);
+                }
             }
             config.removeTargetSchemaList();
             config.setTargetSchemaList(schemaMappingList);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/JDBCImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/JDBCImporter.java
@@ -30,6 +30,7 @@
  */
 package com.cubrid.cubridmigration.core.engine.importer.impl;
 
+import com.cubrid.common.log.LogUtil;
 import com.cubrid.cubridmigration.core.common.Closer;
 import com.cubrid.cubridmigration.core.common.DBUtils;
 import com.cubrid.cubridmigration.core.dbobject.Column;
@@ -62,6 +63,8 @@ import com.cubrid.cubridmigration.core.trans.DBTransformHelper;
 import com.cubrid.cubridmigration.cubrid.CUBRIDSQLHelper;
 import com.cubrid.cubridmigration.cubrid.stmt.CUBRIDParameterSetter;
 
+import org.slf4j.Logger;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -78,6 +81,8 @@ import java.util.Map;
  * @version 1.0 - 2011-8-3 created by Kevin Cao
  */
 public class JDBCImporter extends Importer {
+
+    private static final Logger LOG = LogUtil.getLogger(JDBCImporter.class);
 
     private final JDBCConManager connectionManager;
     private final MigrationConfiguration config;
@@ -575,11 +580,11 @@ public class JDBCImporter extends Importer {
     public void createSchema(Schema dummySchema) {
         String ddl = CUBRIDSQLHelper.getInstance(null).getSchemaDDL(dummySchema);
         dummySchema.setDDL(ddl);
-        if (targetUserExists(dummySchema.getTargetSchemaName())) {
-            createObjectSuccess(dummySchema);
-            return;
-        }
         try {
+            if (targetUserExists(dummySchema.getTargetSchemaName())) {
+                createObjectSuccess(dummySchema);
+                return;
+            }
             executeDDL(ddl);
             createObjectSuccess(dummySchema);
         } catch (RuntimeException e) {
@@ -599,6 +604,10 @@ public class JDBCImporter extends Importer {
                 return rs.next();
             }
         } catch (SQLException ex) {
+            LOG.warn(
+                    "Failed to check existence of target user [{}]; assuming absent.",
+                    userName,
+                    ex);
             return false;
         } finally {
             connectionManager.closeTar(conn);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/JDBCImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/JDBCImporter.java
@@ -64,6 +64,7 @@ import com.cubrid.cubridmigration.cubrid.stmt.CUBRIDParameterSetter;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -574,11 +575,33 @@ public class JDBCImporter extends Importer {
     public void createSchema(Schema dummySchema) {
         String ddl = CUBRIDSQLHelper.getInstance(null).getSchemaDDL(dummySchema);
         dummySchema.setDDL(ddl);
+        if (targetUserExists(dummySchema.getTargetSchemaName())) {
+            createObjectSuccess(dummySchema);
+            return;
+        }
         try {
             executeDDL(ddl);
             createObjectSuccess(dummySchema);
         } catch (RuntimeException e) {
             createObjectFailed(dummySchema, e);
+        }
+    }
+
+    private boolean targetUserExists(String userName) {
+        if (userName == null || userName.trim().isEmpty()) {
+            return false;
+        }
+        Connection conn = connectionManager.getTargetConnection();
+        try (PreparedStatement stmt =
+                conn.prepareStatement("SELECT 1 FROM db_user WHERE name = ?")) {
+            stmt.setString(1, userName.toUpperCase());
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException ex) {
+            return false;
+        } finally {
+            connectionManager.closeTar(conn);
         }
     }
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4945>

### Purpose
Console Script 명령으로 생성한 온라인 마이그레이션 스크립트가 `<schema new="fasle"`로 만들어져, 실행 시 대상 DB에 스키마가 생성되지 않고 마이그레이션이 실패하는 문제를 수정합니다.

### Implementation
- online 타겟일 때 매핑 스키마를 새로 생성하는 스키마 집합에 등록하여, 생성되는 스크립트가 `<schema new="true">` 되도록 함.
- CREATE USER 실행 전 타겟에 동일 user 존재 여부를 조회하여, 이미 있으면 건너 뛰어서 기존 스키마로의 재마이그레이션 시 불필요한 실패를 방지.

### Remarks
- `<schema new="false">` 옵션은 [TOOLS-4922](http://jira.cubrid.org/browse/TOOLS-4922)에서 추가되었습니다.
