### PR TITLE
[TOOLS-4380] Migration to XLS fails upon large number of records

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
@@ -325,7 +325,23 @@ public class MigrationDirAndFilesManager implements ICanDispose {
      * @return true if full.
      */
     public boolean isDataFileFull(String fileName) {
-        if (!config.isOneTableOneFile() || config.getMaxCountPerFile() <= 0) {
+        return isDataFileFull(fileName, 0);
+    }
+
+    /**
+     * Check if the data file is full when adding next count of records
+     *
+     * @param fileName String
+     * @param nextCount int
+     * @return true if full.
+     */
+    public boolean isDataFileFull(String fileName, int nextCount) {
+        int maxCount = config.getMaxCountPerFile();
+        if (config.targetIsXLS()) {
+            if (maxCount <= 0 || maxCount > MigrationConfiguration.XLS_MAX_COUNT) {
+                maxCount = MigrationConfiguration.XLS_MAX_COUNT;
+            }
+        } else if (!config.isOneTableOneFile() || maxCount <= 0) {
             return false;
         }
         synchronized (MigrationDirAndFilesManager.class) {
@@ -333,7 +349,7 @@ public class MigrationDirAndFilesManager implements ICanDispose {
             if (dfi == null) {
                 return false;
             }
-            return dfi.getRecordCount() >= config.getMaxCountPerFile();
+            return dfi.getRecordCount() + nextCount > maxCount;
         }
     }
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
@@ -347,7 +347,7 @@ public class MigrationDirAndFilesManager implements ICanDispose {
         synchronized (MigrationDirAndFilesManager.class) {
             DataFileInfo dfi = dataFiles.get(fileName);
             if (dfi == null) {
-                return false;
+                return nextCount > maxCount;
             }
             return dfi.getRecordCount() + nextCount > maxCount;
         }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/MigrationDirAndFilesManager.java
@@ -336,13 +336,12 @@ public class MigrationDirAndFilesManager implements ICanDispose {
      * @return true if full.
      */
     public boolean isDataFileFull(String fileName, int nextCount) {
-        int maxCount = config.getMaxCountPerFile();
-        if (config.targetIsXLS()) {
-            if (maxCount <= 0 || maxCount > MigrationConfiguration.XLS_MAX_COUNT) {
-                maxCount = MigrationConfiguration.XLS_MAX_COUNT;
-            }
-        } else if (!config.isOneTableOneFile() || maxCount <= 0) {
+        if (!config.targetIsXLS()) {
             return false;
+        }
+        int maxCount = config.getMaxCountPerFile();
+        if (maxCount <= 0 || maxCount > MigrationConfiguration.XLS_MAX_COUNT) {
+            maxCount = MigrationConfiguration.XLS_MAX_COUNT;
         }
         synchronized (MigrationDirAndFilesManager.class) {
             DataFileInfo dfi = dataFiles.get(fileName);

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/config/MigrationConfiguration.java
@@ -2544,9 +2544,16 @@ public class MigrationConfiguration {
     /**
      * Commit count
      *
-     * @return the commitCount default 500
+     * @return the commitCount default 1000
      */
     public int getCommitCount() {
+        if (targetIsXLS()) {
+            int maxCount = getMaxCountPerFile();
+            if (maxCount <= 0 || maxCount > XLS_MAX_COUNT) {
+                maxCount = XLS_MAX_COUNT;
+            }
+            return Math.min(commitCount, maxCount);
+        }
         return commitCount;
     }
 

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/LoadFileImporter.java
@@ -82,9 +82,7 @@ public class LoadFileImporter extends OfflineImporter {
                 String name,
                 String ext,
                 String pathID) {
-            this.fileHeader = header;
-            this.fileExt = ext;
-            this.fileTableFullName =
+            this.fileHeader =
                     header
                             + File.separator
                             + owner
@@ -95,8 +93,9 @@ public class LoadFileImporter extends OfflineImporter {
                             + "_"
                             + pathID
                             + "_"
-                            + name
-                            + ext;
+                            + name;
+            this.fileExt = ext;
+            this.fileTableFullName = this.fileHeader + ext;
             this.fileFullName = fileFullName;
         }
 
@@ -223,7 +222,7 @@ public class LoadFileImporter extends OfflineImporter {
             CurrentDataFileInfo es = tableFiles.get(schemaName + stc.getName());
 
             // If the target file is full.
-            if (mdfm.isDataFileFull(es.fileTableFullName)) {
+            if (mdfm.isDataFileFull(es.fileTableFullName, impCount)) {
                 // Full name will be changed.
                 es.nextFile();
             }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4380>

### Related Issue
<http://jira.cubrid.org/browse/TOOLS-4391> (MariaDB)
<http://jira.cubrid.org/browse/TOOLS-4394> (Oracle)
<http://jira.cubrid.org/browse/TOOLS-4923> (Tibero)
<http://jira.cubrid.org/browse/TOOLS-4399> (MSSQL)
<http://jira.cubrid.org/browse/TOOLS-4389> (MySQL)

### Purpose
Fixes the Excel migration failure that occurs when exporting a large number of records (exceeding the legacy Excel 65K row limitation)

### Implementation
- Added `isDataFileFull` to check if the upcoming record batch will exceed the file limit.
- Updated `LoadFileImporter.java` to check this threshold proactively and trigger a new file before an overflow happens.

### Remarks
This PR strictly addresses the file-splitting requirement for legacy `.xls` files to close the 5 linked issues.
