### PR TITLE
[TOOLS-4964] Gate e2e jobs on test result, not on the publish step

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,9 +78,12 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16
+      - if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16
         with:
           regex: '^\[[A-Z]+-\d+\]\s.+'
+      - if: ${{ github.actor == 'dependabot[bot]' }}
+        run: echo "pr-style skipped for bot PR"
   code-style:
     name: code-style
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,21 +120,21 @@ jobs:
         run: |
           mvn -B clean test \
             -Dtest="$TEST_PATTERN" \
-            -Dmaven.test.failure.ignore=true \
             -Dpicocli.ansi=false \
             -Dorg.fusesource.jansi.Ansi.disable=true
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040  # v2.23.0
         if: always()
+        continue-on-error: true
         with:
           check_name: E2E Results (${{ matrix.name }})
           files: tests/e2e/target/surefire-reports/*.xml
           comment_mode: failures
           report_individual_runs: true
           check_run_annotations: all tests, skipped tests
-          action_fail: true
-          action_fail_on_inconclusive: true
+          action_fail: false
+          action_fail_on_inconclusive: false
 
       - name: Upload Surefire Reports
         if: always()


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4964>

### Purpose
Dependabot 같은 read-only 토큰 PR에서 e2e 잡이 테스트는 통과했는데도 레드가 뜹니다. 결과 게시 스텝이 check run을 만들려다 write 토큰이 없어 403으로 죽었기 때문입니다. 이 PR은 실제 테스트(mvn) 결과로 판단하게 바꿔서 테스트가 통과되면 그린이 되도록 설정합니다. 추가로 봇 PR의 경우 pr-stype 잡을 수행하지 않도록 설정합니다.

### Implementation
 - e2e 잡에서 `-Dmaven.test.failure.ignore=true` 제거. 테스트 실패르 mvn이 직접 잡아 잡을 red로 표시
 - publish 스텁에 `continue-on-error: true` + `action_fail: false`. 결과 게시는 실패해도 잡을 죽이지 않도록 설정
 - check.yml pr-style: 봇 PR(제목이 Jira 키 형식과 맞지 않아 무조건 실패하게 됨)은 제목 검사 스텝을 스킵, 잡은 green 유지해 required 체크 통과

### Remarks
N/A
