### PR TITLE
[TOOLS-4950] XLS cell character limit 32K

### DIFF
--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/event/MigrationXLSNoSupportEvent.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/event/MigrationXLSNoSupportEvent.java
@@ -52,7 +52,7 @@ public class MigrationXLSNoSupportEvent extends MigrationEvent {
     public String toString() {
         return "Row Index : "
                 + rowIndex
-                + " Colum Index : "
+                + ", Colum Index : "
                 + columIndex
                 + " in "
                 + tableName

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/event/MigrationXLSNoSupportEvent.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/event/MigrationXLSNoSupportEvent.java
@@ -52,7 +52,7 @@ public class MigrationXLSNoSupportEvent extends MigrationEvent {
     public String toString() {
         return "Row Index : "
                 + rowIndex
-                + ", Colum Index : "
+                + ", Column Index : "
                 + columIndex
                 + " in "
                 + tableName

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -286,26 +286,27 @@ public abstract class OfflineImporter extends Importer {
 
                     boolean hasError = false;
                     for (int i = 0; i < res.size(); i++) {
-                    	String val = res.get(i);
-                    	if (val != null && val.length() > MAX_EXCEL_CELL_LENGTH) {
-                    		hasError = true;
-                    		eventHandler.handleEvent(
+                        String val = res.get(i);
+                        if (val != null && val.length() > MAX_EXCEL_CELL_LENGTH) {
+                            hasError = true;
+                            eventHandler.handleEvent(
                                     new MigrationXLSNoSupportEvent(
                                             tt.getName(),
                                             recordNo,
-                                            i+1,
+                                            i + 1,
                                             "Too long data (data length in xml must be less than"
-                                                    + " 32768. - Row is skipped, no output generated.)"));
-                    	}
+                                                    + " 32768. - Row is skipped, no output"
+                                                    + " generated.)"));
+                        }
                     }
 
                     if (hasError) {
-                    	continue;
+                        continue;
                     }
 
                     int index = 0;
                     for (String val : res) {
-                    	sheet.addCell(new jxl.write.Label(index++, total, val));
+                        sheet.addCell(new jxl.write.Label(index++, total, val));
                     }
                     total++;
                 }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -270,11 +270,12 @@ public abstract class OfflineImporter extends Importer {
             WritableWorkbook workbook = Workbook.createWorkbook(file, workbookSettings);
             WritableSheet sheet = workbook.createSheet(tt.getName(), 0);
 
+            int total = 0;
+            int recordNo = 0;
             try {
                 List<String> lobFiles = new ArrayList<String>();
-                int total = 0;
-                int fail = 0;
                 for (Record re : records) {
+                    recordNo++;
                     if (re == null) {
                         continue;
                     }
@@ -283,28 +284,34 @@ public abstract class OfflineImporter extends Importer {
                         continue;
                     }
 
-                    int index = 0;
-                    for (String val : res) {
-                        if (val.length() > MAX_EXCEL_CELL_LENGTH) {
-                            sheet.addCell(new jxl.write.Label(index++, total, ""));
-                            eventHandler.handleEvent(
+                    boolean hasError = false;
+                    for (int i = 0; i < res.size(); i++) {
+                    	String val = res.get(i);
+                    	if (val != null && val.length() > MAX_EXCEL_CELL_LENGTH) {
+                    		hasError = true;
+                    		eventHandler.handleEvent(
                                     new MigrationXLSNoSupportEvent(
                                             tt.getName(),
-                                            total,
-                                            index,
+                                            recordNo,
+                                            i+1,
                                             "Too long data (data length in xml must be less than"
-                                                    + " 32768.)"));
-                            fail++;
-                        } else {
-                            sheet.addCell(new jxl.write.Label(index++, total, val));
-                        }
+                                                    + " 32768. - Row is skipped, no output generated.)"));
+                    	}
                     }
 
+                    if (hasError) {
+                    	continue;
+                    }
+
+                    int index = 0;
+                    for (String val : res) {
+                    	sheet.addCell(new jxl.write.Label(index++, total, val));
+                    }
                     total++;
                 }
 
                 workbook.write();
-                return total - fail;
+                return total;
             } finally {
                 workbook.close();
             }

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -275,7 +275,6 @@ public abstract class OfflineImporter extends Importer {
             try {
                 List<String> lobFiles = new ArrayList<String>();
                 for (Record re : records) {
-                    recordNo++;
                     if (re == null) {
                         continue;
                     }
@@ -283,6 +282,7 @@ public abstract class OfflineImporter extends Importer {
                     if (res == null) {
                         continue;
                     }
+                    recordNo++;
 
                     boolean hasError = false;
                     for (int i = 0; i < res.size(); i++) {

--- a/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
+++ b/plugins/com.cubrid.cubridmigration.core/src/com/cubrid/cubridmigration/core/engine/importer/impl/OfflineImporter.java
@@ -306,7 +306,7 @@ public abstract class OfflineImporter extends Importer {
 
                     int index = 0;
                     for (String val : res) {
-                        sheet.addCell(new jxl.write.Label(index++, total, val));
+                        sheet.addCell(new jxl.write.Label(index++, total, val != null ? val : ""));
                     }
                     total++;
                 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4950>

### Purpose
This PR fixes an issue where the logged row index for skipped rows in the migration report was incorrect when exporting to XLS files.

### Implementation
- Updated log error message more descriptive as: 
  `"Too long data (data length in xml must be less than 32768. - Row is skipped, no output generated.)".`
- Skip the entire row on cell limit error, instead of writing an empty cell and keeping the rest of the row (which was the old behavior), the entire row is now skipped if any single cell in that row contains characters exceeding the Excel cell limit.
- Shifted both the row index and column index in the error log to start from 1 (previously they were 0-based).