### PR TITLE
[TOOLS-4965] Run Tibero E2E tests in CI on a self-hosted runner

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
-      - uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
+      - uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         id: files
         continue-on-error: true
       - name: Check license
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16
+        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16  # v1.0.2
         with:
           regex: '^\[[A-Z]+-\d+\]\s.+'
       - if: ${{ github.actor == 'dependabot[bot]' }}
@@ -89,21 +89,21 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
         with:
           distribution: temurin
           java-version: '21'
       - id: changed
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         with:
           files: |
             **/*.java
           write_output_files: true
       - id: format
-        uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd
+        uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd  # v4.0.0
         if: steps.changed.outputs.any_changed == 'true'
         with:
           release-name: v1.32.0
@@ -138,8 +138,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
         with:
           distribution: temurin
           java-version: '21'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,10 @@ on:
       - develop
       - release/**
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - '**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -64,6 +67,10 @@ jobs:
     needs: build-console
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -157,6 +164,10 @@ jobs:
     needs: build-console
     runs-on: [self-hosted, tibero]
     timeout-minutes: 60
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     if: >
       github.event_name == 'workflow_dispatch' ||
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
         with:
           distribution: temurin
           java-version: '21'
@@ -39,10 +39,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
         with:
           distribution: temurin
           java-version: '21'
@@ -52,7 +52,7 @@ jobs:
         run: chmod +x build.sh && ./build.sh -p c
 
       - name: Upload Console tarball
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: cmt-console-tarball
           path: target/CUBRID-Migration-Toolkit-console-*.tar.gz
@@ -84,17 +84,17 @@ jobs:
             tests: 'Cli*Test'
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
         with:
           distribution: temurin
           java-version: '21'
           cache: maven
 
       - name: Download Console tarball
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: cmt-console-tarball
           path: target
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload Surefire Reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: surefire-reports-${{ matrix.name }}
           path: tests/e2e/target/surefire-reports/**
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload E2E Failure Artifacts
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: e2e-failure-artifacts-${{ matrix.name }}
           path: tests/e2e/target/e2e/**
@@ -162,17 +162,17 @@ jobs:
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95  # v5.6.0
         with:
           distribution: temurin
           java-version: '21'
           cache: maven
 
       - name: Download Console tarball
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: cmt-console-tarball
           path: target
@@ -243,7 +243,7 @@ jobs:
 
       - name: Upload Surefire Reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: surefire-reports-tibero
           path: tests/e2e/target/surefire-reports/**
@@ -251,7 +251,7 @@ jobs:
 
       - name: Upload E2E Failure Artifacts
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: e2e-failure-artifacts-tibero
           path: tests/e2e/target/e2e/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,9 +168,7 @@ jobs:
       contents: read
       checks: write
       pull-requests: write
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,3 +151,105 @@ jobs:
           name: e2e-failure-artifacts-${{ matrix.name }}
           path: tests/e2e/target/e2e/**
           if-no-files-found: ignore
+
+  e2e-tibero:
+    name: e2e-tibero
+    needs: build-console
+    runs-on: [self-hosted, tibero]
+    timeout-minutes: 60
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Download Console tarball
+        uses: actions/download-artifact@v8
+        with:
+          name: cmt-console-tarball
+          path: target
+
+      - name: Provision Console
+        run: |
+          mkdir -p cmt-console
+          tar xzf target/CUBRID-Migration-Toolkit-console-*.tar.gz \
+            --strip-components=1 -C cmt-console
+          chmod +x cmt-console/migration.sh
+          echo "CMT_CONSOLE_HOME=$GITHUB_WORKSPACE/cmt-console" >> "$GITHUB_ENV"
+
+      - name: Prepare Tibero Environment
+        run: |
+          : "${E2E_TIBERO_PREPARE:?E2E_TIBERO_PREPARE is not set on this runner}"
+          bash "$E2E_TIBERO_PREPARE" "$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+
+      - name: Run Tibero E2E
+        working-directory: tests/e2e
+        env:
+          NO_COLOR: '1'
+          CLICOLOR: '0'
+          TERM: dumb
+        run: |
+          mvn -B clean test \
+            -Dtest='TiberoTo*Test' \
+            -Dpicocli.ansi=false \
+            -Dorg.fusesource.jansi.Ansi.disable=true \
+            -De2e.tibero.image="$E2E_TIBERO_IMAGE" \
+            -De2e.tibero.hostname="$E2E_TIBERO_HOSTNAME" \
+            -De2e.tibero.license="$E2E_TIBERO_LICENSE" \
+            -De2e.tibero.faketime="$E2E_TIBERO_FAKETIME"
+
+      # @EnabledIf skips silently when the Tibero environment is broken, so an
+      # all-skipped run would otherwise pass. This job exists to guarantee
+      # Tibero coverage — fail unless at least one test actually executed.
+      - name: Assert Tibero Tests Executed
+        working-directory: tests/e2e
+        run: |
+          executed=0
+          for f in target/surefire-reports/TEST-*.xml; do
+            [ -f "$f" ] || continue
+            tests=$(grep -o 'tests="[0-9]*"' "$f" | head -n1 | tr -dc '0-9')
+            skipped=$(grep -o 'skipped="[0-9]*"' "$f" | head -n1 | tr -dc '0-9')
+            executed=$((executed + ${tests:-0} - ${skipped:-0}))
+          done
+          echo "non-skipped Tibero tests executed: $executed"
+          if [ "$executed" -eq 0 ]; then
+            echo "::error::e2e-tibero executed zero tests — the Tibero environment was silently skipped; check runner provisioning"
+            exit 1
+          fi
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3  # v2.24.0
+        if: always()
+        continue-on-error: true
+        with:
+          check_name: E2E Results (tibero)
+          files: tests/e2e/target/surefire-reports/*.xml
+          comment_mode: failures
+          report_individual_runs: true
+          check_run_annotations: all tests, skipped tests
+          action_fail: false
+          action_fail_on_inconclusive: false
+
+      - name: Upload Surefire Reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: surefire-reports-tibero
+          path: tests/e2e/target/surefire-reports/**
+          if-no-files-found: ignore
+
+      - name: Upload E2E Failure Artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-failure-artifacts-tibero
+          path: tests/e2e/target/e2e/**
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,9 @@ jobs:
           NO_COLOR: '1'
           CLICOLOR: '0'
           TERM: dumb
+          # Snapshots hold wall-clock DATE values; a DST-observing runner TZ
+          # shifts them by an hour. Pin UTC like the GitHub-hosted matrix.
+          TZ: UTC
         run: |
           mvn -B clean test \
             -Dtest='TiberoTo*Test' \

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -57,8 +57,9 @@ Review the diff before committing.
 
 Executing Tibero scenarios requires a bring your own assets setup.
 
-- **JDBC jar** — must be at `tests/e2e/lib/tibero7-jdbc-17.jar`
-  (Maven profile activates only when this exact path exists)
+- **JDBC jar** — must be at `tests/e2e/lib/tibero-jdbc.jar`
+  (Maven profile activates only when this exact path exists; the name is
+  version-neutral, so copy either the Tibero 6 or 7 driver to it)
 - **License file** — anywhere on the host; absolute path set via
   `e2e.tibero.license`
 - **Docker image** — built or pulled into the local Docker daemon;

--- a/tests/e2e/e2e-test.properties.example
+++ b/tests/e2e/e2e-test.properties.example
@@ -15,6 +15,5 @@ e2e.tibero.hostname=
 # Absolute path to license.xml (relative paths are rejected).
 e2e.tibero.license=
 
-# libfaketime offset — number of days to backdate the container's clock
-# at boot. Must keep (today - N days) inside the license validity window.
+# Clock offset applied to the container at boot, in days back from today.
 e2e.tibero.faketime=

--- a/tests/e2e/pom.xml
+++ b/tests/e2e/pom.xml
@@ -355,8 +355,6 @@
             <id>tibero</id>
             <activation>
                 <file>
-                    <!-- ${basedir}, not ${project.basedir}: pre-3.9 Maven does not
-                         interpolate the latter in file activation (silently inactive). -->
                     <exists>${basedir}/lib/tibero-jdbc.jar</exists>
                 </file>
             </activation>

--- a/tests/e2e/pom.xml
+++ b/tests/e2e/pom.xml
@@ -355,17 +355,19 @@
             <id>tibero</id>
             <activation>
                 <file>
-                    <exists>${project.basedir}/lib/tibero7-jdbc-17.jar</exists>
+                    <!-- ${basedir}, not ${project.basedir}: pre-3.9 Maven does not
+                         interpolate the latter in file activation (silently inactive). -->
+                    <exists>${basedir}/lib/tibero-jdbc.jar</exists>
                 </file>
             </activation>
 
             <dependencies>
                 <dependency>
                     <groupId>com.tmax.tibero</groupId>
-                    <artifactId>tibero7-jdbc</artifactId>
-                    <version>17</version>
+                    <artifactId>tibero-jdbc</artifactId>
+                    <version>local</version>
                     <scope>system</scope>
-                    <systemPath>${project.basedir}/lib/tibero7-jdbc-17.jar</systemPath>
+                    <systemPath>${basedir}/lib/tibero-jdbc.jar</systemPath>
                 </dependency>
             </dependencies>
 
@@ -386,7 +388,7 @@
                                         <resource>
                                             <directory>${project.basedir}/lib</directory>
                                             <includes>
-                                                <include>tibero7-jdbc-*.jar</include>
+                                                <include>tibero-jdbc.jar</include>
                                             </includes>
                                         </resource>
                                     </resources>

--- a/tests/e2e/src/test/java/com/cmt/e2e/framework/db/JdbcDriverJars.java
+++ b/tests/e2e/src/test/java/com/cmt/e2e/framework/db/JdbcDriverJars.java
@@ -83,7 +83,7 @@ public final class JdbcDriverJars {
             Map.of(
                     DB.CUBRID, List.of("JDBC-*-cubrid.jar", "cubrid-jdbc-*.jar"),
                     DB.ORACLE, List.of("ojdbc8-*.jar", "ojdbc8.jar", "ojdbc*.jar"),
-                    DB.TIBERO, List.of("tibero7-jdbc-17.jar", "tibero7-jdbc-*.jar"),
+                    DB.TIBERO, List.of("tibero-jdbc.jar"),
                     DB.MYSQL, List.of("mysql-connector-j-*.jar", "mysql-connector-java-*.jar"),
                     DB.MARIADB, List.of("mariadb-java-client-*.jar"),
                     DB.INFORMIX, List.of("informix-jdbc-*.jar"),

--- a/tests/e2e/src/test/java/com/cmt/e2e/framework/db/containers/TiberoContainer.java
+++ b/tests/e2e/src/test/java/com/cmt/e2e/framework/db/containers/TiberoContainer.java
@@ -43,8 +43,8 @@ import java.time.Duration;
 /**
  * Tibero 7 Testcontainer.
  *
- * <p>Image, hostname, license path, and FAKETIME come from {@link TiberoEnvironment} (config keys
- * e2e.tibero.image / hostname / license / faketime — see {@code e2e-test.properties.example}).
+ * <p>Image, hostname, license path, and clock offset come from {@link TiberoEnvironment} (config
+ * keys e2e.tibero.image / hostname / license / faketime — see {@code e2e-test.properties.example}).
  * Constants below ({@code TIBERO_PORT}, {@code SID}, {@code LICENSE_IN_CONTAINER}, DBA credentials,
  * schema users) are fixed by the bundled image and seed scripts.
  */
@@ -66,7 +66,7 @@ public final class TiberoContainer implements DatabaseContainer {
         DockerImageName image = DockerImageName.parse(TiberoEnvironment.image());
         String hostname = TiberoEnvironment.hostname();
         Path licenseHostPath = TiberoEnvironment.licensePath();
-        String faketime = "-" + TiberoEnvironment.faketimeDaysBack() + "d";
+        String clockOffset = "-" + TiberoEnvironment.faketimeDaysBack() + "d";
 
         this.container =
                 new GenericContainer<>(image)
@@ -77,7 +77,7 @@ public final class TiberoContainer implements DatabaseContainer {
                                 })
                         .withExposedPorts(TIBERO_PORT)
                         .withEnv("TB_ROOT_PASSWORD", DBA_PASSWORD)
-                        .withEnv("FAKETIME", faketime)
+                        .withEnv("FAKETIME", clockOffset)
                         .withCopyFileToContainer(
                                 MountableFile.forHostPath(licenseHostPath.toString()),
                                 LICENSE_IN_CONTAINER)

--- a/tests/e2e/src/test/java/com/cmt/e2e/framework/db/containers/TiberoEnvironment.java
+++ b/tests/e2e/src/test/java/com/cmt/e2e/framework/db/containers/TiberoEnvironment.java
@@ -102,8 +102,7 @@ public final class TiberoEnvironment {
         if (days == null) {
             log.info(
                     "[Tibero] skipping — config '{}' must be a positive "
-                            + "integer (= days back). Got: '{}'. Example: '100' is "
-                            + "translated to FAKETIME=-100d.",
+                            + "integer (= days back). Got: '{}'.",
                     FAKETIME_KEY,
                     rawValue(FAKETIME_KEY));
             return false;
@@ -127,7 +126,7 @@ public final class TiberoEnvironment {
         return Paths.get(required(LICENSE_KEY));
     }
 
-    /** Days back for libfaketime; container env becomes {@code FAKETIME=-Nd}. */
+    /** Clock offset in days back, applied to the container at start. */
     public static int faketimeDaysBack() {
         Integer days = parseFaketimeDaysBack(rawValue(FAKETIME_KEY));
         if (days == null) {

--- a/tests/e2e/src/test/java/com/cmt/e2e/framework/db/containers/TiberoEnvironment.java
+++ b/tests/e2e/src/test/java/com/cmt/e2e/framework/db/containers/TiberoEnvironment.java
@@ -69,7 +69,7 @@ public final class TiberoEnvironment {
         if (!driverOnClasspath()) {
             log.info(
                     "[Tibero] skipping — JDBC driver com.tmax.tibero.jdbc.TbDriver "
-                            + "not on classpath. Place tibero7-jdbc-*.jar at tests/e2e/lib/.");
+                            + "not on classpath. Place tibero-jdbc.jar at tests/e2e/lib/.");
             return false;
         }
         String missing = firstMissingRequiredKey();


### PR DESCRIPTION
<http://jira.cubrid.org/browse/TOOLS-4965>

### Purpose
Tibero E2E를 사내 self-hosted 러너에서 자동 실행하도록 CI에 추가합니다.

### Implementation
**CI 잡 (.github/workflows/ci.yml)**
`e2e-tibero` 잡을 추가했습니다. `build-console` 아티팩트를 기존 E2E 매트릭스와 공유하므로 콘솔 빌드는 한 번만 돕니다.
 - `needs: build-console`, `runs-on: [self-hosted, tibero]`, `timeout-minutes: 60`
 - 스텝: checkout → JDK 21 → 콘솔 아티팩트 다운로드/전개 → 환경 준비 → mvn → 실행 수 단언 → 결과 게시 → 아티팩트 업로드

실행 게이트는 이벤트 종류로만 판단합니다(`pull_request` 또는 `workflow_dispatch`, push 제외). 외부 기여자 PR의 실행 여부는 레포의 fork PR 승인 정책이 통제하므로, 워크플로에서 작성자를 검사하지 않습니다.

**설정값 전달**
워크플로에는 값을 두지 않고, 러너에 있는 스크립트가 산출한 값을 받아서 시스템 프로퍼티로 넘깁니다. 워크플로에 남는 것은 변수 이름뿐입니다.

**실행 수 단언 스텝**
Tibero TC는 환경이 없으면 `@EnabledIf`로 스킵됩니다. 로컬에서는 맞는 동작이지만 CI에서는 "전부 스킵"과 "전부 통과"가 똑같이 초록불이 됩니다. 그래서 mvn 직후 surefire XML에서 실제 실행된 테스트 수를 세고, 0이면 잡을 실패시킵니다.

**JDBC 드라이버 파일명 변경**
`tibero7-jdbc-17.jar`을 버전 중립 이름 `tibero-jdbc.jar`로 통일했습니다.

**토큰 권한 명시**
워크플로 기본값을 `contents: read`로 두고, 결과 게시가 필요한 e2e 잡에만 `checks: write`와 `pull-requests: write`를 부여했습니다.

### Remarks
 - upstream에 `tibero` 라벨 러너를 먼저 등록 후 본 PR을 머지합니다.
 - 레포 설정의 fork PR 승인 정책이 "모든 외부 기여자 승인 필요"로 되어야 합니다.
