### PR TITLE
[TOOLS-4959] Harden CI/build and enforce required status checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# Code under tests/ is owned by @Srltas.
-# Changes there auto-request @Srltas as a PR reviewer.
 /tests/ @Srltas

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Code under tests/ is owned by @Srltas.
+# Changes there auto-request @Srltas as a PR reviewer.
+/tests/ @Srltas

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,22 +38,23 @@ jobs:
           license_headers=.github/workflows/license_headers
           result="PASS"
 
+          # CHANGED_FILES is a space-separated list; word-splitting is intended.
+          # shellcheck disable=SC2086
           for f in $CHANGED_FILES; do
             if [ -d "$f" ]; then
               continue
             fi
 
-            ext=$(expr $f : ".*\(\..*\)")
-            case $ext in
-            .java) true;;
+            case "$f" in
+            *.java) ;;
             *) continue ;;
             esac
 
             result_for_f="FAIL"
-            for header in `find $license_headers -type f`; do
-              line_cnt=`wc -l < $header`
-              head -n $line_cnt $f | diff -q -w - $header 2>&1 1>/dev/null
-              if [ $? -eq 0 ]; then
+            for header in "$license_headers"/*; do
+              [ -f "$header" ] || continue
+              line_cnt=$(wc -l < "$header")
+              if head -n "$line_cnt" "$f" | diff -q -w - "$header" >/dev/null 2>&1; then
                 result_for_f="PASS"
                 break
               fi
@@ -65,7 +66,7 @@ jobs:
             fi
           done
           
-          test $result = "PASS"
+          test "$result" = "PASS"
   pr-style:
     name: pr-style
     runs-on: ubuntu-24.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,6 @@ jobs:
           license_headers=.github/workflows/license_headers
           result="PASS"
 
-          # CHANGED_FILES is a space-separated list; word-splitting is intended.
           # shellcheck disable=SC2086
           for f in $CHANGED_FILES; do
             if [ -d "$f" ]; then

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -90,17 +90,37 @@ jobs:
           files: |
             **/*.java
           write_output_files: true
-      - uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd
+      - id: format
+        uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd
         if: steps.changed.outputs.any_changed == 'true'
         with:
           release-name: v1.32.0
           args: "--aosp --replace --set-exit-if-changed @.github/outputs/all_changed_files.txt"
           skip-commit: true
-      - name: Suggest code changes
-        if: failure()
-        uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff
-        with:
-          tool_name: code-style (indent, googlejavaformat)
+      - name: Report required formatting
+        if: ${{ failure() && steps.format.outcome == 'failure' }}
+        run: |
+          echo "::group::Required formatting changes"
+          git --no-pager diff
+          echo "::endgroup::"
+          {
+            echo "## Code style check failed"
+            echo ""
+            echo "Some Java files are not formatted with google-java-format (AOSP)."
+            echo "Run the formatter locally on the changed files and commit the result:"
+            echo ""
+            echo '```bash'
+            echo 'java -jar google-java-format-1.32.0-all-deps.jar --aosp --replace <changed .java files>'
+            echo '```'
+            echo ""
+            echo "<details><summary>Required changes (diff)</summary>"
+            echo ""
+            echo '```diff'
+            git --no-pager diff | head -n 800
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
   unit-test:
     name: unit-test
     runs-on: ubuntu-24.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,12 +27,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: jitterbit/get-changed-files@v1
+        with:
+          fetch-depth: 0
+      - uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62
         id: files
         continue-on-error: true
       - name: Check license
         env:
-          CHANGED_FILES: "${{ steps.files.outputs.added_modified }}"
+          CHANGED_FILES: "${{ steps.files.outputs.all_changed_files }}"
         run: |
           set +e
           license_headers=.github/workflows/license_headers

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ jobs:
     name: license
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: jitterbit/get-changed-files@v1
         id: files
         continue-on-error: true
@@ -70,7 +70,7 @@ jobs:
     name: pr-style
     runs-on: ubuntu-24.04
     steps:
-      - uses: deepakputhraya/action-pr-title@master
+      - uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16
         with:
           regex: '^\[[A-Z]+-\d+\]\s.+'
   code-style:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,10 +21,15 @@ on:
       - develop
       - release/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   license:
     name: license
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,6 +76,7 @@ jobs:
   pr-style:
     name: pr-style
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16
         with:
@@ -78,6 +84,7 @@ jobs:
   code-style:
     name: code-style
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:
@@ -126,6 +133,7 @@ jobs:
   unit-test:
     name: unit-test
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,15 @@ on:
       - '**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-desktop:
     name: build-desktop
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,6 +36,7 @@ jobs:
   build-console:
     name: build-console
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,6 +63,7 @@ jobs:
     name: e2e-${{ matrix.name }}
     needs: build-console
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ tmp/
 /cubrid-migration.log
 /cubrid-migration.*.log.gz
 /logback-status.log
-.settings
 local.properties
 .loadpath
 
@@ -35,6 +34,3 @@ tests/unit-test/logs/
 ## E2E test
 
 tests/e2e/e2e-test.properties
-
-## Mac
-.DS_Store

--- a/build.ps1
+++ b/build.ps1
@@ -143,16 +143,22 @@ $MvnDebug = if ($Debug) { @("-Dtycho.debug.resolver=true", "-X") } else { @() }
 Show-Env
 Update-BuildVersion
 
+# mvn is a native command; $ErrorActionPreference does not stop on its non-zero
+# exit before PowerShell 7.4, so check $LASTEXITCODE after each run explicitly.
 switch ($SelectedProfile) {
     "all" {
         & $Mvn clean package "-Dcubridmigration-version=$ReleaseVersion" -Pdesktop $MvnDebug
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         & $Mvn clean package "-Dcubridmigration-version=$ReleaseVersion" -Pconsole $MvnDebug
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     }
     "desktop" {
         & $Mvn clean package "-Dcubridmigration-version=$ReleaseVersion" -Pdesktop $MvnDebug
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     }
     "console" {
         & $Mvn clean package "-Dcubridmigration-version=$ReleaseVersion" -Pconsole $MvnDebug
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
     }
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -143,8 +143,6 @@ $MvnDebug = if ($Debug) { @("-Dtycho.debug.resolver=true", "-X") } else { @() }
 Show-Env
 Update-BuildVersion
 
-# mvn is a native command; $ErrorActionPreference does not stop on its non-zero
-# exit before PowerShell 7.4, so check $LASTEXITCODE after each run explicitly.
 switch ($SelectedProfile) {
     "all" {
         & $Mvn clean package "-Dcubridmigration-version=$ReleaseVersion" -Pdesktop $MvnDebug

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-MVN="`which mvn`"
+MVN="$(command -v mvn)"
 PROFILE="all"
-MVN_DEBUG=""
+MVN_DEBUG=()
 DIR=$PWD
 TARGET=$DIR/target
 PRODUCT_TARGET=$DIR/product/com.cubrid.cubridmigration.desktop/target
@@ -33,7 +33,7 @@ function get_options ()
   while getopts ":p:X" opt; do
     case $opt in
 	  p ) PROFILE=$(printf %s "$OPTARG" | tr '[:upper:]' '[:lower:]') ;;
-          X ) MVN_DEBUG="-Dtycho.debug.resolver=true -X" ;;
+          X ) MVN_DEBUG=(-Dtycho.debug.resolver=true -X) ;;
           * ) show_usage 
               exit ;;
     esac
@@ -43,11 +43,11 @@ function get_options ()
 function check_configuration ()
 {
   if [ -n "${JAVA_HOME}" ]; then
-    echo JAVA_HOME: ${JAVA_HOME}
+    echo "JAVA_HOME: ${JAVA_HOME}"
   fi
 
   if [ -n "${MAVEN_HOME}" ]; then
-    echo MAVEN_HOME: ${MAVEN_HOME}
+    echo "MAVEN_HOME: ${MAVEN_HOME}"
     MVN="${MAVEN_HOME}/bin/mvn"
   fi
 
@@ -61,79 +61,79 @@ function update_build_version ()
 {
   echo "Version File Update....  (plugins/com.cubrid.cubridmigration.ui/version.properties)"
 
-  if [ -d ${DIR}/.git ]; then
+  if [ -d "${DIR}/.git" ]; then
     COMMIT_NUMBER=$(git rev-list --count HEAD | awk '{ printf "%04d", $1 }')
   else
     COMMIT_NUMBER=0000
   fi
 
-  VERSION=$(cat ${VERSION_FILE_PATH} | grep version | cut -d '=' -f2)
-  sed -i "/releaseVersion/d" $RELEASE_VERSION_FILE_PATH
-  echo "releaseVersion=" $VERSION >> $RELEASE_VERSION_FILE_PATH
+  VERSION=$(grep '^version=' "$VERSION_FILE_PATH" | cut -d '=' -f2)
+  sed -i "/releaseVersion/d" "$RELEASE_VERSION_FILE_PATH"
+  echo "releaseVersion=$VERSION" >> "$RELEASE_VERSION_FILE_PATH"
 
   RELEASE_VERSION=$VERSION.$COMMIT_NUMBER
-  sed -i "/buildVersionId/d" $RELEASE_VERSION_FILE_PATH
-  echo "buildVersionId="$RELEASE_VERSION >> $RELEASE_VERSION_FILE_PATH
+  sed -i "/buildVersionId/d" "$RELEASE_VERSION_FILE_PATH"
+  echo "buildVersionId=$RELEASE_VERSION" >> "$RELEASE_VERSION_FILE_PATH"
   
-  echo "VERSION=" $VERSION
-  echo "COMMIT_NUMBER=" $COMMIT_NUMBER
-  echo "RELEASE_VERSION=" $RELEASE_VERSION
+  echo "VERSION=$VERSION"
+  echo "COMMIT_NUMBER=$COMMIT_NUMBER"
+  echo "RELEASE_VERSION=$RELEASE_VERSION"
 }
 
 function copy_desktopcmt_to_directory ()
 {
   CMT_LINUX=$PRODUCT_TARGET/$CMT_PRODUCT_NAME-$RELEASE_VERSION-linux-x86_64.tar.gz
-  if [ -e $CMT_LINUX ]; then
-    cp -vfp $CMT_LINUX $TARGET
+  if [ -e "$CMT_LINUX" ]; then
+    cp -vfp "$CMT_LINUX" "$TARGET"
   fi
 
   CMT_MAC=$PRODUCT_TARGET/$CMT_PRODUCT_NAME-$RELEASE_VERSION-macosx-cocoa-x86_64.tar.gz
-  if [ -e $CMT_MAC ]; then
-    cp -vfp $CMT_MAC $TARGET
+  if [ -e "$CMT_MAC" ]; then
+    cp -vfp "$CMT_MAC" "$TARGET"
   fi
 
   CMT_WINDOWS=$PRODUCT_TARGET/$CMT_PRODUCT_NAME-$RELEASE_VERSION-windows-x64.zip
-  if [ -e $CMT_WINDOWS ]; then
-    cp -vfp $CMT_WINDOWS $TARGET
+  if [ -e "$CMT_WINDOWS" ]; then
+    cp -vfp "$CMT_WINDOWS" "$TARGET"
   fi
 
   CMT_SITE_TAR_GZ=$PRODUCT_TARGET/$CMT_SITE_NAME-$RELEASE_VERSION.tar.gz
-  if [ -e $CMT_SITE_TAR_GZ ]; then
-    cp -vfp $CMT_SITE_TAR_GZ $TARGET
+  if [ -e "$CMT_SITE_TAR_GZ" ]; then
+    cp -vfp "$CMT_SITE_TAR_GZ" "$TARGET"
   fi
 
   CMT_SITE_ZIP=$PRODUCT_TARGET/$CMT_SITE_NAME-$RELEASE_VERSION.zip
-  if [ -e $CMT_SITE_ZIP ]; then
-    cp -vfp $CMT_SITE_ZIP $TARGET
+  if [ -e "$CMT_SITE_ZIP" ]; then
+    cp -vfp "$CMT_SITE_ZIP" "$TARGET"
   fi
 }
 
 function copy_consolecmt_to_directory ()
 {
   CONSOLE_LINUX=$CONSOLE_TARGET/$CMT_CONSOLE_NAME-$RELEASE_VERSION-linux.tar.gz
-  if [ -e $CONSOLE_LINUX ]; then
-    cp -vfp $CONSOLE_LINUX $TARGET
+  if [ -e "$CONSOLE_LINUX" ]; then
+    cp -vfp "$CONSOLE_LINUX" "$TARGET"
   fi
 
   CONSOLE_WINDOWS=$CONSOLE_TARGET/$CMT_CONSOLE_NAME-$RELEASE_VERSION-windows.zip
-  if [ -e $CONSOLE_WINDOWS ]; then
-    cp -vfp $CONSOLE_WINDOWS $TARGET
+  if [ -e "$CONSOLE_WINDOWS" ]; then
+    cp -vfp "$CONSOLE_WINDOWS" "$TARGET"
   fi
 
 }
 
 function copy_cmt_to_directory ()
 {
-  if [ ! -d $TARGET ]; then
-    mkdir $TARGET
+  if [ ! -d "$TARGET" ]; then
+    mkdir "$TARGET"
   fi
 
-  if [ $PROFILE = "all" ] || [ $PROFILE = "a" ]; then
+  if [ "$PROFILE" = "all" ] || [ "$PROFILE" = "a" ]; then
     copy_desktopcmt_to_directory
     copy_consolecmt_to_directory
-  elif [ $PROFILE = "desktop" ] || [ $PROFILE = "d" ]; then
+  elif [ "$PROFILE" = "desktop" ] || [ "$PROFILE" = "d" ]; then
     copy_desktopcmt_to_directory
-  elif [ $PROFILE = "console" ] || [ $PROFILE = "c" ]; then
+  elif [ "$PROFILE" = "console" ] || [ "$PROFILE" = "c" ]; then
     copy_consolecmt_to_directory
   fi
 }
@@ -161,13 +161,13 @@ get_options "$@"
 check_configuration
 update_build_version
 
-if [ $PROFILE = "all" ] || [ $PROFILE = "a" ]; then
-  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pdesktop $MVN_DEBUG || exit $?
-  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pconsole $MVN_DEBUG || exit $?
-elif [ $PROFILE = "desktop" ] || [ $PROFILE = "d" ]; then
-  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pdesktop $MVN_DEBUG || exit $?
-elif [ $PROFILE = "console" ] || [ $PROFILE = "c" ]; then
-  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pconsole $MVN_DEBUG || exit $?
+if [ "$PROFILE" = "all" ] || [ "$PROFILE" = "a" ]; then
+  $MVN clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pdesktop "${MVN_DEBUG[@]}" || exit $?
+  $MVN clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pconsole "${MVN_DEBUG[@]}" || exit $?
+elif [ "$PROFILE" = "desktop" ] || [ "$PROFILE" = "d" ]; then
+  $MVN clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pdesktop "${MVN_DEBUG[@]}" || exit $?
+elif [ "$PROFILE" = "console" ] || [ "$PROFILE" = "c" ]; then
+  $MVN clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pconsole "${MVN_DEBUG[@]}" || exit $?
 else
   show_usage
 fi

--- a/build.sh
+++ b/build.sh
@@ -162,12 +162,12 @@ check_configuration
 update_build_version
 
 if [ $PROFILE = "all" ] || [ $PROFILE = "a" ]; then
-  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pdesktop $MVN_DEBUG
-  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pconsole $MVN_DEBUG
+  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pdesktop $MVN_DEBUG || exit $?
+  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pconsole $MVN_DEBUG || exit $?
 elif [ $PROFILE = "desktop" ] || [ $PROFILE = "d" ]; then
-  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pdesktop $MVN_DEBUG
+  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pdesktop $MVN_DEBUG || exit $?
 elif [ $PROFILE = "console" ] || [ $PROFILE = "c" ]; then
-  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pconsole $MVN_DEBUG
+  $MVN clean package -Dcubridmigration-version=$RELEASE_VERSION -Pconsole $MVN_DEBUG || exit $?
 else
   show_usage
 fi

--- a/build.sh
+++ b/build.sh
@@ -162,12 +162,12 @@ check_configuration
 update_build_version
 
 if [ "$PROFILE" = "all" ] || [ "$PROFILE" = "a" ]; then
-  $MVN clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pdesktop "${MVN_DEBUG[@]}" || exit $?
-  $MVN clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pconsole "${MVN_DEBUG[@]}" || exit $?
+  "$MVN" clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pdesktop "${MVN_DEBUG[@]}" || exit $?
+  "$MVN" clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pconsole "${MVN_DEBUG[@]}" || exit $?
 elif [ "$PROFILE" = "desktop" ] || [ "$PROFILE" = "d" ]; then
-  $MVN clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pdesktop "${MVN_DEBUG[@]}" || exit $?
+  "$MVN" clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pdesktop "${MVN_DEBUG[@]}" || exit $?
 elif [ "$PROFILE" = "console" ] || [ "$PROFILE" = "c" ]; then
-  $MVN clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pconsole "${MVN_DEBUG[@]}" || exit $?
+  "$MVN" clean package -Dcubridmigration-version="$RELEASE_VERSION" -Pconsole "${MVN_DEBUG[@]}" || exit $?
 else
   show_usage
 fi

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -3,3 +3,7 @@
 # com.cmt.e2e.framework.target package contents.
 !src/test/java/com/cmt/e2e/framework/target/
 !src/test/java/com/cmt/e2e/framework/target/**
+
+# Tibero JDBC driver is proprietary and supplied locally (see pom.xml
+# systemPath), so it must not be committed to this public repo.
+/lib/

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -4,6 +4,4 @@
 !src/test/java/com/cmt/e2e/framework/target/
 !src/test/java/com/cmt/e2e/framework/target/**
 
-# Tibero JDBC driver is proprietary and supplied locally (see pom.xml
-# systemPath), so it must not be committed to this public repo.
 /lib/


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4959>

### Purpose
CI/build 파이프라인 안정성과 머지 품질을 높이기 위한 작업입니다.

### Implementation
**ci.yml**
- concurrency 그룹을 ref 단위로 두고 cancel-in-progress 적용 (연속 push 시 이전 실행 취소)
- timeout-minutes 추가: build 잡 20, e2e 잡 60

**check.yml**
 - action/checkout v2 to v4 업그레이드 (license 잡), action-pr-title@master를 릴리스 SHA로 고정
 - code-style reviewdog 인라인 코멘트 제거, 실패 시 필요한 포맷 diff를 job summary와 로그에 출력하는 것으로 변경
 - license get-changed-files 액션을 jitterbit/get-changed-files에서 SHA 고정 tj-actions/changed-files로 교체 (fetch-depth: 0 추가, 출력 변수 all_changed_files)
 - license 체크 run 쉘 스크립트 정리 (2>&1 리다이렉트 순서 수정, find 백틱 및 expr 제거, 변수 인용)
 - concurrency 그룹 + cancel-in-progress 적용, 잡별 timeout-minutes 추가 (license 10, pr-style 10, code-style 15, unit-test 20)

**build.sh, build.ps1**
 - Maven 빌드 실패가 스크립트 종료코드로 전파되도록 수정 (기존엔 실패해도 exit 0 가능)
 - (build.sh만) 쉘 품질 개선: 변수 인용, command -v, ^version= 앵커 grep, MVN_DEBUG 배열화

**CODEOWNERS**
 - tests 디렉터리 코드 오너 추가

**.gitignore**
 - 상용 Tibero JDBC 드라이버(tests/e2e/lib) 무시
 - 루트 .gitignore 중복 규칙 정리

**dependabot.yml**
 - github-actions 주간 업데이트, 모든 액션을 한 PR로 그룹화, SHA 고정 액션 자동 갱신

### Remarks
N/A
